### PR TITLE
Release v5.2.11 fix recent internal searches referer key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+= 5.2.11 - 2025-04-11 =
+- **Fix:** Prevented PHP warning by checking if 'referer' array key is set in searchterms reports view.
+
 = 5.2.10 - 2025-03-09 =
 - **Enhancement**: Improved SQL update query to support offset with `LIMIT`.
 

--- a/admin/view/wp-slimstat-reports.php
+++ b/admin/view/wp-slimstat-reports.php
@@ -1119,7 +1119,7 @@ class wp_slimstat_reports
                             }
 
                             $row_details   = __('Referrer', 'wp-slimstat') . ": $domain";
-                            $element_value = self::get_search_terms_info($results[$i]['searchterms'], $results[$i]['referer'], true);
+                            $element_value = self::get_search_terms_info($results[$i]['searchterms'], isset($results[$i]['referer']) ? $results[$i]['referer'] : '', true);
                         } else {
                             $element_value = htmlentities($results[$i]['searchterms'], ENT_QUOTES, 'UTF-8');
                         }


### PR DESCRIPTION
### Describe your changes
This PR resolves a PHP warning (Undefined array key "referer") in the Recent Internal Searches report by adding a conditional check for the presence of the referer key in the $results array before accessing it. This ensures compatibility with data rows where referer may be undefined or null, preventing runtime warnings and improving stability.

### Submission Review Guidelines:

- ✅ I have performed a self-review of my code
- ✅ Not a core feature; no tests required
- ✅ Will this be part of a product update? Yes — Prevents unnecessary PHP warnings during report rendering
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- ✅ I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209960007657144
  - https://app.asana.com/0/0/1210030983014015