### PR TITLE
feat: Add license-status notification tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "post-update-cmd": [
       "~/.composer/vendor/bin/mozart compose",
       "composer dump-autoload"
-    ]
+    ],
+    "test:license-tags": "php tests/license-tag-gating-test.php"
   }
 }

--- a/src/Services/Admin/ConditionTagEvaluator.php
+++ b/src/Services/Admin/ConditionTagEvaluator.php
@@ -8,7 +8,7 @@ class ConditionTagEvaluator
 	 * Minimum plugin version that supports license-related tags.
 	 * Notifications using license tags must include is-version-{x} >= this value.
 	 */
-	const LICENSE_TAGS_MIN_VERSION = '5.4.0';
+	public const LICENSE_TAGS_MIN_VERSION = '5.4.0';
 
 	/**
 	 * Tags that require version gating for backward compatibility.

--- a/src/Services/Admin/ConditionTagEvaluator.php
+++ b/src/Services/Admin/ConditionTagEvaluator.php
@@ -83,9 +83,9 @@ class ConditionTagEvaluator
 		}
 
 		$key    = \wp_slimstat::$settings['slimstat_pro_license_key'] ?? '';
-		$status = \wp_slimstat::$settings['slimstat_pro_license_status'] ?? false;
+		$status = (bool) (\wp_slimstat::$settings['slimstat_pro_license_status'] ?? false);
 
-		return !empty($key) && $status === true;
+		return !empty($key) && $status;
 	}
 
 	/**
@@ -108,9 +108,9 @@ class ConditionTagEvaluator
 			return true;
 		}
 
-		$status = \wp_slimstat::$settings['slimstat_pro_license_status'] ?? false;
+		$status = (bool) (\wp_slimstat::$settings['slimstat_pro_license_status'] ?? false);
 
-		return $status !== true;
+		return !$status;
 	}
 
 	/**

--- a/src/Services/Admin/ConditionTagEvaluator.php
+++ b/src/Services/Admin/ConditionTagEvaluator.php
@@ -5,14 +5,36 @@ namespace SlimStat\Services\Admin;
 class ConditionTagEvaluator
 {
 	/**
+	 * Minimum plugin version that supports license-related tags.
+	 * Notifications using license tags must include is-version-{x} >= this value.
+	 */
+	const LICENSE_TAGS_MIN_VERSION = '5.4.0';
+
+	/**
+	 * Tags that require version gating for backward compatibility.
+	 * Old plugin versions evaluate unknown tags as true (fail-open),
+	 * so these tags must be paired with is-version-* to prevent mis-targeting.
+	 *
+	 * @var array
+	 */
+	private static $versionGatedTags = [
+		'is-license-active',
+		'is-license-inactive',
+		'no-license',
+	];
+
+	/**
 	 * Array mapping condition tags to their respective methods.
 	 *
 	 * @var array
 	 */
 	private static $tags = [
-		'is-admin'   => 'isAdminUser',
-		'is-premium' => 'isPremiumUser',
-		'no-premium' => 'noPremiumUser',
+		'is-admin'            => 'isAdminUser',
+		'is-premium'          => 'isPremiumUser',
+		'no-premium'          => 'noPremiumUser',
+		'is-license-active'   => 'isLicenseActive',
+		'is-license-inactive' => 'isLicenseInactive',
+		'no-license'          => 'hasNoLicense',
 	];
 
 	/**
@@ -43,6 +65,77 @@ class ConditionTagEvaluator
 	public static function noPremiumUser()
 	{
 		return !\wp_slimstat::pro_is_installed();
+	}
+
+	/**
+	 * Check if the user has an active (validated) premium license.
+	 *
+	 * Requires: Pro plugin installed, a license key entered, and license status true.
+	 * Pro installation is checked because deactivating Pro does not clear stored status,
+	 * which would cause stale status=true to misclassify lapsed users as active.
+	 *
+	 * @return bool
+	 */
+	public static function isLicenseActive()
+	{
+		if (!\wp_slimstat::pro_is_installed()) {
+			return false;
+		}
+
+		$key    = \wp_slimstat::$settings['slimstat_pro_license_key'] ?? '';
+		$status = \wp_slimstat::$settings['slimstat_pro_license_status'] ?? false;
+
+		return !empty($key) && $status === true;
+	}
+
+	/**
+	 * Check if the user has an inactive license.
+	 *
+	 * True when a license key exists but is not currently validated:
+	 * Pro not installed (lapsed customer), status is false/null, or never validated.
+	 *
+	 * @return bool
+	 */
+	public static function isLicenseInactive()
+	{
+		$key = \wp_slimstat::$settings['slimstat_pro_license_key'] ?? '';
+
+		if (empty($key)) {
+			return false;
+		}
+
+		if (!\wp_slimstat::pro_is_installed()) {
+			return true;
+		}
+
+		$status = \wp_slimstat::$settings['slimstat_pro_license_status'] ?? false;
+
+		return $status !== true;
+	}
+
+	/**
+	 * Check if the user has no license at all.
+	 *
+	 * True when no license key has ever been entered.
+	 * Uses key presence as the durable signal for "ever purchased."
+	 *
+	 * @return bool
+	 */
+	public static function hasNoLicense()
+	{
+		$key = \wp_slimstat::$settings['slimstat_pro_license_key'] ?? '';
+
+		return empty($key);
+	}
+
+	/**
+	 * Get the list of tags that require version gating.
+	 *
+	 * @return array
+	 */
+	public static function getVersionGatedTags()
+	{
+		return self::$versionGatedTags;
 	}
 
 	/**

--- a/src/Services/Admin/Notification/NotificationProcessor.php
+++ b/src/Services/Admin/Notification/NotificationProcessor.php
@@ -12,6 +12,12 @@ class NotificationProcessor
 		if (!empty($notifications) && is_array($notifications)) {
 			foreach ($notifications as $key => $notification) {
 				if (!empty($notification['tags']) && is_array($notification['tags'])) {
+					// Enforce version gating for license-related tags
+					if (self::requiresVersionGate($notification['tags']) && !self::hasValidVersionGate($notification['tags'])) {
+						unset($notifications[$key]);
+						continue;
+					}
+
 					$condition = true;
 					foreach ($notification['tags'] as $tag) {
 						if (!ConditionTagEvaluator::checkConditions($tag)) {
@@ -32,6 +38,49 @@ class NotificationProcessor
 		}
 
 		return $notifications;
+	}
+
+	/**
+	 * Check if a notification's tags include any version-gated tag.
+	 *
+	 * @param array $tags
+	 * @return bool
+	 */
+	private static function requiresVersionGate(array $tags)
+	{
+		return !empty(\array_intersect($tags, ConditionTagEvaluator::getVersionGatedTags()));
+	}
+
+	/**
+	 * Check if a notification includes a valid is-version-* tag at or above the minimum floor.
+	 *
+	 * Validates:
+	 * 1. At least one is-version-* tag is present
+	 * 2. The version string is well-formed (digits and dots only)
+	 * 3. The version is >= LICENSE_TAGS_MIN_VERSION
+	 *
+	 * @param array $tags
+	 * @return bool
+	 */
+	private static function hasValidVersionGate(array $tags)
+	{
+		foreach ($tags as $tag) {
+			if (\strpos($tag, 'is-version-') !== 0) {
+				continue;
+			}
+
+			$version = \substr($tag, \strlen('is-version-'));
+
+			if (!\preg_match('/^\d+\.\d+(\.\d+)?$/', $version)) {
+				continue;
+			}
+
+			if (\version_compare($version, ConditionTagEvaluator::LICENSE_TAGS_MIN_VERSION, '>=')) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public static function decorateNotifications($notifications)

--- a/src/Services/CronEventManager.php
+++ b/src/Services/CronEventManager.php
@@ -52,19 +52,19 @@ class CronEventManager
 
 	public function handleDailyTasks()
 	{
-		if ('on' === \wp_slimstat::$settings['display_notifications']) {
-			/**
-			 * Fires daily to allow license status revalidation.
-			 *
-			 * The Pro plugin can hook into this action to periodically refresh
-			 * the license status stored in slimstat_options, ensuring that
-			 * license-based notification tags (is-license-active, is-license-inactive)
-			 * evaluate against fresh data rather than stale cached status.
-			 *
-			 * @since 5.4.0
-			 */
-			\do_action('slimstat_daily_license_check');
+		/**
+		 * Fires daily to allow license status revalidation.
+		 *
+		 * The Pro plugin can hook into this action to periodically refresh
+		 * the license status stored in slimstat_options, ensuring that
+		 * license-based notification tags (is-license-active, is-license-inactive)
+		 * evaluate against fresh data rather than stale cached status.
+		 *
+		 * @since 5.4.0
+		 */
+		\do_action('slimstat_daily_license_check');
 
+		if ('on' === \wp_slimstat::$settings['display_notifications']) {
 			$this->fetchNotification();
 		}
 	}

--- a/src/Services/CronEventManager.php
+++ b/src/Services/CronEventManager.php
@@ -52,19 +52,19 @@ class CronEventManager
 
 	public function handleDailyTasks()
 	{
-		/**
-		 * Fires daily to allow license status revalidation.
-		 *
-		 * The Pro plugin can hook into this action to periodically refresh
-		 * the license status stored in slimstat_options, ensuring that
-		 * license-based notification tags (is-license-active, is-license-inactive)
-		 * evaluate against fresh data rather than stale cached status.
-		 *
-		 * @since 5.4.0
-		 */
-		\do_action('slimstat_daily_license_check');
-
 		if ('on' === \wp_slimstat::$settings['display_notifications']) {
+			/**
+			 * Fires daily to allow license status revalidation.
+			 *
+			 * The Pro plugin can hook into this action to periodically refresh
+			 * the license status stored in slimstat_options, ensuring that
+			 * license-based notification tags (is-license-active, is-license-inactive)
+			 * evaluate against fresh data rather than stale cached status.
+			 *
+			 * @since 5.4.0
+			 */
+			\do_action('slimstat_daily_license_check');
+
 			$this->fetchNotification();
 		}
 	}

--- a/src/Services/CronEventManager.php
+++ b/src/Services/CronEventManager.php
@@ -60,6 +60,10 @@ class CronEventManager
 		 * license-based notification tags (is-license-active, is-license-inactive)
 		 * evaluate against fresh data rather than stale cached status.
 		 *
+		 * Important: Handlers MUST update \wp_slimstat::$settings['slimstat_pro_license_status']
+		 * directly in addition to persisting to the database, because tag evaluation reads
+		 * from the in-memory static property during the same request.
+		 *
 		 * @since 5.4.0
 		 */
 		\do_action('slimstat_daily_license_check');

--- a/src/Services/CronEventManager.php
+++ b/src/Services/CronEventManager.php
@@ -52,6 +52,18 @@ class CronEventManager
 
 	public function handleDailyTasks()
 	{
+		/**
+		 * Fires daily to allow license status revalidation.
+		 *
+		 * The Pro plugin can hook into this action to periodically refresh
+		 * the license status stored in slimstat_options, ensuring that
+		 * license-based notification tags (is-license-active, is-license-inactive)
+		 * evaluate against fresh data rather than stale cached status.
+		 *
+		 * @since 5.4.0
+		 */
+		\do_action('slimstat_daily_license_check');
+
 		if ('on' === \wp_slimstat::$settings['display_notifications']) {
 			$this->fetchNotification();
 		}

--- a/tests/license-tag-gating-test.php
+++ b/tests/license-tag-gating-test.php
@@ -142,6 +142,20 @@ namespace {
 	]);
 	assert_count_is($out, 0, 'no-license should not match if a license key exists');
 
+	// Stale status=true after Pro uninstall (key edge case from design)
+	\wp_slimstat::$proInstalled = false;
+	\wp_slimstat::$settings['slimstat_pro_license_key'] = 'abc123';
+	\wp_slimstat::$settings['slimstat_pro_license_status'] = true;
+	$out = NotificationProcessor::filterNotificationsByTags([
+		['id' => 9, 'tags' => ['is-license-active', 'is-version-5.4.0']],
+	]);
+	assert_count_is($out, 0, 'is-license-active must be false when Pro is uninstalled even with stale status=true');
+
+	$out = NotificationProcessor::filterNotificationsByTags([
+		['id' => 10, 'tags' => ['is-license-inactive', 'is-version-5.4.0']],
+	]);
+	assert_count_is($out, 1, 'is-license-inactive must be true for lapsed user with stale status');
+
 	$manager = (new \ReflectionClass(CronEventManager::class))->newInstanceWithoutConstructor();
 
 	$GLOBALS['slimstat_test_actions'] = [];
@@ -150,7 +164,7 @@ namespace {
 
 	$manager->handleDailyTasks();
 
-	assert_true(!in_array('slimstat_daily_license_check', $GLOBALS['slimstat_test_actions'], true), 'daily license hook must not fire when notifications are off');
+	assert_true(in_array('slimstat_daily_license_check', $GLOBALS['slimstat_test_actions'], true), 'daily license hook must fire even when notifications are off');
 	assert_true(NotificationFetcher::$fetchCalls === 0, 'daily notification fetch must not run when notifications are off');
 
 	$GLOBALS['slimstat_test_actions'] = [];

--- a/tests/license-tag-gating-test.php
+++ b/tests/license-tag-gating-test.php
@@ -63,7 +63,7 @@ namespace {
 		return 'en_US';
 	}
 
-	function get_option($key)
+	function get_option($_key)
 	{
 		return '';
 	}
@@ -156,6 +156,8 @@ namespace {
 	]);
 	assert_count_is($out, 1, 'is-license-inactive must be true for lapsed user with stale status');
 
+	// Bypass constructor to avoid Event::schedule and add_action side-effects
+	// that require WordPress globals not available in this isolated test.
 	$manager = (new \ReflectionClass(CronEventManager::class))->newInstanceWithoutConstructor();
 
 	$GLOBALS['slimstat_test_actions'] = [];

--- a/tests/license-tag-gating-test.php
+++ b/tests/license-tag-gating-test.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+	$assertions = 0;
+
+	function assert_true($condition, $message)
+	{
+		global $assertions;
+		$assertions++;
+
+		if (!$condition) {
+			fwrite(STDERR, "FAIL: {$message}\n");
+			exit(1);
+		}
+	}
+
+	function assert_count_is(array $items, $expectedCount, $message)
+	{
+		assert_true(count($items) === $expectedCount, $message . " (expected {$expectedCount}, got " . count($items) . ')');
+	}
+
+	if (!defined('SLIMSTAT_ANALYTICS_VERSION')) {
+		define('SLIMSTAT_ANALYTICS_VERSION', '5.4.0');
+	}
+
+	class wp_slimstat
+	{
+		public static $settings = [];
+		public static $proInstalled = false;
+
+		public static function pro_is_installed()
+		{
+			return self::$proInstalled;
+		}
+	}
+
+	$GLOBALS['slimstat_test_actions'] = [];
+
+	function do_action($tag)
+	{
+		$GLOBALS['slimstat_test_actions'][] = $tag;
+	}
+
+	function current_user_can($capability)
+	{
+		return 'administrator' === $capability;
+	}
+
+	function is_user_logged_in()
+	{
+		return true;
+	}
+
+	function wp_get_current_user()
+	{
+		return (object) ['user_email' => 'admin@example.com'];
+	}
+
+	function get_locale()
+	{
+		return 'en_US';
+	}
+
+	function get_option($key)
+	{
+		return '';
+	}
+}
+
+namespace SlimStat\Services\Admin\Notification {
+	class NotificationFetcher
+	{
+		public static $fetchCalls = 0;
+
+		public function fetchNotification()
+		{
+			self::$fetchCalls++;
+		}
+	}
+}
+
+namespace {
+	require_once __DIR__ . '/../src/Services/Admin/ConditionTagEvaluator.php';
+	require_once __DIR__ . '/../src/Services/Admin/Notification/NotificationProcessor.php';
+	require_once __DIR__ . '/../src/Services/CronEventManager.php';
+
+	use SlimStat\Services\Admin\Notification\NotificationFetcher;
+	use SlimStat\Services\Admin\Notification\NotificationProcessor;
+	use SlimStat\Services\CronEventManager;
+
+	\wp_slimstat::$proInstalled = true;
+	\wp_slimstat::$settings = [
+		'slimstat_pro_license_key' => 'abc123',
+		'slimstat_pro_license_status' => true,
+	];
+
+	$out = NotificationProcessor::filterNotificationsByTags([
+		['id' => 1, 'tags' => ['is-license-active']],
+	]);
+	assert_count_is($out, 0, 'license tags without an is-version-* gate must be filtered');
+
+	$out = NotificationProcessor::filterNotificationsByTags([
+		['id' => 2, 'tags' => ['is-license-active', 'is-version-5.4.0']],
+	]);
+	assert_count_is($out, 1, 'valid is-version gate should allow license-active tag');
+
+	$out = NotificationProcessor::filterNotificationsByTags([
+		['id' => 3, 'tags' => ['is-license-active', 'is-version-foo']],
+	]);
+	assert_count_is($out, 0, 'malformed is-version gate should be rejected');
+
+	$out = NotificationProcessor::filterNotificationsByTags([
+		['id' => 4, 'tags' => ['is-license-active', 'is-version-5.3.9']],
+	]);
+	assert_count_is($out, 0, 'is-version below minimum supported version should be rejected');
+
+	\wp_slimstat::$proInstalled = false;
+	\wp_slimstat::$settings['slimstat_pro_license_status'] = false;
+	$out = NotificationProcessor::filterNotificationsByTags([
+		['id' => 5, 'tags' => ['is-license-inactive', 'is-version-5.4.0']],
+	]);
+	assert_count_is($out, 1, 'license-inactive should match when a key exists and Pro is not installed');
+
+	\wp_slimstat::$proInstalled = true;
+	$out = NotificationProcessor::filterNotificationsByTags([
+		['id' => 6, 'tags' => ['is-premium']],
+	]);
+	assert_count_is($out, 1, 'existing non-license tags should remain unchanged');
+
+	\wp_slimstat::$proInstalled = false;
+	\wp_slimstat::$settings['slimstat_pro_license_key'] = '';
+	$out = NotificationProcessor::filterNotificationsByTags([
+		['id' => 7, 'tags' => ['no-license', 'is-version-5.4.0']],
+	]);
+	assert_count_is($out, 1, 'no-license should match when no key has ever been stored');
+
+	\wp_slimstat::$settings['slimstat_pro_license_key'] = 'abc123';
+	$out = NotificationProcessor::filterNotificationsByTags([
+		['id' => 8, 'tags' => ['no-license', 'is-version-5.4.0']],
+	]);
+	assert_count_is($out, 0, 'no-license should not match if a license key exists');
+
+	$manager = (new \ReflectionClass(CronEventManager::class))->newInstanceWithoutConstructor();
+
+	$GLOBALS['slimstat_test_actions'] = [];
+	NotificationFetcher::$fetchCalls = 0;
+	\wp_slimstat::$settings['display_notifications'] = 'off';
+
+	$manager->handleDailyTasks();
+
+	assert_true(!in_array('slimstat_daily_license_check', $GLOBALS['slimstat_test_actions'], true), 'daily license hook must not fire when notifications are off');
+	assert_true(NotificationFetcher::$fetchCalls === 0, 'daily notification fetch must not run when notifications are off');
+
+	$GLOBALS['slimstat_test_actions'] = [];
+	NotificationFetcher::$fetchCalls = 0;
+	\wp_slimstat::$settings['display_notifications'] = 'on';
+
+	$manager->handleDailyTasks();
+
+	assert_true(in_array('slimstat_daily_license_check', $GLOBALS['slimstat_test_actions'], true), 'daily license hook must fire when notifications are on');
+	assert_true(NotificationFetcher::$fetchCalls === 1, 'daily notification fetch should run when notifications are on');
+
+	global $assertions;
+	echo "All {$assertions} assertions passed in license-tag-gating-test.php\n";
+}


### PR DESCRIPTION
## Summary

Adds three new notification condition tags to segment admin users by license status, enabling targeted notifications for:

1. **Active license holders** (`is-license-active`) — Pro installed + key entered + validated
2. **Lapsed/inactive license holders** (`is-license-inactive`) — key exists but not currently valid (expired, Pro uninstalled, or never validated)
3. **Never-purchased users** (`no-license`) — no license key ever entered

> **Full documentation**: See [`jaan-to/docs/notification-tags.md`](https://github.com/wp-slimstat/slimstat-workflow/blob/main/jaan-to/docs/notification-tags.md) for complete tag reference, edge cases, version gating rules, and usage examples.

### Key Design Decisions

- **`is-license-active` requires `pro_is_installed()`** — Pro deactivation does not clear stored `status=true`, so checking installation prevents stale misclassification
- **`is-license-inactive` does NOT require Pro** — uninstalled-Pro users with a key are lapsed customers, not "never had a license"
- **`no-license` uses key presence only** — the license key is the durable signal for "ever purchased"
- **Named `inactive` not `expired`** — status can be false, null, or stale from network errors; cannot distinguish cause with current data model

### Version Gating (Backward Compatibility)

Old plugin versions (< 5.4.0) evaluate unknown tags as `true` (fail-open), which would leak license-targeted notifications to all admins. To prevent this:

- `NotificationProcessor` enforces that notifications with license tags must include a valid `is-version-*` tag >= 5.4.0
- Malformed versions (e.g., `is-version-foo`) are rejected via regex validation
- Old clients are protected by the `is-version-5.4.0` tag itself (their version check fails)

### Stale Status Mitigation

License status only refreshes on Pro settings tab visit/save. Added `slimstat_daily_license_check` action hook in daily cron for the Pro plugin to hook into for periodic revalidation (Pro-side implementation is a follow-up).

## Files Changed

- **`ConditionTagEvaluator.php`** — 3 new tag methods, version-gated tags list, min version constant
- **`NotificationProcessor.php`** — version gating guard in `filterNotificationsByTags()`
- **`CronEventManager.php`** — `slimstat_daily_license_check` action hook in daily cron

## Test plan

- [ ] Verify `no-license` = true on site without Pro and no key in settings
- [ ] Verify `is-license-active` = true with Pro + key + status=true
- [ ] Verify `is-license-inactive` = true with Pro + key + status=false
- [ ] Verify `is-license-inactive` = true after Pro uninstalled (key persists)
- [ ] Verify notification with license tags but no version tag is filtered out
- [ ] Verify notification with `is-version-5.4.0` displays correctly
- [ ] Verify existing `is-premium`/`no-premium` tags are unchanged
- [ ] Verify `slimstat_daily_license_check` fires during daily cron

## Known Limitations

- **Stale status**: Until Pro plugin hooks into `slimstat_daily_license_check`, license status may be stale
- **Old clients**: Cannot be protected if API sends license tags WITHOUT `is-version-*`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * License-aware conditional tags for evaluating license state (is-license-active, is-license-inactive, no-license)
  * Version-gating with minimum-version validation that influences which notifications/tags are shown
  * Daily automatic license revalidation hook to refresh license-based evaluations

* **Tests**
  * New self-contained test harness exercising license-tag gating and daily revalidation behavior

* **Chores**
  * Added a script to run the license-tag gating test suite
<!-- end of auto-generated comment: release notes by coderabbit.ai -->