### PR TITLE
Release 5.4 email report

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -1035,6 +1035,8 @@ class wp_slimstat_admin
         include(__DIR__ . '/view/layout.php');
     }
 
+    // END: wp_slimstat_include_layout
+
     /**
      * Includes the email report screen
      */
@@ -1043,7 +1045,7 @@ class wp_slimstat_admin
         include(__DIR__ . '/view/email-report.php');
     }
 
-    // END: wp_slimstat_include_addons
+    // END: wp_slimstat_include_email_report
 
     /**
      * Handles the upgrade to pro from the free version
@@ -1901,6 +1903,10 @@ class wp_slimstat_admin
 
     public static function add_header()
     {
+        if (isset($_GET['page']) && ('slimlayout' === $_GET['page'] || 'slimconfig' === $_GET['page'])) {
+            return self::get_template('header', ['is_pro' => wp_slimstat::pro_is_installed()]);
+        }
+
         return null;
     }
 

--- a/admin/view/email-report.php
+++ b/admin/view/email-report.php
@@ -22,7 +22,7 @@ if (!$is_pro) {
         wp_slimstat_admin::get_template('slimstat-pro-modal');
         ?>
         <div class="wrap slimstat upgrade-pro email-report-locked">
-            <img class="upgrade-pro-background" src="<?php echo esc_url(plugin_dir_url(__FILE__) . '../assets/images/pro-blur.jpg'); ?>">
+            <img class="upgrade-pro-background" src="<?php echo esc_url(plugin_dir_url(__FILE__) . '../assets/images/email report.PNG'); ?>">
         </div>
     </div>
     <?php

--- a/admin/view/email-report.php
+++ b/admin/view/email-report.php
@@ -7,6 +7,8 @@ $is_pro = wp_slimstat::pro_is_installed();
 
 if (!$is_pro) {
     // For free users: show blurred content with modal
+    // Load header
+    wp_slimstat_admin::get_template('header', ['is_pro' => false]);
     ?>
     <style>
         .slimstat-pro-modal,
@@ -20,17 +22,17 @@ if (!$is_pro) {
         wp_slimstat_admin::get_template('slimstat-pro-modal');
         ?>
         <div class="wrap slimstat upgrade-pro email-report-locked">
-            <?php wp_slimstat_admin::get_template('header', ['is_pro' => false]); ?>
-            <img class="upgrade-pro-background" src="<?php echo esc_url(plugin_dir_url(__FILE__) . '../assets/images/email report.PNG'); ?>">
+            <img class="upgrade-pro-background" src="<?php echo esc_url(plugin_dir_url(__FILE__) . '../assets/images/pro-blur.jpg'); ?>">
         </div>
     </div>
     <?php
 } else {
     // For premium users: show the actual email report content
+    // Load header
+    wp_slimstat_admin::get_template('header', ['is_pro' => true]);
     ?>
     <div class="backdrop-container">
         <div class="wrap slimstat slimstat-email-report">
-            <?php wp_slimstat_admin::get_template('header', ['is_pro' => true]); ?>
             <h2><?php _e('Email Report', 'wp-slimstat'); ?></h2>
             
             <div class="slimstat-email-report-content">


### PR DESCRIPTION
## Move Email Reports Settings to Dedicated Page

### Summary
Moved the Email Reports configuration section from the Settings page (tab 7) to the dedicated Email Report page (`/wp-admin/admin.php?page=slimemail`).

### Changes
- **EmailReportsAddon.php**: 
  - Replaced `slimstat_options_on_page` filter with `slimstat_email_report_content` action hook
  - Created new `renderEmailReportSettings()` method to render the complete form on the email report page
  - Updated script enqueuing to target `slimemail` page instead of `slimconfig&tab=7`
  - Updated cron job scheduling to work with new form submission

- **email-report.php**: 
  - Added `backdrop-container` wrapper for proper white background styling
  - Now displays email report settings form for Pro users

### Features
- ✅ All email report settings now on dedicated page
- ✅ Bootstrap Switch toggle UI (matches settings page design)
- ✅ Form submission with nonce verification
- ✅ Success messages on save
- ✅ AJAX functionality preserved (tagEditor for recipients/reports)
- ✅ Consistent white background styling with other pages

### Settings Available
- Report List (with dropdown to add reports)
- Recipients (with Test button)
- Frequency (Daily/Weekly/Monthly)
- Attach Reports as CSV toggle
- Email Authors toggle
- Filters
- Custom Message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a modern date-range picker with preset support and server-side helpers, replace legacy date filters, and add a dedicated Email Report admin page.
> 
> - **UI/Frontend**:
>   - Replace legacy date filter controls with a unified date-range picker in `admin/view/index.php` using `daterangepicker` and Moment.
>   - New JS `admin/assets/js/daterangepicker/slimstat-daterangepicker.js` to manage presets, URL updates, accessibility, and cache clear button; enqueued with corresponding CSS/JS assets.
> - **Backend/Server-side**:
>   - Add `src/Components/DateRangeHelper.php` for timezone-aware preset ranges, URL param parsing (`type`, `from`, `to`), validation, and display formatting; localized strings exposed to JS.
>   - Update `wp_slimstat_db` to parse new date params, compute intervals safely (DST-aware), switch to `wp_date`, and slightly adjust end-range handling; disable query caching via `allowCaching(false)`.
> - **Admin Integration**:
>   - Conditionally enqueue daterangepicker assets on SlimStat report pages in `admin/index.php` (with localization), default posts column interval set to `28` days.
>   - Add new menu route `slimemail` and `admin/view/email-report.php` to render Email Report page (Pro hooks/modal handling).
>   - Minor cleanup in `slimstat-pro-modal` partial (backdrop markup).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b85667010d41ff9dcec046620aa12709b150c0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->