### PR TITLE
Fix admin bar migration bug for upgrading users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+= 5.4.1 =
+
+Fix
+- Fixed admin bar migration bug where "Online: X" counter didn't appear after upgrading from older versions due to flawed `empty()` check on 'use_separate_menu' setting.
+
 = 5.4.0 - 2026-03-08 =
 
 - Full release notes → [WordPress Real-time Analytics Plugin](https://wp-slimstat.com/wordpress-analytics-plugin-slimstat-5-4-release-notes/?utm_source=wordpress&utm_medium=changelog&utm_campaign=changelog&utm_content=5-4-0) – Slimstat 5.4 – Real-Time, Real Privacy

--- a/admin/index.php
+++ b/admin/index.php
@@ -732,6 +732,13 @@ class wp_slimstat_admin
             }
         }
 
+        // --- Updates for version 5.4.1 ---
+        // Fix admin bar migration: empty('no') returned false in 5.4.0, missing users with legacy 'no' value
+        // Safe because this runs once (version bumps to 5.4.1 after), users who disable later are already on 5.4.1+
+        if (version_compare(wp_slimstat::$settings['version'], '5.4.1', '<')) {
+            wp_slimstat::$settings['use_separate_menu'] = 'on';
+        }
+
         // Now we can update the version stored in the database
         wp_slimstat::$settings['version']            = SLIMSTAT_ANALYTICS_VERSION;
         wp_slimstat::$settings['notice_latest_news'] = 'on';

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Text Domain: wp-slimstat
 Requires at least: 5.6
 Requires PHP: 7.4
 Tested up to: 6.9.1
-Stable tag: 5.4.0
+Stable tag: 5.4.1
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +73,9 @@ An extensive knowledge base is available on our [website](https://www.wp-slimsta
 9. **Settings** - Plenty of options to customize the plugin's behavior
 
 == Changelog ==
+= 5.4.1 =
+- **Fix**: Admin bar "Online: X" counter now properly appears after upgrading from older versions.
+
 = 5.4.0 - 2026-03-08 =
 - **Breaking**: Removed internal GDPR consent management system (shortcode, banner, opt-in/opt-out cookies) in favor of external CMP integrations.
 - **New**: Integration with Consent Management Platforms (CMPs) for GDPR compliance: WP Consent API and Real Cookie Banner Pro.

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -3,7 +3,7 @@
  * Plugin Name: SlimStat Analytics
  * Plugin URI: https://wp-slimstat.com/
  * Description: The leading web analytics plugin for WordPress
- * Version: 5.4.0
+ * Version: 5.4.1
  * Author: Jason Crouse, VeronaLabs
  * Text Domain: wp-slimstat
  * Domain Path: /languages
@@ -20,7 +20,7 @@ if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
 }
 
 // Set the plugin version and directory
-define('SLIMSTAT_ANALYTICS_VERSION', '5.4.0');
+define('SLIMSTAT_ANALYTICS_VERSION', '5.4.1');
 define('SLIMSTAT_FILE', __FILE__);
 define('SLIMSTAT_DIR', __DIR__);
 define('SLIMSTAT_URL', plugins_url('', __FILE__));


### PR DESCRIPTION
Added version-gated migration for 5.4.1 to ensure 'use_separate_menu' setting is properly set to 'on' for users upgrading from older versions where the empty() check failed for the string 'no'.

Close #146

### Describe your changes
...

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fix**
  * Admin bar "Online: X" counter now appears correctly after upgrading from older versions.

* **Chores**
  * Added 5.4.1 release notes and bumped the plugin version.
  * Improved the upgrade/migration so the menu-related setting is initialized during updates to 5.4.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->