### PR TITLE
Fix for: Problem with the Capabilities option in the Exclusions tab

### DIFF
--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -501,7 +501,7 @@ class wp_slimstat {
 			}
 
 			// Don't track users with given capabilities
-			foreach ( self::string_to_array( self::$settings[ 'ignore_capabilities' ] ) as $a_capability ) {
+			foreach ( $GLOBALS[ 'current_user' ]->roles as $a_capability ) {
 				if ( self::_is_blacklisted( $a_capability, self::$settings[ 'ignore_capabilities' ] ) ) {
 					return false;
 				}
@@ -2000,25 +2000,33 @@ class slimstat_widget extends WP_Widget {
 		}
 		?>
 
-		<p>
-		<label for="<?php echo esc_attr( $this->get_field_id( 'slimstat_widget_id' ) ); ?>"><?php _e( 'Report', 'wp-slimstat' ) ?></label> 
-		<select class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'slimstat_widget_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'slimstat_widget_id' ) ); ?>">
-			<option value="">Select a widget</option>
-			<?php echo $select_options ?>
-		</select>
-		</p>
+<p>
+  <label
+    for="<?php echo esc_attr( $this->get_field_id( 'slimstat_widget_id' ) ); ?>"><?php _e( 'Report', 'wp-slimstat' ) ?></label>
+  <select class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'slimstat_widget_id' ) ); ?>"
+    name="<?php echo esc_attr( $this->get_field_name( 'slimstat_widget_id' ) ); ?>">
+    <option value="">Select a widget</option>
+    <?php echo $select_options ?>
+  </select>
+</p>
 
-		<p>
-		<label for="<?php echo esc_attr( $this->get_field_id( 'slimstat_widget_title' ) ); ?>"><?php _e( 'Title', 'wp-slimstat' ) ?></label> 
-		<input type="text" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'slimstat_widget_title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'slimstat_widget_title' ) ); ?>" value="<?php echo trim( strip_tags( $slimstat_widget_title ) ) ?>">
-		</p>
+<p>
+  <label
+    for="<?php echo esc_attr( $this->get_field_id( 'slimstat_widget_title' ) ); ?>"><?php _e( 'Title', 'wp-slimstat' ) ?></label>
+  <input type="text" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'slimstat_widget_title' ) ); ?>"
+    name="<?php echo esc_attr( $this->get_field_name( 'slimstat_widget_title' ) ); ?>"
+    value="<?php echo trim( strip_tags( $slimstat_widget_title ) ) ?>">
+</p>
 
-		<p>
-		<label for="<?php echo esc_attr( $this->get_field_id( 'slimstat_widget_filters' ) ); ?>"><?php _e( 'Optional filters', 'wp-slimstat' ); ?></label> 
-		<a href="https://slimstat.freshdesk.com/solution/articles/5000631833-what-is-the-syntax-of-a-slimstat-shortcode-#slimstat-operators" target="_blank">[?]</a>
-		<textarea class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'slimstat_widget_filters' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'slimstat_widget_filters' ) ); ?>"><?php echo trim( strip_tags( $slimstat_widget_filters ) ) ?></textarea>
-		</p>
-		<?php
+<p>
+  <label
+    for="<?php echo esc_attr( $this->get_field_id( 'slimstat_widget_filters' ) ); ?>"><?php _e( 'Optional filters', 'wp-slimstat' ); ?></label>
+  <a href="https://slimstat.freshdesk.com/solution/articles/5000631833-what-is-the-syntax-of-a-slimstat-shortcode-#slimstat-operators"
+    target="_blank">[?]</a>
+  <textarea class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'slimstat_widget_filters' ) ); ?>"
+    name="<?php echo esc_attr( $this->get_field_name( 'slimstat_widget_filters' ) ); ?>"><?php echo trim( strip_tags( $slimstat_widget_filters ) ) ?></textarea>
+</p>
+<?php
 	}
 
 	/**


### PR DESCRIPTION
## Description

I have a problem with the Capabilities option in the Exclusions tab. If I add any role to this field, statistics are not stored for all roles. For example, if I add the administrator role to the exclusion, statistics are not stored for both administrators and subscribers.