### PR TITLE
Fix PHP deprecation warnings and GDPR consent handling issues

### DIFF
--- a/admin/view/layout.php
+++ b/admin/view/layout.php
@@ -6,6 +6,10 @@ $already_seen = [];
 <div class="backdrop-container ">
     <div class="wrap slimstat slimstat-layout">
         <?php wp_slimstat_admin::get_template('header', ['is_pro' => wp_slimstat::pro_is_installed()]); ?>
+
+        <h1 class="wp-heading-inline"><?php _e('Customize', 'wp-slimstat'); ?></h1>
+        <hr class="wp-header-end">
+
         <p><?php
             _e('You can drag and drop the placeholders here below from one widget area to another, to customize the layout of each report screen. You can place multiple charts on the same view, clone reports or move them to the Inactive Reports if you are not interested in that specific metric.', 'wp-slimstat');
 if (is_network_admin()) {

--- a/admin/view/wp-slimstat-reports.php
+++ b/admin/view/wp-slimstat-reports.php
@@ -1927,6 +1927,9 @@ class wp_slimstat_reports
      */
     public static function get_resource_title($_resource = '')
     {
+        // Ensure $_resource is never null to avoid PHP 8.1+ deprecation warnings
+        $_resource = $_resource ?? '';
+
         if ('on' != wp_slimstat::$settings['convert_resource_urls_to_titles']) {
             return htmlentities(urldecode($_resource), ENT_QUOTES, 'UTF-8');
         }

--- a/wp-slimstat.js
+++ b/wp-slimstat.js
@@ -1034,7 +1034,7 @@ var SlimStat = (function () {
 
             // Only use previous consent upgrade if current consent is unknown (null)
             // Do NOT override an explicit rejection (false) with a previous consent
-            if (cmpAllows !== true && cmpAllows !== false && hasConsentUpgradeSucceeded()) {
+            if (cmpAllows !== true && hasConsentUpgradeSucceeded()) {
                 cmpAllows = true;
             }
         }

--- a/wp-slimstat.js
+++ b/wp-slimstat.js
@@ -1032,7 +1032,9 @@ var SlimStat = (function () {
             } else {
             }
 
-            if (cmpAllows !== true && hasConsentUpgradeSucceeded()) {
+            // Only use previous consent upgrade if current consent is unknown (null)
+            // Do NOT override an explicit rejection (false) with a previous consent
+            if (cmpAllows !== true && cmpAllows !== false && hasConsentUpgradeSucceeded()) {
                 cmpAllows = true;
             }
         }
@@ -1627,6 +1629,11 @@ if (!window.requestIdleCallback) {
                         hasConsent = window.wp_has_consent(selectedCategory);
                     } else if (event.detail.consent !== undefined) {
                         hasConsent = event.detail.consent === true || event.detail.consent === "allow";
+                    }
+
+                    // Clear consent upgrade state when consent is denied
+                    if (!hasConsent) {
+                        markConsentUpgradeDone(false);
                     }
 
                     var parsedConsent = normalizeConsent({

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -177,6 +177,13 @@ class wp_slimstat
 		self::$settings = apply_filters('slimstat_init_options', self::$settings);
 
 		$consent_integration = self::$settings['consent_integration'] ?? '';
+
+		// If WP Consent API is selected but the function doesn't exist, reset to default
+		if ('wp_consent_api' === $consent_integration && !function_exists('wp_has_consent')) {
+			$consent_integration = '';
+			self::$settings['consent_integration'] = '';
+		}
+
 		if ('' === $consent_integration && ('on' === (self::$settings['use_slimstat_banner'] ?? 'off'))) {
 			$consent_integration = 'slimstat_banner';
 			self::$settings['consent_integration'] = $consent_integration;


### PR DESCRIPTION
- Fix md5() null parameter deprecation in get_resource_title()
- Add null coalescing check to prevent passing null to md5(), urldecode(), and htmlentities()
- Add page title "Customize" to layout.php matching Settings page format
- Fix WP Consent API default value: auto-reset to SlimStat banner when plugin not available
- Fix consent rejection bug: prevent previous consent upgrades from overriding explicit rejections
- Clear consent upgrade state when user denies consent to prevent stale state issues

Resolves issues:
1. PHP 8.1+ deprecation warnings for null parameters
2. Customize page missing title
3. WP Consent API setting persisting when plugin deactivated
4. Tracking continuing after user rejects consent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Describe your changes
...

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
