### PR TITLE
Fix refresh button not resetting countdown timer (#153)

### DIFF
--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -1383,6 +1383,7 @@ jQuery(function () {
 // ----- BEGIN: SLIMSTATADMIN HELPER FUNCTIONS ---------------------------------------
 var SlimStatAdmin = {
     refresh_handle: null,
+    _lastManualRefreshTime: 0,
 
     refresh_report: function (id) {
         return function () {
@@ -1393,7 +1394,7 @@ var SlimStatAdmin = {
 
             // Clear the autorefresh timer, if set
             if (SlimStatAdmin.refresh_handle != null) {
-                clearTimeout(SlimStatAdmin.refresh_handle);
+                clearInterval(SlimStatAdmin.refresh_handle);
             }
 
             data = {
@@ -1446,7 +1447,7 @@ var SlimStatAdmin = {
                         });
 
                         if (id == "slim_p7_02") {
-                            SlimStatAdmin._refresh_timer = SlimStatAdminParams.refresh_interval;
+                            SlimStatAdmin._lastManualRefreshTime = Date.now();
                         }
                     }
                 })
@@ -1465,6 +1466,15 @@ var SlimStatAdmin = {
             var now = new Date();
             var currentSeconds = now.getSeconds();
             var currentMinute = now.getMinutes();
+
+            // Check if a manual refresh happened recently (within 2 seconds)
+            var timeSinceManualRefresh = Date.now() - SlimStatAdmin._lastManualRefreshTime;
+            if (timeSinceManualRefresh < 2000) {
+                jQuery(".refresh-timer").html("0:00");
+                // Reset the trigger minute to sync with the wall clock after manual refresh
+                lastTriggerMinute = -1;
+                return;
+            }
 
             // Trigger pulse at exactly :00 of a new minute
             if (currentSeconds === 0 && lastTriggerMinute !== currentMinute) {


### PR DESCRIPTION
- Fix clearTimeout to clearInterval for interval handle
- Add _lastManualRefreshTime to track manual refresh events
- Show 0:00 for 2 seconds after manual refresh to provide visual feedback
- Replace unused _refresh_timer with functional _lastManualRefreshTime

Close #153

### Describe your changes
...

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
