### PR TITLE
fix: remove short-lived cache from pages/countries live count query

### DIFF
--- a/src/Reports/Types/Analytics/LiveAnalyticsReport.php
+++ b/src/Reports/Types/Analytics/LiveAnalyticsReport.php
@@ -147,7 +147,6 @@ class LiveAnalyticsReport extends AbstractReport implements ReportInterface, Ren
 		$row          = Query::select( "COUNT(DISTINCT NULLIF(resource,'')) AS pages_count, COUNT(DISTINCT NULLIF(country,'')) AS countries_count" )
 			->from( "{$wpdb->prefix}slim_stats" )
 			->where( 'dt', '>=', $threshold_30 )
-			->allowCaching( true, 1 )
 			->getRow();
 
 		return [

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -784,7 +784,7 @@ class wp_slimstat
     {
         return [
             'version'                => SLIMSTAT_ANALYTICS_VERSION,
-            'secret'                 => wp_hash(uniqid(time(), true)),
+            'secret'                 => wp_hash(wp_generate_password(64, true, true)),
             'browscap_last_modified' => 0,
 
             // General
@@ -913,7 +913,7 @@ class wp_slimstat
             'can_admin'            => '',
 
             // Access Control - REST API
-            'rest_api_tokens' => wp_hash(uniqid(time() - 3600, true)),
+            'rest_api_tokens' => wp_hash(wp_generate_password(64, true, true)),
 
             // Maintenance
             // -----------------------------------------------------------------------


### PR DESCRIPTION
The "Pages live" counter was displaying 0 on initial page load due to a 1-second cache that served stale data. Removing the cache ensures the query always returns fresh real-time data, making it consistent with "Users live" which worked correctly on initial load.

The 1-second cache was too short to provide performance benefits but too long for real-time analytics, and didn't align with the minute-boundary refresh strategy used by the JavaScript auto-refresh mechanism.

### Describe your changes
...

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
