### PR TITLE
Fix: Gate consent banner on gdpr_enabled setting

### DIFF
--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -240,7 +240,8 @@ class wp_slimstat
 			add_filter('script_loader_tag', [self::class, 'add_defer_to_script_tag'], 10, 2);
 		}
 
-		$banner_enabled = ('on' === (self::$settings['use_slimstat_banner'] ?? 'off'));
+		$banner_enabled = ('on' === (self::$settings['gdpr_enabled'] ?? 'on'))
+			&& ('on' === (self::$settings['use_slimstat_banner'] ?? 'off'));
 		if ($banner_enabled) {
 			add_action('wp_enqueue_scripts', [self::class, 'enqueue_gdpr_assets'], 20);
 			add_action('login_enqueue_scripts', [self::class, 'enqueue_gdpr_assets'], 20);


### PR DESCRIPTION
Close #140 - Consent banner was showing even when GDPR Compliance Mode was disabled because the check only validated use_slimstat_banner without checking gdpr_enabled.

Now the banner only renders when BOTH conditions are met:
- gdpr_enabled is 'on'
- use_slimstat_banner is 'on'

### Describe your changes
...

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated banner display logic to align with privacy compliance. The banner now displays only when GDPR compliance is enabled and the banner feature is activated, ensuring better control over consent-related messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->