### PR TITLE
fix: security patch — capability checks, input sanitization, SQL allowlist (PR #123 review)

### DIFF
--- a/admin/config/index.php
+++ b/admin/config/index.php
@@ -895,7 +895,7 @@ if (!empty($settings) && !empty($_REQUEST['slimstat_update_settings']) && wp_ver
         }
 
         // All other options
-        foreach ($_POST['options'] as $a_post_slug => $a_post_value) {
+        foreach (wp_unslash($_POST['options']) as $a_post_slug => $a_post_value) {
             if (empty($settings[$current_tab]['rows'][$a_post_slug]) || !empty($settings[$current_tab]['rows'][$a_post_slug]['readonly']) || in_array($settings[$current_tab]['rows'][$a_post_slug]['type'], ['section_header', 'plain-text']) || in_array($a_post_slug, ['enable_maxmind', 'enable_browscap'])) {
                 continue;
             }

--- a/admin/index.php
+++ b/admin/index.php
@@ -1537,7 +1537,7 @@ class wp_slimstat_admin
 
         $saved_filters = get_option('slimstat_filters', []);
 
-        switch ($_POST['type']) {
+        switch (sanitize_key(wp_unslash($_POST['type'] ?? ''))) {
             case 'save':
                 $new_filter = json_decode(stripslashes_deep(sanitize_text_field($_POST['filter_array'])), true);
 
@@ -1979,6 +1979,11 @@ class wp_slimstat_admin
 	{
 		check_ajax_referer('wp_rest', 'security');
 
+		if (!current_user_can(\wp_slimstat::$settings['capability_can_admin'])) {
+			wp_send_json_error(__('Permission denied', 'wp-slimstat'));
+			return;
+		}
+
 		try {
 			$provider = \wp_slimstat::$settings['geolocation_provider'] ?? 'maxmind';
             if ('cloudflare' === $provider) {
@@ -2012,6 +2017,11 @@ class wp_slimstat_admin
 	public static function check_geoip_database()
 	{
 		check_ajax_referer('wp_rest', 'security');
+
+		if (!current_user_can(\wp_slimstat::$settings['capability_can_admin'])) {
+			wp_send_json_error(__('Permission denied', 'wp-slimstat'));
+			return;
+		}
 
 		try {
 			$provider = \wp_slimstat::$settings['geolocation_provider'] ?? 'maxmind';

--- a/admin/view/wp-slimstat-db.php
+++ b/admin/view/wp-slimstat-db.php
@@ -181,7 +181,9 @@ class wp_slimstat_db
         // Filters are set via javascript as hidden fields and submitted as a POST request. They override anything passed through the regular input fields
         if (!empty($_REQUEST['fs']) && is_array($_REQUEST['fs'])) {
             foreach ($_REQUEST['fs'] as $a_request_filter_name => $a_request_filter_value) {
-                $filters_array[sanitize_text_field(wp_unslash($a_request_filter_name))] = sprintf('%s %s', sanitize_text_field(wp_unslash($a_request_filter_name)), sanitize_text_field(wp_unslash($a_request_filter_value)));
+                $safe_name  = sanitize_text_field(wp_unslash($a_request_filter_name));
+                $safe_value = str_replace('&&&', '', sanitize_text_field(wp_unslash($a_request_filter_value)));
+                $filters_array[$safe_name] = sprintf('%s %s', $safe_name, $safe_value);
             }
         }
 
@@ -890,15 +892,21 @@ class wp_slimstat_db
 
     public static function count_records_having($_column = 'id', $_where = '', $_having = '')
     {
+        // Allowlist: only known schema columns are allowed as identifiers
+        $allowed_columns = array_keys(self::$columns_names);
+        if (!in_array($_column, $allowed_columns, true)) {
+            return 0;
+        }
+
         $table = $GLOBALS['wpdb']->prefix . 'slim_stats';
-        $distinct_column = ('id' != $_column) ? 'DISTINCT ' . $_column : $_column;
+        $distinct_column = ('id' !== $_column) ? 'DISTINCT ' . esc_sql($_column) : esc_sql($_column);
 
         $query = Query::select("COUNT(*) as counthits")
             ->from("(
                 SELECT {$distinct_column}
                 FROM {$table}
                 WHERE " . self::get_combined_where($_where, $_column) . "
-                GROUP BY {$_column}
+                GROUP BY " . esc_sql($_column) . "
                 HAVING {$_having}
             ) AS ts1");
 

--- a/admin/view/wp-slimstat-reports.php
+++ b/admin/view/wp-slimstat-reports.php
@@ -2026,7 +2026,7 @@ class wp_slimstat_reports
         if (!empty($_POST['report_id'])) {
             check_ajax_referer('meta-box-order', 'security');
             // Let's make sure the request is coming from an authorized source
-            $report_id = $_POST['report_id'];
+            $report_id = sanitize_key(wp_unslash($_POST['report_id']));
         } elseif (!empty($_args['id'])) {
             $report_id = $_args['id'];
         }

--- a/src/Controllers/Rest/TrackingRestController.php
+++ b/src/Controllers/Rest/TrackingRestController.php
@@ -118,6 +118,15 @@ class TrackingRestController implements RestControllerInterface
             if (!is_array($payload)) {
                 $payload = [];
             }
+
+            // Sanitize known scalar keys explicitly; preserve all other keys for extension compatibility
+            $scalar_keys = ['action', 'n', 'bw', 'bh', 'ref', 'res', 'lt', 'dc', 'ob', 'ss_nonce'];
+            foreach ($scalar_keys as $key) {
+                if (isset($payload[$key])) {
+                    $payload[$key] = sanitize_text_field(wp_unslash((string) $payload[$key]));
+                }
+            }
+
             $payload['action'] = 'slimtrack';
             \wp_slimstat::$raw_post_array = $payload;
         }

--- a/src/Modules/Chart.php
+++ b/src/Modules/Chart.php
@@ -70,9 +70,14 @@ class Chart
             \wp_slimstat_db::init();
         }
 
-        // Restore filters from args if provided
+        // Restore filters from args if provided; validate column keys against known schema
         if (!empty($args['filters']) && is_array($args['filters'])) {
-            \wp_slimstat_db::$filters_normalized['columns'] = $args['filters'];
+            $allowed_columns = array_keys(\wp_slimstat_db::$columns_names);
+            foreach ($args['filters'] as $col => $val) {
+                if (in_array($col, $allowed_columns, true)) {
+                    \wp_slimstat_db::$filters_normalized['columns'][$col] = $val;
+                }
+            }
         }
 
         \wp_slimstat_db::$filters_normalized['utime']['start'] = $args['start'];

--- a/src/Tracker/Ajax.php
+++ b/src/Tracker/Ajax.php
@@ -312,7 +312,8 @@ class Ajax
                         \wp_slimstat::set_stat($stat);
                         $id = Processor::process();
                     } elseif (!$is_allowed_host($parsed_resource['host'])) {
-                        $stat['outbound_resource'] = $resource;
+                        $sanitized_url = sanitize_url($resource);
+                        $stat['outbound_resource'] = !empty($sanitized_url) ? $sanitized_url : '';
                         $stat['dt_out']             = \wp_slimstat::date_i18n('U');
 
                         // Update stat before storage

--- a/src/Tracker/Tracker.php
+++ b/src/Tracker/Tracker.php
@@ -83,7 +83,7 @@ class Tracker
         $identifier     = 0;
 
         if (isset($_COOKIE['slimstat_tracking_code'])) {
-            $identifier = self::_get_value_without_checksum($_COOKIE['slimstat_tracking_code']);
+            $identifier = self::_get_value_without_checksum(sanitize_text_field(wp_unslash($_COOKIE['slimstat_tracking_code'])));
             if (false === $identifier) {
                 return false;
             }

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -1424,7 +1424,7 @@ class slimstat_widget extends WP_Widget
         ], $_instance));
 
         if (!empty($slimstat_widget_title)) {
-            echo (empty($_args['before_title']) ? '<h2 class="widget-title">' : $_args['before_title']) . $slimstat_widget_title . (empty($_args['after_title']) ? '</h2>' : $_args['after_title']);
+            echo (empty($_args['before_title']) ? '<h2 class="widget-title">' : $_args['before_title']) . esc_html($slimstat_widget_title) . (empty($_args['after_title']) ? '</h2>' : $_args['after_title']);
         }
         if (!empty($slimstat_widget_id)) {
             echo do_shortcode(sprintf("[slimstat f='widget' w='%s']%s[/slimstat]", $slimstat_widget_id, $slimstat_widget_filters));
@@ -1487,9 +1487,9 @@ class slimstat_widget extends WP_Widget
     {
         $instance = $_old_instance;
 
-        $instance['slimstat_widget_id']      = $_new_instance['slimstat_widget_id'];
-        $instance['slimstat_widget_title']   = $_new_instance['slimstat_widget_title'];
-        $instance['slimstat_widget_filters'] = $_new_instance['slimstat_widget_filters'];
+        $instance['slimstat_widget_id']      = sanitize_key($_new_instance['slimstat_widget_id'] ?? '');
+        $instance['slimstat_widget_title']   = sanitize_text_field(wp_unslash($_new_instance['slimstat_widget_title'] ?? ''));
+        $instance['slimstat_widget_filters'] = sanitize_textarea_field(wp_unslash($_new_instance['slimstat_widget_filters'] ?? ''));
         return $instance;
     }
 }
@@ -1505,6 +1505,13 @@ if (function_exists('add_action')) {
     if ((!empty($_SERVER['HTTP_CONTENT_TYPE']) || !empty($_SERVER['CONTENT_TYPE'])) && [] === $_POST) {
         $raw_post_string = file_get_contents('php://input');
         parse_str($raw_post_string, wp_slimstat::$raw_post_array);
+
+        // Sanitize the action key from the raw body before using it
+        if (!empty(wp_slimstat::$raw_post_array['action'])) {
+            wp_slimstat::$raw_post_array['action'] = sanitize_key(
+                wp_unslash(wp_slimstat::$raw_post_array['action'])
+            );
+        }
     } elseif ([] !== $_POST) {
         wp_slimstat::$raw_post_array = $_POST;
     }
@@ -1513,8 +1520,9 @@ if (function_exists('add_action')) {
     if (!empty(wp_slimstat::$raw_post_array['action']) && 'slimtrack' == wp_slimstat::$raw_post_array['action']) {
 
         // This is needed because admin-ajax.php is reading $_REQUEST to fire the corresponding action
+        // Use a hardcoded literal instead of passing the user-supplied value
         if (empty($_POST['action'])) {
-            $_POST['action'] = wp_slimstat::$raw_post_array['action'];
+            $_POST['action'] = 'slimtrack';
         }
 
         add_action('wp_ajax_nopriv_slimtrack', [\SlimStat\Tracker\Ajax::class, 'handle']);


### PR DESCRIPTION
## Summary

Backward-compatible security patch addressing findings from the PR #123 security review (comment #3989039886). Public interfaces, hook contracts, and the consent cookie are unchanged in this patch.

### CRITICAL Fixes

- **C1** — Added `current_user_can(wp_slimstat::$settings['capability_can_admin'])` to `update_geoip_database()` and `check_geoip_database()` in `admin/index.php`. Both handlers only verified a `wp_rest` nonce, making them accessible to any logged-in user. Uses the plugin's own configurable capability setting (consistent with `delete_pageview()`).
- **C3** — Sanitized the `action` key parsed from `php://input` with `sanitize_key(wp_unslash(...))`. Set `$_POST['action']` to the hardcoded literal `'slimtrack'` instead of passing the raw user-supplied value.
- **C4** — Added column allowlist validation in `count_records_having()` using `array_keys(self::$columns_names)` and wrapped identifiers with `esc_sql()`. Returns `0` for unknown columns. All existing call sites are unaffected.
- **C5** — Sanitized widget instance values on save (`sanitize_key`, `sanitize_text_field`, `sanitize_textarea_field` + `wp_unslash`). Escaped widget title on output with `esc_html()`.

### WARNING Fixes

- **W2** — `sanitize_key(wp_unslash($_POST['type']))` in `manage_filters()`
- **W3** — `wp_unslash($_POST['options'])` before the settings save loop iteration
- **W4** — `sanitize_key(wp_unslash($_POST['report_id']))` in the report rendering handler
- **W5** — Sanitize known scalar keys explicitly in `TrackingRestController`; unknown keys preserved for extension compatibility (`consent_upgrade`, `pageview_id`, etc.)
- **W6** — Strip `&&&` delimiter from filter values after sanitization to prevent filter injection via `fs[]` parameters
- **W13** — Validate chart filter column keys against `wp_slimstat_db::$columns_names` allowlist before assigning
- **W15** — Apply `sanitize_url()` to `outbound_resource` before persistence, with empty-string fallback
- **W18** — `sanitize_text_field(wp_unslash(...))` on legacy `slimstat_tracking_code` cookie read

### Deferred (separate tickets)

W1 (hook double-fire), W7 (REMOTE_ADDR hard-fail), W9 (instanceof enforcement), W16 (httponly cookie), W17 (inline style), W19 (extract() contract) — require compatibility analysis or architecture changes.

## Test plan

- [ ] GeoIP: admin updates/checks GeoIP DB succeeds; subscriber attempt returns JSON Permission denied error
- [ ] Tracking: POST to REST tracking endpoint records correctly; consent_upgrade flow still works
- [ ] Widget: title saves and displays correctly; shortcode filters render
- [ ] Reports/filters: saved filters load, manage_filters AJAX works, report rendering intact
- [ ] PHPCS: run phpcs on modified files; no new violations
