### PR TITLE
Opt-in cookie detection was too strict

### DIFF
--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -356,7 +356,7 @@ class wp_slimstat {
 		
 			$cookie_found = false;
 			foreach ( $cookie_names as $a_name => $a_value ) {
-				if ( isset( $_COOKIE[ $a_name ] ) && $_COOKIE[ $a_name ] == $a_value ) {
+				if ( isset( $_COOKIE[ $a_name ] ) && strpos( $_COOKIE[ $a_name ], $a_value ) !== false ) {
 					$cookie_found = true;
 				}
 			}


### PR DESCRIPTION
The opt-in cookie-check was comparing the cookie-value to an exact match.
This is too strict in most of the cases. 
My proposal matches the documentation and ensures that the opt-in check is the same as the opt-out check.