### PR TITLE
fix: address PR #123 review findings (security, adblock hash, chart granularity, consent cache)

### DIFF
--- a/src/Components/Ajax.php
+++ b/src/Components/Ajax.php
@@ -15,4 +15,16 @@ class Ajax
         \add_action('wp_ajax_slimstat_' . $action, $callback);
         \add_action('wp_ajax_nopriv_slimstat_' . $action, $callback);
     }
+
+    /**
+     * Register an AJAX action for authenticated users only (no nopriv).
+     * Use this for admin-only actions that must not be accessible to anonymous visitors.
+     *
+     * @param string $action
+     * @param callable $callback
+     */
+    public static function registerAdmin($action, $callback)
+    {
+        \add_action('wp_ajax_slimstat_' . $action, $callback);
+    }
 }

--- a/src/Controllers/Rest/ConsentChangeRestController.php
+++ b/src/Controllers/Rest/ConsentChangeRestController.php
@@ -26,6 +26,12 @@ if (!defined('ABSPATH')) {
  */
 class ConsentChangeRestController implements RestControllerInterface
 {
+	/** @var \WP_REST_Request|null */
+	private $currentRequest = null;
+
+	/** @var string|null Memoized cache key; empty string = no stable identifier (skip caching). */
+	private $consentCacheKey = null;
+
 	/**
 	 * Register REST API routes
 	 *
@@ -138,6 +144,8 @@ class ConsentChangeRestController implements RestControllerInterface
 	 */
 	public function handle_consent_change(\WP_REST_Request $request)
 	{
+		$this->currentRequest = $request;
+
 		$nonce = $request->get_param('nonce');
 		if (!wp_verify_nonce($nonce, 'wp_rest')) {
 			return new \WP_Error(
@@ -198,15 +206,52 @@ class ConsentChangeRestController implements RestControllerInterface
 	}
 
 	/**
+	 * Resolve a stable, per-visitor cache key for consent state.
+	 * Memoized: key is generated once per request and reused for all cache operations.
+	 * Returns empty string when no stable visitor identifier is available (caching skipped).
+	 *
+	 * @return string
+	 */
+	private function getConsentCacheKey(): string
+	{
+		if ($this->consentCacheKey !== null) {
+			return $this->consentCacheKey;
+		}
+
+		// 1. Tracking cookie — most stable, persists across pageviews for the same visitor
+		$tracking_cookie = $_COOKIE['slimstat_tracking_code'] ?? '';
+		if (!empty($tracking_cookie)) {
+			$this->consentCacheKey = 'slimstat_consent_state_' . md5($tracking_cookie);
+			return $this->consentCacheKey;
+		}
+
+		// 2. pageview_id from request — visitor-scoped for this page load
+		$pageview_id_raw = $this->currentRequest
+			? ($this->currentRequest->get_param('pageview_id') ?? '')
+			: '';
+		if (!empty($pageview_id_raw)) {
+			$this->consentCacheKey = 'slimstat_consent_state_' . md5($pageview_id_raw);
+			return $this->consentCacheKey;
+		}
+
+		// 3. No stable identifier — sentinel empty string (caching skipped)
+		$this->consentCacheKey = '';
+		return $this->consentCacheKey;
+	}
+
+	/**
 	 * Get previous consent state from cache or database
 	 *
 	 * @return array Previous consent state
 	 */
 	private function getPreviousConsentState(): array
 	{
-		$cached = wp_cache_get('slimstat_consent_state', 'slimstat');
-		if (false !== $cached && is_array($cached)) {
-			return $cached;
+		$key = $this->getConsentCacheKey();
+		if (!empty($key)) {
+			$cached = wp_cache_get($key, 'slimstat');
+			if (false !== $cached && is_array($cached)) {
+				return $cached;
+			}
 		}
 
 		$integration_key = Consent::getIntegrationKey();
@@ -350,7 +395,10 @@ class ConsentChangeRestController implements RestControllerInterface
 			Session::setTrackingCookie($visit_id, 'visit', null, true);
 		}
 
-		wp_cache_set('slimstat_consent_state', $parsed_consent, 'slimstat', HOUR_IN_SECONDS);
+		$key = $this->getConsentCacheKey();
+		if (!empty($key)) {
+			wp_cache_set($key, $parsed_consent, 'slimstat', HOUR_IN_SECONDS);
+		}
 
 		do_action('slimstat_consent_granted', $pageview_id, $parsed_consent);
 	}
@@ -366,11 +414,11 @@ class ConsentChangeRestController implements RestControllerInterface
 	{
 		Session::deleteTrackingCookie();
 
-		if (function_exists('wp_cache_delete')) {
-			wp_cache_delete('slimstat_consent_state', 'slimstat');
+		$key = $this->getConsentCacheKey();
+		if (!empty($key)) {
+			wp_cache_delete($key, 'slimstat');
+			wp_cache_set($key, $parsed_consent, 'slimstat', HOUR_IN_SECONDS);
 		}
-
-		wp_cache_set('slimstat_consent_state', $parsed_consent, 'slimstat', HOUR_IN_SECONDS);
 
 		do_action('slimstat_consent_revoked', $parsed_consent, $source);
 	}

--- a/src/Modules/Chart.php
+++ b/src/Modules/Chart.php
@@ -183,12 +183,12 @@ class Chart
             return 'monthly';
         }
 
-        if ($diff > 2 * self::DAY) {
-            return 'daily';
-        }
-
         if ($diff > 7 * self::DAY) {
             return 'weekly';
+        }
+
+        if ($diff > 2 * self::DAY) {
+            return 'daily';
         }
 
         return 'hourly';

--- a/src/Services/Admin/Notification/NotificationActions.php
+++ b/src/Services/Admin/Notification/NotificationActions.php
@@ -9,13 +9,19 @@ class NotificationActions
 {
 	public function register()
 	{
-		Ajax::register('dismiss_notification', [$this, 'dismissNotification']);
-		Ajax::register('update_notifications_status', [$this, 'updateNotificationsStatus']);
+		Ajax::registerAdmin('dismiss_notification', [$this, 'dismissNotification']);
+		Ajax::registerAdmin('update_notifications_status', [$this, 'updateNotificationsStatus']);
 	}
 
 	public function dismissNotification()
 	{
 		\check_ajax_referer('wp_rest', 'slimstat_nonce');
+
+		$required_cap = \wp_slimstat::$settings['capability_can_admin'] ?? 'manage_options';
+		if (!\current_user_can($required_cap)) {
+			\wp_send_json_error(['message' => \__('Permission denied.', 'wp-slimstat')], 403);
+			exit();
+		}
 
 		$notificationId = Request::get('notification_id');
 
@@ -34,6 +40,12 @@ class NotificationActions
 	public function updateNotificationsStatus()
 	{
 		\check_ajax_referer('wp_rest', 'slimstat_nonce');
+
+		$required_cap = \wp_slimstat::$settings['capability_can_admin'] ?? 'manage_options';
+		if (!\current_user_can($required_cap)) {
+			\wp_send_json_error(['message' => \__('Permission denied.', 'wp-slimstat')], 403);
+			exit();
+		}
 
 		$hasUpdatedNotifications = NotificationProcessor::updateNotificationsStatus();
 

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -968,7 +968,7 @@ class wp_slimstat
 		$rest_base_url     = rest_url();
         $ajax_url          = admin_url('admin-ajax.php');
         $ajax_url_relative = admin_url('admin-ajax.php', 'relative');
-        $adblock_hash      = md5(site_url() . 'slimstat_request' . SLIMSTAT_ANALYTICS_VERSION);
+        $adblock_hash      = \SlimStat\Providers\RestApiManager::getSecureAdblockHash();
         $adblock_url       = home_url(sprintf('request/%s/', $adblock_hash));
 
         // Always provide all possible endpoints for fallback logic


### PR DESCRIPTION
## Summary

Resolves all 4 findings raised in the [PR #123 review comment](https://github.com/wp-slimstat/wp-slimstat/pull/123#issuecomment-3990219108).

- **[CRITICAL]** Unauthenticated AJAX can mutate admin notification state — add `Ajax::registerAdmin()` (no nopriv) and `current_user_can(capability_can_admin)` checks in both notification handlers
- **[WARNING]** Adblock bypass hash mismatch — client used `md5()`, server validated `HMAC-SHA256`; client now calls `RestApiManager::getSecureAdblockHash()`
- **[WARNING]** Weekly chart granularity branch was unreachable — `>2 DAY` check preceded `>7 DAY`; conditions swapped
- **[WARNING]** Consent cache key was global — replaced with per-visitor memoized key (tracking cookie → pageview_id → skip caching)

## Test plan

- [ ] Unauthenticated POST to `admin-ajax.php?action=slimstat_dismiss_notification` returns `0` (no nopriv hook)
- [ ] Authenticated subscriber with valid nonce → JSON `{"success":false}` 403
- [ ] Authenticated admin with valid nonce → success
- [ ] Adblock bypass transport: `ajaxurl_adblock` URL hash matches server `getSecureAdblockHash()` output; tracking hit succeeds
- [ ] Date range 8–14 days → chart resolves to **weekly** granularity (was daily before fix)
- [ ] Date range 3–7 days → still **daily** (no regression)
- [ ] Two concurrent visitors on Redis cache each get independent consent transition evaluation