### PR TITLE
Fix/issue 146 admin bar migration

### DIFF
--- a/admin/assets/js/slimstat-chart.js
+++ b/admin/assets/js/slimstat-chart.js
@@ -80,15 +80,16 @@ document.addEventListener("DOMContentLoaded", function () {
 
     function fetchChartData(chartId, granularity) {
         var element = document.getElementById("slimstat_chart_data_" + chartId);
-        var args = JSON.parse(element.getAttribute("data-args"));
         var chartCanvas = document.getElementById("slimstat_chart_" + chartId);
         var inside = chartCanvas ? chartCanvas.closest(".inside") : null;
         var chartWrap = chartCanvas ? chartCanvas.closest(".slimstat-chart-wrap") : null;
 
-        if (!inside || !chartWrap) {
-            console.warn("SlimStat: Could not find chart container elements for chart " + chartId);
+        if (!element || !chartCanvas || !inside || !chartWrap) {
+            console.warn("SlimStat: Could not find chart elements for chart " + chartId);
             return;
         }
+
+        var args = JSON.parse(element.getAttribute("data-args"));
 
         var loadingIndicator = document.createElement("p");
         loadingIndicator.classList.add("loading");

--- a/admin/assets/js/slimstat-chart.js
+++ b/admin/assets/js/slimstat-chart.js
@@ -81,14 +81,22 @@ document.addEventListener("DOMContentLoaded", function () {
     function fetchChartData(chartId, granularity) {
         var element = document.getElementById("slimstat_chart_data_" + chartId);
         var args = JSON.parse(element.getAttribute("data-args"));
-        var inside = document.querySelector(".inside:has(#slimstat_chart_" + chartId + ")");
+        var chartCanvas = document.getElementById("slimstat_chart_" + chartId);
+        var inside = chartCanvas ? chartCanvas.closest(".inside") : null;
+        var chartWrap = chartCanvas ? chartCanvas.closest(".slimstat-chart-wrap") : null;
+
+        if (!inside || !chartWrap) {
+            console.warn("SlimStat: Could not find chart container elements for chart " + chartId);
+            return;
+        }
+
         var loadingIndicator = document.createElement("p");
         loadingIndicator.classList.add("loading");
         var spinner = document.createElement("i");
         spinner.classList.add("slimstat-font-spin4", "animate-spin");
         loadingIndicator.appendChild(spinner);
         inside.appendChild(loadingIndicator);
-        document.querySelector(".slimstat-chart-wrap:has(#slimstat_chart_" + chartId + ")").style.display = "none";
+        chartWrap.style.display = "none";
 
         var xhr = new XMLHttpRequest();
         xhr.open("POST", slimstat_chart_vars.ajax_url, true);
@@ -140,7 +148,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     element.dataset.translations = JSON.stringify(translations2);
 
                     inside.removeChild(loadingIndicator);
-                    document.querySelector(".slimstat-chart-wrap:has(#slimstat_chart_" + chartId + ")").style.display = "block";
+                    chartWrap.style.display = "block";
                 } else {
                     console.error("XHR error:", xhr.statusText);
                 }

--- a/admin/index.php
+++ b/admin/index.php
@@ -732,6 +732,11 @@ class wp_slimstat_admin
             }
         }
 
+        // --- Updates for version 5.4.1 ---
+        if (version_compare(wp_slimstat::$settings['version'], '5.4.1', '<')) {
+            wp_slimstat::$settings['use_separate_menu'] = 'on';
+        }
+
         // Now we can update the version stored in the database
         wp_slimstat::$settings['version']            = SLIMSTAT_ANALYTICS_VERSION;
         wp_slimstat::$settings['notice_latest_news'] = 'on';

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -240,7 +240,8 @@ class wp_slimstat
 			add_filter('script_loader_tag', [self::class, 'add_defer_to_script_tag'], 10, 2);
 		}
 
-		$banner_enabled = ('on' === (self::$settings['use_slimstat_banner'] ?? 'off'));
+		$banner_enabled = ('on' === (self::$settings['gdpr_enabled'] ?? 'on'))
+			&& ('on' === (self::$settings['use_slimstat_banner'] ?? 'off'));
 		if ($banner_enabled) {
 			add_action('wp_enqueue_scripts', [self::class, 'enqueue_gdpr_assets'], 20);
 			add_action('login_enqueue_scripts', [self::class, 'enqueue_gdpr_assets'], 20);


### PR DESCRIPTION
 ## Summary                                                                                                                                                                       
  - Fixed admin bar migration bug where "Online: X" counter didn't appear after upgrading from older versions                                                                      
  - The issue was caused by `empty()` check returning `false` for the string `'no'`, preventing the setting upgrade                                                                
                                                                                                                                                                                   
  ## Changes                                                                                                                                                                       
  - Added version-gated migration block for 5.4.1 that sets `use_separate_menu` to `'on'`                                                                                        
  - Updated version to 5.4.1 in plugin header and constant
  - Added changelog entries

  ## Test plan
  - [ ] Upgrade from a version < 5.4.0 where `use_separate_menu` was set to `'no'`
  - [ ] Verify admin bar "Online: X" counter appears after upgrade

  Close #146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened chart display reliability with improved element detection to prevent rendering errors.
  * GDPR banner visibility now requires both the banner and GDPR compliance to be enabled.

* **New Features**
  * Separate admin menu layout option introduced and enabled for version 5.4.1 upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->