### PR TITLE
Sync header Online Visitors with Live Analytics Users Live

### DIFF
--- a/admin/assets/js/live-analytics.js
+++ b/admin/assets/js/live-analytics.js
@@ -711,6 +711,12 @@
             this.animateValue(countriesElement, data.countries_live);
         }
 
+        // Sync header online visitors count with users_live to ensure they always match
+        var headerOnlineElement = document.getElementById("slimstat-online-visitors-count");
+        if (headerOnlineElement && typeof data.users_live !== "undefined") {
+            this.animateValue(headerOnlineElement, data.users_live);
+        }
+
         // Update current metric from server response to ensure sync
         if (data.selected_metric) {
             if (data.selected_metric !== this.currentMetric) {

--- a/admin/index.php
+++ b/admin/index.php
@@ -1378,7 +1378,7 @@ class wp_slimstat_admin
         global $wpdb;
         $table = "{$wpdb->prefix}slim_stats";
         $current_minute_start = (int) floor(current_time('timestamp') / 60) * 60;
-        $window_minutes = 5; // 5 minutes = 300 seconds
+        $window_minutes = 30; // 30 minutes - synced with Live Analytics Users Live
         $window_start = $current_minute_start - (($window_minutes - 1) * 60);
 
         $sql = $wpdb->prepare(

--- a/admin/view/partials/header.php
+++ b/admin/view/partials/header.php
@@ -21,7 +21,7 @@ if (class_exists('wp_slimstat_db')) {
     global $wpdb;
     $table = "{$wpdb->prefix}slim_stats";
     $current_minute_start = (int) floor(current_time('timestamp') / 60) * 60;
-    $window_minutes = 5; // 5 minutes = 300 seconds
+    $window_minutes = 30; // 30 minutes - synced with Live Analytics Users Live
     $window_start = $current_minute_start - (($window_minutes - 1) * 60);
 
     $sql = $wpdb->prepare(


### PR DESCRIPTION
- Changed header online visitors window from 5 to 30 minutes
- Updated AJAX handler to use same 30-minute window
- Added JS sync to update header when Live Analytics refreshes

### Describe your changes
...

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
