### PR TITLE
#13 remove slimstat_tracking_code cookie on opt-out / not opt-in

### DIFF
--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -337,6 +337,14 @@ class wp_slimstat {
 
 			foreach ( $cookie_names as $a_name => $a_value ) {
 				if ( isset( $_COOKIE[ $a_name ] ) && strpos( $_COOKIE[ $a_name ], $a_value ) !== false ) {
+					// remove slimstat cookie
+					unset($_COOKIE['slimstat_tracking_code']);
+					@setcookie(
+					  'slimstat_tracking_code',
+					  '',
+					  time() - ( 15 * 60 ) , // invalidate
+					  COOKIEPATH
+					);
 					return false;
 				}
 			}
@@ -363,6 +371,14 @@ class wp_slimstat {
 			}
 
 			if ( !$cookie_found ) {
+				// remove slimstat cookie
+				unset($_COOKIE['slimstat_tracking_code']);
+				@setcookie(
+				  'slimstat_tracking_code',
+				  '',
+				  time() - ( 15 * 60 ) , // invalidate
+				  COOKIEPATH
+				);
 				return false;
 			}
 		}


### PR DESCRIPTION
@slimstat Tested here. Works. Please review and merge. Maybe it is time to make a new release of the plugin, so people can get the recent enhancements. Thanks!