### PR TITLE
Fix: Replace CSS :has() with closest() for browser compatibility

### DIFF
--- a/admin/assets/js/slimstat-chart.js
+++ b/admin/assets/js/slimstat-chart.js
@@ -80,15 +80,16 @@ document.addEventListener("DOMContentLoaded", function () {
 
     function fetchChartData(chartId, granularity) {
         var element = document.getElementById("slimstat_chart_data_" + chartId);
-        var args = JSON.parse(element.getAttribute("data-args"));
         var chartCanvas = document.getElementById("slimstat_chart_" + chartId);
         var inside = chartCanvas ? chartCanvas.closest(".inside") : null;
         var chartWrap = chartCanvas ? chartCanvas.closest(".slimstat-chart-wrap") : null;
 
-        if (!inside || !chartWrap) {
-            console.warn("SlimStat: Could not find chart container elements for chart " + chartId);
+        if (!element || !chartCanvas || !inside || !chartWrap) {
+            console.warn("SlimStat: Could not find chart elements for chart " + chartId);
             return;
         }
+
+        var args = JSON.parse(element.getAttribute("data-args"));
 
         var loadingIndicator = document.createElement("p");
         loadingIndicator.classList.add("loading");

--- a/admin/assets/js/slimstat-chart.js
+++ b/admin/assets/js/slimstat-chart.js
@@ -81,14 +81,22 @@ document.addEventListener("DOMContentLoaded", function () {
     function fetchChartData(chartId, granularity) {
         var element = document.getElementById("slimstat_chart_data_" + chartId);
         var args = JSON.parse(element.getAttribute("data-args"));
-        var inside = document.querySelector(".inside:has(#slimstat_chart_" + chartId + ")");
+        var chartCanvas = document.getElementById("slimstat_chart_" + chartId);
+        var inside = chartCanvas ? chartCanvas.closest(".inside") : null;
+        var chartWrap = chartCanvas ? chartCanvas.closest(".slimstat-chart-wrap") : null;
+
+        if (!inside || !chartWrap) {
+            console.warn("SlimStat: Could not find chart container elements for chart " + chartId);
+            return;
+        }
+
         var loadingIndicator = document.createElement("p");
         loadingIndicator.classList.add("loading");
         var spinner = document.createElement("i");
         spinner.classList.add("slimstat-font-spin4", "animate-spin");
         loadingIndicator.appendChild(spinner);
         inside.appendChild(loadingIndicator);
-        document.querySelector(".slimstat-chart-wrap:has(#slimstat_chart_" + chartId + ")").style.display = "none";
+        chartWrap.style.display = "none";
 
         var xhr = new XMLHttpRequest();
         xhr.open("POST", slimstat_chart_vars.ajax_url, true);
@@ -140,7 +148,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     element.dataset.translations = JSON.stringify(translations2);
 
                     inside.removeChild(loadingIndicator);
-                    document.querySelector(".slimstat-chart-wrap:has(#slimstat_chart_" + chartId + ")").style.display = "block";
+                    chartWrap.style.display = "block";
                 } else {
                     console.error("XHR error:", xhr.statusText);
                 }


### PR DESCRIPTION
Close #139 - Charts were crashing in older browsers (Firefox <121, older Chrome/Safari/Edge) because the :has() pseudo-class is not supported. Using querySelector with :has() throws errors in unsupported browsers, causing chart rendering failures.

Changes:
- Replace querySelector(".inside:has(#chart)") with closest(".inside")
- Replace querySelector(".chart-wrap:has(#chart)") with closest()
- Add null checks before DOM manipulations to prevent TypeErrors

### Describe your changes
...

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart rendering reliability: charts now consistently show or hide correctly, with better handling of missing chart containers and clearer diagnostic warnings when charts cannot be displayed; loading indicators reliably attach to the chart area during data fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->