### PR TITLE
Fix: GDPR banner duplicate controls & WPML/Polylang i18n

### DIFF
--- a/admin/config/index.php
+++ b/admin/config/index.php
@@ -151,7 +151,7 @@ $settings = [
 				'title'             => __('Consent Banner Message', 'wp-slimstat'),
 				'type'              => 'rich_text',
 				'after_input_field' => '',
-				'description'       => __('Content displayed inside the SlimStat consent banner. Basic HTML (p, a, strong, em) is allowed. Use the editor above to format your message.', 'wp-slimstat'),
+				'description'       => __('Content displayed inside the SlimStat consent banner. Basic HTML (p, a, strong, em) is allowed. Links must use full URLs (anchor-only links are stripped). Use the editor above to format your message.', 'wp-slimstat'),
 				'conditional' => [
 					'field' => 'gdpr_enabled,consent_integration',
 					'type' => 'checked,equals',
@@ -937,6 +937,27 @@ if (!empty($settings) && !empty($_REQUEST['slimstat_update_settings']) && wp_ver
 
         // Save the new values in the database
         wp_slimstat::update_option('slimstat_options', wp_slimstat::$settings);
+
+        // Register GDPR banner strings for WPML/Polylang translation
+        $gdpr_translatable = [
+            'opt_out_message'          => wp_slimstat::$settings['opt_out_message'] ?? '',
+            'gdpr_accept_button_text'  => wp_slimstat::$settings['gdpr_accept_button_text'] ?? '',
+            'gdpr_decline_button_text' => wp_slimstat::$settings['gdpr_decline_button_text'] ?? '',
+        ];
+
+        foreach ($gdpr_translatable as $name => $value) {
+            if (empty($value)) {
+                continue;
+            }
+
+            // WPML registration
+            do_action('wpml_register_single_string', 'wp-slimstat', $name, $value);
+
+            // Native Polylang registration
+            if (function_exists('pll_register_string')) {
+                pll_register_string($name, $value, 'wp-slimstat', ($name === 'opt_out_message'));
+            }
+        }
 
         if ([] !== $save_messages) {
             wp_slimstat_admin::show_message(implode(' ', $save_messages), 'warning');

--- a/src/Services/GDPRService.php
+++ b/src/Services/GDPRService.php
@@ -146,6 +146,29 @@ class GDPRService
 	}
 
 	/**
+	 * Translate a dynamic string via WPML or Polylang if available.
+	 *
+	 * @param string $value The string to translate
+	 * @param string $name  The string identifier
+	 * @return string Translated string, or original if no translation plugin active
+	 */
+	private function translateString(string $value, string $name): string
+	{
+		// WPML and WPML-compatible plugins (including Polylang with WPML API)
+		$translated = apply_filters('wpml_translate_single_string', $value, 'wp-slimstat', $name);
+		if ($translated !== $value) {
+			return $translated;
+		}
+
+		// Native Polylang fallback
+		if (function_exists('pll__')) {
+			return pll__($value);
+		}
+
+		return $value;
+	}
+
+	/**
 	 * Get consent banner HTML
 	 *
 	 * @return string HTML markup for the banner
@@ -159,6 +182,11 @@ class GDPRService
 
 		// Get banner message from settings (with fallback)
 		$message = stripslashes($this->settings['opt_out_message'] ?? '');
+
+		// Apply WPML/Polylang translation if available
+		if (!empty($message)) {
+			$message = $this->translateString($message, 'opt_out_message');
+		}
 
 		// If message is empty, use default message
 		if (empty($message)) {
@@ -179,13 +207,17 @@ class GDPRService
 		];
 		$message = wp_kses($message, $allowed_tags);
 
+		// Strip anchor-only or empty-href links (legacy accept/deny controls)
+		// Preserves links with real URLs (e.g. privacy policy pages)
+		$message = preg_replace('/<a\s[^>]*href\s*=\s*["\']#?["\'][^>]*>(.*?)<\/a>/is', '$1', $message);
+
 		// Get button text from settings
 		$acceptText = empty($this->settings['gdpr_accept_button_text'])
 			? __('Accept', 'wp-slimstat')
-			: $this->settings['gdpr_accept_button_text'];
+			: $this->translateString($this->settings['gdpr_accept_button_text'], 'gdpr_accept_button_text');
 		$denyText = empty($this->settings['gdpr_decline_button_text'])
 			? __('Deny', 'wp-slimstat')
-			: $this->settings['gdpr_decline_button_text'];
+			: $this->translateString($this->settings['gdpr_decline_button_text'], 'gdpr_decline_button_text');
 
 		$acceptButton = sprintf(
 			'<button type="button" class="slimstat-gdpr-accept" data-consent="accepted">%s</button>',

--- a/src/Services/GDPRService.php
+++ b/src/Services/GDPRService.php
@@ -207,9 +207,20 @@ class GDPRService
 		];
 		$message = wp_kses($message, $allowed_tags);
 
-		// Strip anchor-only or empty-href links (legacy accept/deny controls)
-		// Preserves links with real URLs (e.g. privacy policy pages)
-		$message = preg_replace('/<a\s[^>]*href\s*=\s*["\']#?["\'][^>]*>(.*?)<\/a>/is', '$1', $message);
+		// Strip links that don't point to real URLs (legacy accept/deny controls)
+		// Keeps: https://..., http://..., /path, //protocol-relative
+		// Strips: #, #fragment, empty, whitespace-only — preserves inner text
+		$message = preg_replace_callback(
+			'/<a\s[^>]*href\s*=\s*["\']([^"\']*)["\'][^>]*>(.*?)<\/a>/is',
+			function ($matches) {
+				$href = trim($matches[1]);
+				if (preg_match('#^(https?://|/)#i', $href)) {
+					return $matches[0]; // Real URL — keep the link
+				}
+				return $matches[2]; // Not a real URL — keep text, strip tag
+			},
+			$message
+		);
 
 		// Get button text from settings
 		$acceptText = empty($this->settings['gdpr_accept_button_text'])


### PR DESCRIPTION
## Summary

- **#144**: Strip anchor-only/empty-href `<a>` links from custom banner message to prevent duplicate Accept/Deny controls alongside the rendered buttons. Real URL links (e.g. privacy policy pages) are preserved. Updates field description to clarify link requirements.
- **#145**: Register custom GDPR banner strings (`opt_out_message`, `gdpr_accept_button_text`, `gdpr_decline_button_text`) with WPML (`wpml_register_single_string`) and Polylang (`pll_register_string`) on settings save. Applies translations at render time via `wpml_translate_single_string` with native Polylang `pll__()` fallback. Zero impact when no translation plugin is active.

Closes #144
Closes #145

## Test plan

- [ ] Set `opt_out_message` to `Click <a href="#">Accept</a> or <a href="#">Deny</a>` — verify anchor-only links are stripped, text preserved, only `<button>` controls visible
- [ ] Set `opt_out_message` to `Read our <a href="https://example.com/privacy">Privacy Policy</a>` — verify real URL link is preserved and clickable
- [ ] Verify `<p>`, `<br>`, `<b>`, `<i>`, `<strong>`, `<em>` tags still render in banner message
- [ ] Without WPML/Polylang: verify banner renders as before with no warnings/errors
- [ ] With WPML: save custom strings → verify they appear in String Translation under context `wp-slimstat` → verify translated values render on language switch
- [ ] With Polylang: save custom strings → verify they are registered and translatable
- [ ] Empty message falls back to default `__()` string; empty button text falls back to `__('Accept')`/`__('Deny')`
- [ ] Banner hidden when consent cookie exists; Accept/Deny buttons still set cookie correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GDPR consent banner and its Accept/Deny button texts now support multilingual translations (WPML/Polylang), so configured messages display in the site language.

* **Documentation**
  * Consent banner guidance updated: links must be full URLs; anchor-only links are stripped to ensure consistent, sanitized banner content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->