### PR TITLE
fix(geoip): prevent infinite AJAX loop when WP-Cron disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ composer.lock
 
 # Testing
 .env.testing
+test-results/
+tests/e2e/.auth/
+tests/e2e/playwright-report/
 # Bun
 bun.lock
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Slimstat Analytics #
 The leading web analytics plugin for WordPress. Track returning customers and registered users, monitor Javascript events, detect intrusions, analyze email campaigns. Thousands of WordPress sites are already using it.
 
-We still have some plans to make SlimStat Analytics better, so please keep your feedback coming, please click here [WordPress Real-time Analytics Plugin](https://wp-slimstat.com/wordpress-analytics-plugin-slimstat-5-2-11-release-notes/?utm_source=wordpress&utm_medium=changelog&utm_campaign=changelog&utm_content=5-2-11) to read more.
+We still have some plans to make SlimStat Analytics better, so please keep your feedback coming, please click here [WordPress Real-time Analytics Plugin](https://wp-slimstat.com/wordpress-analytics-plugin-slimstat-5-4-release-notes/?utm_source=wordpress&utm_medium=changelog&utm_campaign=changelog&utm_content=5-4-0) to read more.
 
 ### Main features ###
 * **Real-Time Access Log**: measure server latency, track page events, keep an eye on your bounce rate and much more.
+* **Admin Bar Stats**: view real-time site stats directly from the WordPress admin bar — online visitors, pageviews, and top pages at a glance.
 * **Shortcodes**: display reports in widgets or directly in posts and pages.
-* **GDPR**: fully compliant with the GDPR European law. You can test your website at [cookiebot.com](https://www.cookiebot.com/en/).
+* **Customize Reports**: Customize all pages—Real-time, Overview, Audience, Site Analysis, and Traffic Sources—to fit your needs easily!
+* **GDPR**: fully compliant with GDPR European law. Integrates seamlessly with WP Consent API. Consent banner translatable with WPML and Polylang.
 * **Filters**: exclude users from slimstat collection based on various criteria, including user roles, common robots, IP subnets, admin pages, country, etc.
 * **Export to Excel**: download your reports as CSV files, generate user heatmaps or get daily emails right in your mailbox (via premium add-ons).
 * **Cache**: compatible with W3 Total Cache, WP SuperCache, CloudFlare and most caching plugins.
 * **Privacy**: hash IP addresses to protect your users' privacy.
 * **Geolocation**: identify your visitors by city and country, browser type and operating system (courtesy of [MaxMind](https://www.maxmind.com/) and [Browscap](https://browscap.org)).
-* **World Map**: see where your visitors are coming from, even on your mobile device (courtesy of [amMap](https://www.ammap.com/)).
+* **World Map**: see where your visitors are coming from, even on your mobile device (courtesy of [JQVMap](https://github.com/10bestdesign/jqvmap)).
 
 ### Contribute ###
 Slimstat Analytics is an open source project, dependent in large part on community support. You can fork our [Github repository](https://github.com/slimstat/wp-slimstat) and submit code enhancements, bugfixes or provide localization files to let our plugin speak even more languages. [This page](https://www.paypal.com/cgi-bin/webscr?cmd###_s-xclick&hosted_button_id###BNJR5EZNY3W38)
@@ -20,7 +22,7 @@ is for those who would like to donate money - be it once, be it regularly, be it
 Try it out, you'll be amazed how good it feels! If you're on a tight budget, and coding is not your thing, please consider writing [a review](https://wordpress.org/support/plugin/wp-slimstat/reviews/#new-post) for Slimstat as a token of appreciation for our hard work!
 
 ### Requirements ###
-* WordPress 6.0+
+* WordPress 5.6+
 * PHP 7.4+
 * MySQL 5.0.3+
 * At least 5 MB of free web space (240 MB if you plan on using the external libraries for geolocation and browser detection)

--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -340,6 +340,9 @@ jQuery(function () {
         } else if (provider === "cloudflare") {
             $licenseRow.css("display", "none");
             $dbActionsRow.css("display", "none");
+        } else if (provider === "disable") {
+            $licenseRow.css("display", "none");
+            $dbActionsRow.css("display", "none");
         }
     }
     // Initialize and bind change

--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -337,10 +337,7 @@ jQuery(function () {
         } else if (provider === "dbip") {
             $licenseRow.css("display", "none");
             $dbActionsRow.css("display", "table-row");
-        } else if (provider === "cloudflare") {
-            $licenseRow.css("display", "none");
-            $dbActionsRow.css("display", "none");
-        } else if (provider === "disable") {
+        } else if (provider === "cloudflare" || provider === "disable") {
             $licenseRow.css("display", "none");
             $dbActionsRow.css("display", "none");
         }

--- a/admin/config/index.php
+++ b/admin/config/index.php
@@ -844,7 +844,8 @@ if (!empty($settings) && !empty($_REQUEST['slimstat_update_settings']) && wp_ver
 
 		// Geolocation settings save (provider-based)
 		if (isset($_POST['options']['geolocation_country']) || isset($_POST['options']['geolocation_provider']) || isset($_POST['options']['maxmind_license_key'])) {
-			$prevProvider = wp_slimstat::resolve_geolocation_provider() ?: 'dbip';
+			$resolved_prev = wp_slimstat::resolve_geolocation_provider();
+			$prevProvider  = false !== $resolved_prev ? $resolved_prev : 'disable';
 			$provider     = sanitize_text_field($_POST['options']['geolocation_provider'] ?? $prevProvider);
             $precision    = ('on' === ($_POST['options']['geolocation_country'] ?? (wp_slimstat::$settings['geolocation_country'] ?? 'on'))) ? 'country' : 'city';
             $license      = sanitize_text_field($_POST['options']['maxmind_license_key'] ?? (wp_slimstat::$settings['maxmind_license_key'] ?? ''));

--- a/admin/config/index.php
+++ b/admin/config/index.php
@@ -795,7 +795,7 @@ if (!empty($settings) && !empty($_REQUEST['slimstat_update_settings']) && wp_ver
                 break;
 
             case 'reset-settings':
-                wp_slimstat::update_option('slimstat_options', wp_slimstat::init_options());
+                wp_slimstat::update_option('slimstat_options', wp_slimstat::get_fresh_defaults());
                 wp_slimstat_admin::show_message(__('All settings were successfully reset to their default values.', 'wp-slimstat'));
                 break;
 

--- a/admin/config/index.php
+++ b/admin/config/index.php
@@ -864,7 +864,7 @@ if (!empty($settings) && !empty($_REQUEST['slimstat_update_settings']) && wp_ver
             }
 
             // If provider needs a DB, schedule a background update to avoid timeouts during save
-            if ('cloudflare' !== $provider) {
+            if (!in_array($provider, ['cloudflare', 'disable'], true)) {
                 try {
                     // Pass new settings explicitly since they haven't been saved to wp_slimstat::$settings yet
                     $service = new \SlimStat\Services\Geolocation\GeolocationService($provider, [

--- a/admin/config/index.php
+++ b/admin/config/index.php
@@ -14,6 +14,13 @@ $last_tracker_error = get_option('slimstat_tracker_error', []);
 // Retrieve any geoip errors for display
 $last_geoip_error = get_option('slimstat_geoip_error', []);
 
+// Lazy-migrate: populate geolocation_provider from legacy flag for correct <select> rendering.
+// Persists on next save (line 939 saves entire $settings array).
+if (!isset(wp_slimstat::$settings['geolocation_provider'])) {
+    $resolved = wp_slimstat::resolve_geolocation_provider();
+    wp_slimstat::$settings['geolocation_provider'] = false !== $resolved ? $resolved : 'disable';
+}
+
 // Build General → Tracker rows, conditionally adding Tracking Request Method under Tracking Mode
 $general_rows = [
     // General - Tracker
@@ -282,6 +289,7 @@ $settings = [
 				'title'         => __('Geolocation Provider', 'wp-slimstat'),
 				'type'          => 'select',
 				'select_values' => [
+					'disable'    => __('Disabled', 'wp-slimstat'),
 					'maxmind'    => __('MaxMind GeoLite2 (recommended)', 'wp-slimstat'),
 					'dbip'       => __('DB-IP City Lite (free)', 'wp-slimstat'),
 					'cloudflare' => __('Cloudflare Header', 'wp-slimstat'),
@@ -836,7 +844,7 @@ if (!empty($settings) && !empty($_REQUEST['slimstat_update_settings']) && wp_ver
 
 		// Geolocation settings save (provider-based)
 		if (isset($_POST['options']['geolocation_country']) || isset($_POST['options']['geolocation_provider']) || isset($_POST['options']['maxmind_license_key'])) {
-			$prevProvider = wp_slimstat::$settings['geolocation_provider'] ?? 'maxmind';
+			$prevProvider = wp_slimstat::resolve_geolocation_provider() ?: 'dbip';
 			$provider     = sanitize_text_field($_POST['options']['geolocation_provider'] ?? $prevProvider);
             $precision    = ('on' === ($_POST['options']['geolocation_country'] ?? (wp_slimstat::$settings['geolocation_country'] ?? 'on'))) ? 'country' : 'city';
             $license      = sanitize_text_field($_POST['options']['maxmind_license_key'] ?? (wp_slimstat::$settings['maxmind_license_key'] ?? ''));
@@ -845,6 +853,15 @@ if (!empty($settings) && !empty($_REQUEST['slimstat_update_settings']) && wp_ver
             wp_slimstat::$settings['geolocation_provider'] = $provider;
             wp_slimstat::$settings['geolocation_country']  = 'country' === $precision ? 'on' : 'no';
             wp_slimstat::$settings['maxmind_license_key']  = $license;
+
+            // Sync legacy flag for tracker (Processor.php) and PRO compatibility
+            if ('maxmind' === $provider) {
+                wp_slimstat::$settings['enable_maxmind'] = 'on';
+            } elseif ('dbip' === $provider || 'cloudflare' === $provider) {
+                wp_slimstat::$settings['enable_maxmind'] = 'no';
+            } elseif ('disable' === $provider) {
+                wp_slimstat::$settings['enable_maxmind'] = 'disable';
+            }
 
             // If provider needs a DB, schedule a background update to avoid timeouts during save
             if ('cloudflare' !== $provider) {

--- a/admin/index.php
+++ b/admin/index.php
@@ -310,20 +310,22 @@ class wp_slimstat_admin
                 $this_update = $this_month_update;
             }
 
-		$db_missing = false;
-		try {
-			$provider = $geoip_provider;
-			$uses_db  = in_array($provider, ['maxmind', 'dbip'], true);
-                if ($uses_db) {
-                    $service    = new \SlimStat\Services\Geolocation\GeolocationService($provider, []);
-                    $db_missing = !file_exists($service->getProvider()->getDbPath());
+            $needs_update = $last_update < $this_update;
+            $db_missing = false;
+            if (!$needs_update) {
+                // Time check passed — only check DB existence if time says we're current
+                try {
+                    $uses_db = in_array($geoip_provider, ['maxmind', 'dbip'], true);
+                    if ($uses_db) {
+                        $service    = new \SlimStat\Services\Geolocation\GeolocationService($geoip_provider, []);
+                        $db_missing = !file_exists($service->getProvider()->getDbPath());
+                    }
+                } catch (\Throwable $e) {
+                    $db_missing = true;
                 }
-            } catch (\Throwable $e) {
-                // If any error occurs while checking, consider DB missing to be safe
-                $db_missing = true;
             }
 
-            if ($db_missing || $last_update < $this_update) {
+            if ($needs_update || $db_missing) {
                 // Fire admin-ajax in a non-blocking way to run the existing update handler
                 $ajax_url = admin_url('admin-ajax.php');
                 // Forward only WordPress authentication cookies for security
@@ -2029,10 +2031,12 @@ class wp_slimstat_admin
 			$provider = \wp_slimstat::resolve_geolocation_provider();
 			if (false === $provider) {
 				wp_send_json_error(__('Geolocation is disabled.', 'wp-slimstat'));
+				return;
 			}
             if ('cloudflare' === $provider) {
                 update_option('slimstat_last_geoip_dl', time());
                 wp_send_json_success(__('Cloudflare geolocation does not require a database.', 'wp-slimstat'));
+                return;
             }
 
             // License validation is handled by the MaxMind provider; do not pre-check here
@@ -2073,9 +2077,11 @@ class wp_slimstat_admin
 			$provider = \wp_slimstat::resolve_geolocation_provider();
 			if (false === $provider) {
 				wp_send_json_error(__('Geolocation is disabled.', 'wp-slimstat'));
+				return;
 			}
             if ('cloudflare' === $provider) {
                 wp_send_json_success(__('Cloudflare geolocation is active. No database to check.', 'wp-slimstat'));
+                return;
             }
             $service = new \SlimStat\Services\Geolocation\GeolocationService($provider, []);
             $exists  = file_exists($service->getProvider()->getDbPath());

--- a/admin/index.php
+++ b/admin/index.php
@@ -293,7 +293,9 @@ class wp_slimstat_admin
         // Fallback: if WP-Cron is disabled or scheduling failed, trigger a non-blocking direct update
         // This ensures environments with DISABLE_WP_CRON still receive GeoIP database updates
         $cron_disabled = (defined('DISABLE_WP_CRON') && DISABLE_WP_CRON) || !wp_next_scheduled('wp_slimstat_update_geoip_database');
-        if ($cron_disabled) {
+        $geoip_provider = \wp_slimstat::resolve_geolocation_provider();
+        if ($cron_disabled && false !== $geoip_provider && is_admin() && !wp_doing_ajax()
+            && current_user_can(\wp_slimstat::$settings['capability_can_admin'])) {
             // Update if DB is missing or last update is older than the most recent past scheduled window
             $last_update = (int) get_option('slimstat_last_geoip_dl', 0);
 
@@ -310,7 +312,7 @@ class wp_slimstat_admin
 
 		$db_missing = false;
 		try {
-			$provider = \wp_slimstat::$settings['geolocation_provider'] ?? 'maxmind';
+			$provider = $geoip_provider;
 			$uses_db  = in_array($provider, ['maxmind', 'dbip'], true);
                 if ($uses_db) {
                     $service    = new \SlimStat\Services\Geolocation\GeolocationService($provider, []);
@@ -2024,8 +2026,12 @@ class wp_slimstat_admin
 		}
 
 		try {
-			$provider = \wp_slimstat::$settings['geolocation_provider'] ?? 'maxmind';
+			$provider = \wp_slimstat::resolve_geolocation_provider();
+			if (false === $provider) {
+				wp_send_json_error(__('Geolocation is disabled.', 'wp-slimstat'));
+			}
             if ('cloudflare' === $provider) {
+                update_option('slimstat_last_geoip_dl', time());
                 wp_send_json_success(__('Cloudflare geolocation does not require a database.', 'wp-slimstat'));
             }
 
@@ -2035,6 +2041,7 @@ class wp_slimstat_admin
             $ok      = $service->updateDatabase();
 
 			if ($ok) {
+                update_option('slimstat_last_geoip_dl', time());
                 wp_send_json_success(__('GeoIP Database Successfully Updated!', 'wp-slimstat'));
             } else {
                 // Log the error for debugging
@@ -2063,7 +2070,10 @@ class wp_slimstat_admin
 		}
 
 		try {
-			$provider = \wp_slimstat::$settings['geolocation_provider'] ?? 'maxmind';
+			$provider = \wp_slimstat::resolve_geolocation_provider();
+			if (false === $provider) {
+				wp_send_json_error(__('Geolocation is disabled.', 'wp-slimstat'));
+			}
             if ('cloudflare' === $provider) {
                 wp_send_json_success(__('Cloudflare geolocation is active. No database to check.', 'wp-slimstat'));
             }

--- a/admin/index.php
+++ b/admin/index.php
@@ -315,7 +315,7 @@ class wp_slimstat_admin
             if (!$needs_update) {
                 // Time check passed — only check DB existence if time says we're current
                 try {
-                    $uses_db = in_array($geoip_provider, ['maxmind', 'dbip'], true);
+                    $uses_db = in_array($geoip_provider, \SlimStat\Services\GeoService::DB_PROVIDERS, true);
                     if ($uses_db) {
                         $service    = new \SlimStat\Services\Geolocation\GeolocationService($geoip_provider, []);
                         $db_missing = !file_exists($service->getProvider()->getDbPath());

--- a/admin/view/index.php
+++ b/admin/view/index.php
@@ -96,7 +96,7 @@ if (!empty($saved_filters)) {
         <?php
         // Provider-aware GeoIP notice: show only if a DB-based provider is selected and the database file is missing
         $provider = wp_slimstat::resolve_geolocation_provider();
-        $uses_db  = in_array($provider, ['dbip', 'maxmind'], true);
+        $uses_db  = in_array($provider, \SlimStat\Services\GeoService::DB_PROVIDERS, true);
         if ($uses_db && 'on' == wp_slimstat::$settings['notice_geolite']) {
             try {
                 $service = new \SlimStat\Services\Geolocation\GeolocationService($provider, []);

--- a/admin/view/index.php
+++ b/admin/view/index.php
@@ -95,7 +95,7 @@ if (!empty($saved_filters)) {
 
         <?php
         // Provider-aware GeoIP notice: show only if a DB-based provider is selected and the database file is missing
-        $provider = wp_slimstat::$settings['geolocation_provider'] ?? 'dbip';
+        $provider = wp_slimstat::resolve_geolocation_provider();
         $uses_db  = in_array($provider, ['dbip', 'maxmind'], true);
         if ($uses_db && 'on' == wp_slimstat::$settings['notice_geolite']) {
             try {

--- a/admin/view/wp-slimstat-reports.php
+++ b/admin/view/wp-slimstat-reports.php
@@ -1746,7 +1746,7 @@ class wp_slimstat_reports
                         $settings_url = network_admin_url('admin.php?page=slimconfig&amp;tab=');
                     }
                     // Provider-aware GeoIP notice (world map): only for DB providers when DB file is missing
-                    $provider = wp_slimstat::$settings['geolocation_provider'] ?? 'dbip';
+                    $provider = wp_slimstat::resolve_geolocation_provider();
                     $uses_db  = in_array($provider, ['dbip', 'maxmind'], true);
                     $db_missing = false;
                     if ($uses_db) {

--- a/admin/view/wp-slimstat-reports.php
+++ b/admin/view/wp-slimstat-reports.php
@@ -1747,7 +1747,7 @@ class wp_slimstat_reports
                     }
                     // Provider-aware GeoIP notice (world map): only for DB providers when DB file is missing
                     $provider = wp_slimstat::resolve_geolocation_provider();
-                    $uses_db  = in_array($provider, ['dbip', 'maxmind'], true);
+                    $uses_db  = in_array($provider, \SlimStat\Services\GeoService::DB_PROVIDERS, true);
                     $db_missing = false;
                     if ($uses_db) {
                         try {

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,17 @@
       "~/.composer/vendor/bin/mozart compose",
       "composer dump-autoload"
     ],
-    "test:license-tags": "php tests/license-tag-gating-test.php"
+    "test:license-tags": "php tests/license-tag-gating-test.php",
+    "test:geoip-resolver": "php tests/resolve-geolocation-provider-test.php",
+    "test:geoservice": "php tests/geoservice-provider-resolution-test.php",
+    "test:legacy-sync": "php tests/legacy-sync-mapping-test.php",
+    "test:lazy-migration": "php tests/lazy-migration-test.php",
+    "test": [
+      "@test:license-tags",
+      "@test:geoip-resolver",
+      "@test:geoservice",
+      "@test:legacy-sync",
+      "@test:lazy-migration"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "test:geoservice": "php tests/geoservice-provider-resolution-test.php",
     "test:legacy-sync": "php tests/legacy-sync-mapping-test.php",
     "test:lazy-migration": "php tests/lazy-migration-test.php",
-    "test": [
+    "test:all": [
       "@test:license-tags",
       "@test:geoip-resolver",
       "@test:geoservice",

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,298 @@
+# WP Slimstat Testing Guide
+
+## Overview
+
+WP Slimstat uses three test layers:
+
+| Layer | Tool | What it tests | Run command |
+|-------|------|--------------|-------------|
+| **Unit** | PHP standalone scripts | Logic correctness (resolver, migration, sync) | `composer test:all` |
+| **E2E** | Playwright + TypeScript | Browser-level behavior with real WordPress | `npm run test:e2e` |
+| **Load** | k6 | Performance under sustained/spike traffic | `npm run test:perf` |
+
+A combined orchestration script runs E2E + load tests together:
+
+```bash
+bash tests/run-qa.sh              # full suite
+bash tests/run-qa.sh --e2e-only   # Playwright only
+bash tests/run-qa.sh --perf-only  # k6 only
+```
+
+---
+
+## Prerequisites
+
+### Local Environment
+
+- **Local by Flywheel** running at `http://localhost:10003`
+- PHP 8.x, MySQL accessible via socket
+- WordPress users: `parhumm` (administrator), `dordane` (author) — both with password `testpass123`
+- MySQL socket: found in Local's `conf/mysql/mysqld.sock` (currently `/Users/parhumm/Library/Application Support/Local/run/X-JdmZXIa/mysql/mysqld.sock`)
+
+### Install Dependencies
+
+```bash
+# Node/Playwright (from plugin root)
+npm install -D @playwright/test mysql2
+npx playwright install chromium
+
+# k6 (macOS)
+brew install k6
+```
+
+---
+
+## Layer 1: PHP Unit Tests
+
+Self-contained PHP scripts in `tests/`. Each file defines test cases, stubs WordPress functions, and runs assertions without requiring a running WordPress instance.
+
+### Files
+
+| File | Tests |
+|------|-------|
+| `resolve-geolocation-provider-test.php` | Provider resolution logic (maxmind, dbip, ip2location, disable) |
+| `geoservice-provider-resolution-test.php` | Geolocation service factory and provider instantiation |
+| `legacy-sync-mapping-test.php` | Legacy field mapping during migration |
+| `lazy-migration-test.php` | Lazy migration path validation |
+| `license-tag-gating-test.php` | License tag gating for pro features |
+| `tracking-rest-controller-test.php` | REST API tracking controller |
+
+### Running
+
+```bash
+# All unit tests
+composer test:all
+
+# Individual test
+composer test:geoip-resolver
+php tests/resolve-geolocation-provider-test.php
+```
+
+### Writing New Unit Tests
+
+1. Create `tests/<feature>-test.php`
+2. Stub required WordPress functions at the top of the file (see existing tests for patterns)
+3. Use `assert()` or simple pass/fail output — no PHPUnit dependency required
+4. Add a composer script: `"test:<name>": "php tests/<feature>-test.php"`
+5. Add it to the `test:all` array in `composer.json`
+
+---
+
+## Layer 2: Playwright E2E Tests
+
+Browser-based tests that interact with a live WordPress instance. Uses a **mu-plugin logger** as oracle to observe server-side behavior that isn't visible in the browser.
+
+### Architecture
+
+```
+tests/e2e/
+├── playwright.config.ts          # Config: baseURL, auth projects, timeouts
+├── global-setup.ts               # Authenticates admin + author, caches auth state
+├── geoip-ajax-loop.spec.ts       # Test suite (6 test cases)
+├── helpers/
+│   ├── setup.ts                  # wp-config toggler, mu-plugin manager, DB helper
+│   └── ajax-logger-mu-plugin.php # PHP mu-plugin that logs AJAX handler calls
+└── .auth/                        # Cached browser auth state (gitignored)
+```
+
+### Key Concept: Server-Side AJAX Observation
+
+SlimStat's GeoIP fallback uses `wp_safe_remote_post()` — a PHP-to-PHP call, **not** browser XHR. Playwright cannot intercept it via the network tab. The solution:
+
+1. A **mu-plugin** (`ajax-logger-mu-plugin.php`) hooks `wp_ajax_slimstat_update_geoip_database` at priority 1
+2. Each invocation is logged as a JSON line to `wp-content/geoip-ajax-calls.log`
+3. Tests read this file to count actual server-side AJAX handler invocations
+4. `setupTest()` installs the mu-plugin and clears the log before each test
+5. `teardownTest()` removes the mu-plugin and restores wp-config
+
+### Auth & Projects
+
+Global setup (`global-setup.ts`) logs in as both users and saves browser storage state to `.auth/admin.json` and `.auth/author.json`. Auth files are cached for 30 minutes — delete `.auth/` to force re-login.
+
+The Playwright config defines an `admin` project (default) and the spec file uses `test.use({ storageState })` to switch to author context within a describe block.
+
+### Shared Helpers (`helpers/setup.ts`)
+
+| Function | Purpose |
+|----------|---------|
+| `setupTest()` | Enables DISABLE_WP_CRON, installs mu-plugin, clears AJAX log, clears geoip timestamp |
+| `teardownTest()` | Restores wp-config, removes mu-plugin, clears log, restores provider setting |
+| `enableDisableWpCron()` | Adds `define('DISABLE_WP_CRON', true)` to wp-config.php |
+| `restoreWpConfig()` | Restores the original wp-config.php from backup |
+| `installMuPlugin()` / `uninstallMuPlugin()` | Copies/removes the AJAX logger mu-plugin |
+| `readAjaxLog()` | Returns parsed JSON entries from the AJAX log |
+| `clearAjaxLog()` | Deletes the AJAX log file |
+| `clearGeoipTimestamp()` | DELETEs `slimstat_last_geoip_dl` from `wp_options` |
+| `getGeoipTimestamp()` | SELECTs current timestamp value |
+| `setSlimstatSetting(key, value)` | Modifies a key in the serialized `slimstat_options` |
+| `setProviderDisabled()` | Sets `geolocation_provider` to `disable` (saves original for restore) |
+| `closeDb()` | Closes the MySQL connection pool |
+
+### Running
+
+```bash
+npm run test:e2e
+
+# Or with Playwright CLI options
+npx playwright test --config=tests/e2e/playwright.config.ts
+npx playwright test --config=tests/e2e/playwright.config.ts -g "Test 3"  # single test
+npx playwright show-report tests/e2e/playwright-report                    # HTML report
+```
+
+### Debugging Failures
+
+1. **Trace files**: On failure, Playwright saves traces to `test-results/`. View with:
+   ```bash
+   npx playwright show-trace test-results/<folder>/trace.zip
+   ```
+
+2. **Screenshots**: Captured on failure in `test-results/`.
+
+3. **AJAX log**: Check `wp-content/geoip-ajax-calls.log` for raw invocation data.
+
+4. **Timeout issues**: Tests 2, 3, and 6 have extended timeouts (60–120s). If the local server is slow, increase `test.setTimeout()` in the spec or `timeout` in the config.
+
+5. **Auth stale**: Delete `tests/e2e/.auth/` and re-run to force fresh login.
+
+6. **MySQL socket changed**: If Local by Flywheel regenerates the socket path, update `MYSQL_SOCKET` in `helpers/setup.ts` and `run-qa.sh`.
+
+### Writing New E2E Tests
+
+1. Add test cases to an existing `.spec.ts` or create a new `tests/e2e/<feature>.spec.ts`
+2. Use `setupTest()` / `teardownTest()` in beforeEach/afterEach for consistent state
+3. For tests that need to observe server-side behavior, follow the mu-plugin logger pattern:
+   - Create a PHP mu-plugin that hooks the relevant action at priority 1
+   - Log to a file in `wp-content/`
+   - Read the file in your test assertions
+4. Tests sharing wp-config or DB state must run sequentially (`workers: 1`, `fullyParallel: false`)
+5. Add appropriate `test.setTimeout()` for tests involving multiple page loads
+
+### Important Gotchas
+
+- **Global regex `lastIndex`**: When using a global regex with `.test()` then `.replace()`, reset `lastIndex = 0` between calls. The `.test()` method advances `lastIndex`, causing `.replace()` to miss the match.
+- **Cross-test race conditions**: Server-side `wp_safe_remote_post` is async. A previous test's AJAX call may complete during the next test. Avoid asserting on DB state set by async operations in other tests.
+- **DISABLE_WP_CRON and login**: WordPress login can be slow when DISABLE_WP_CRON is active. The global setup caches auth to avoid repeated logins.
+
+---
+
+## Layer 3: k6 Load Tests
+
+Simulates high-volume admin traffic to verify fixes hold under sustained and spike loads.
+
+### File: `tests/perf/geoip-load.js`
+
+### Scenarios
+
+| Scenario | Pattern | Duration |
+|----------|---------|----------|
+| `steady_state` | 20 RPS constant | 2 minutes |
+| `spike` | 5 → 50 → 5 RPS ramp | 1 minute (starts at 2m30s) |
+
+### Thresholds
+
+| Metric | Threshold |
+|--------|-----------|
+| `http_req_failed` | < 5% error rate |
+| `http_req_duration` p95 | < 5 seconds |
+| `admin_page_duration` p99 | < 8 seconds |
+
+### Pre-Requisites for k6
+
+k6 doesn't share Playwright's test helpers. The environment must be pre-configured:
+
+1. `DISABLE_WP_CRON` added to wp-config.php
+2. mu-plugin logger installed to `wp-content/mu-plugins/`
+3. `slimstat_last_geoip_dl` option deleted from DB
+
+The `run-qa.sh` script handles this automatically in Phase 3 (before k6, after Playwright).
+
+### Running
+
+```bash
+# Via orchestrator (handles setup)
+bash tests/run-qa.sh --perf-only
+
+# Standalone (requires manual setup)
+k6 run tests/perf/geoip-load.js
+
+# With custom parameters
+k6 run tests/perf/geoip-load.js -e BASE_URL=http://localhost:10003 -e WP_USER=parhumm -e WP_PASS=testpass123
+```
+
+### Writing New k6 Tests
+
+1. Create `tests/perf/<scenario>.js`
+2. Use `setup()` to authenticate via `wp-login.php` POST
+3. Define scenarios and thresholds in `options`
+4. Use `teardown()` to read/report oracle log files
+5. Add a composer or npm script, and include in `run-qa.sh` if needed
+
+---
+
+## Orchestration: `tests/run-qa.sh`
+
+Runs the full QA pipeline with proper setup and cleanup:
+
+| Phase | What it does |
+|-------|-------------|
+| 0 | Verify site is running (HTTP check) |
+| 1 | Backup wp-config.php |
+| 2 | Run Playwright E2E (tests manage their own setup/teardown) |
+| 3 | Configure environment for k6 (DISABLE_WP_CRON, mu-plugin, clear DB) |
+| 4 | Run k6 load test |
+| 5 | Post-test DB verification (check timestamp and AJAX count) |
+| 6 | Summary and exit code |
+
+Cleanup trap restores wp-config, removes mu-plugin, and clears AJAX log on exit.
+
+---
+
+## Adding Tests for a New Feature
+
+### Decision: Which layer?
+
+| If you need to test... | Use |
+|----------------------|-----|
+| Pure logic (no WordPress runtime needed) | PHP unit test |
+| Browser behavior, admin UI, user roles | Playwright E2E |
+| Performance under load, race conditions at scale | k6 load test |
+| Server-side behavior invisible to browser | Playwright E2E + mu-plugin oracle |
+
+### Checklist for new test files
+
+- [ ] Test file created in appropriate directory
+- [ ] Run command added to `composer.json` or `package.json`
+- [ ] `test:all` array updated (PHP) or orchestration script updated (E2E/perf)
+- [ ] Test passes locally
+- [ ] Any new helpers documented in this guide
+- [ ] Cleanup/teardown handles all state changes (wp-config, DB, files)
+
+---
+
+## File Reference
+
+```
+wp-slimstat/
+├── composer.json                          # PHP test scripts (test:all, test:*)
+├── package.json                           # Node test scripts (test:e2e, test:perf, test:qa)
+├── tests/
+│   ├── resolve-geolocation-provider-test.php
+│   ├── geoservice-provider-resolution-test.php
+│   ├── legacy-sync-mapping-test.php
+│   ├── lazy-migration-test.php
+│   ├── license-tag-gating-test.php
+│   ├── tracking-rest-controller-test.php
+│   ├── run-qa.sh                          # Full QA orchestrator
+│   ├── e2e/
+│   │   ├── playwright.config.ts
+│   │   ├── global-setup.ts
+│   │   ├── geoip-ajax-loop.spec.ts        # GeoIP AJAX loop E2E tests
+│   │   ├── helpers/
+│   │   │   ├── setup.ts                   # Shared test utilities
+│   │   │   └── ajax-logger-mu-plugin.php  # Server-side AJAX observer
+│   │   └── .auth/                         # Cached auth state (gitignored)
+│   └── perf/
+│       └── geoip-load.js                  # k6 load test
+└── docs/
+    └── TESTING.md                         # This file
+```

--- a/package.json
+++ b/package.json
@@ -3,14 +3,19 @@
   "scripts": {
     "watch": "watch \"npm run sass-compile\" ./admin/assets/scss",
     "sass-compile": "concurrently \"node-sass admin/assets/scss/admin.scss admin/assets/css/admin.css --output-style compressed\"",
-    "build": "esbuild wp-slimstat.js --bundle --minify --sourcemap --outfile=wp-slimstat.min.js"
+    "build": "esbuild wp-slimstat.js --bundle --minify --sourcemap --outfile=wp-slimstat.min.js",
+    "test:e2e": "npx playwright test --config=tests/e2e/playwright.config.ts",
+    "test:perf": "k6 run tests/perf/geoip-load.js",
+    "test:qa": "bash tests/run-qa.sh"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/runtime-corejs2": "^7.0.0",
+    "@playwright/test": "^1.58.2",
     "breakpoint-sass": "^2.7.1",
     "concurrently": "^8.2.0",
     "esbuild": "^0.25.8",
+    "mysql2": "^3.19.1",
     "node-sass": "^9.0.0",
     "terser": "^5.27.0",
     "watch": "^0.13.0"

--- a/readme.txt
+++ b/readme.txt
@@ -16,22 +16,24 @@ Track returning customers and registered users, monitor Javascript events, detec
 
 = Main Features =
 * **Real-Time Access Log**: measure server latency, track page events, keep an eye on your bounce rate and much more.
+* **Admin Bar Stats**: view real-time site stats directly from the WordPress admin bar — online visitors, pageviews, and top pages at a glance.
 * **Shortcodes**: display reports in widgets or directly in posts and pages.
 * **Customize Reports**: Customize all pages—Real-time, Overview, Audience, Site Analysis, and Traffic Sources—to fit your needs easily!
-* **GDPR**: fully compliant with GDPR European law. Integrates seamlessly with popular Consent Management Platforms (WP Consent API, Real Cookie Banner).
+* **GDPR**: fully compliant with GDPR European law. Integrates seamlessly with WP Consent API. Consent banner translatable with WPML and Polylang.
 * **Filters**: exclude users from statistics collection based on various criteria, including user roles, common robots, IP subnets, admin pages, country, etc.
 * **Export to Excel**: download your reports as CSV files, generate user heatmaps or get daily emails right in your mailbox (via Pro).
 * **Cache**: compatible with W3 Total Cache, WP SuperCache, CloudFlare and most caching plugins.
 * **Privacy**: hash IP addresses to protect your users' privacy.
 * **Geolocation**: identify your visitors by city and country, browser type and operating system (courtesy of [MaxMind](https://www.maxmind.com/) and [Browscap](https://browscap.org)).
-* **World Map**: see where your visitors are coming from, even on your mobile device (courtesy of [amMap](https://www.ammap.com/)).
+* **World Map**: see where your visitors are coming from, even on your mobile device (courtesy of [JQVMap](https://github.com/10bestdesign/jqvmap)).
 
 = Pro Pack Features =
 * **Network Analytics**: Enable a network-wide view of your reports and settings.
-* **Email Reports**: Receive your reports directly in your mailbox.
+* **Email Reports**: Receive your reports directly in your mailbox with customizable column mappings and HTML tables.
 * **Export to Excel**: Download your reports as CSV files.
 * **Heatmap**: Display a heatmap layer of the most clicked areas on your website.
 * **User Overview**: Monitor your registered users by tracking their activities and time on site.
+* **User Avatars**: Gravatar integration in the User Overview report for quick visitor identification.
 * **MaxMind Integration**: Connect to MaxMind's Geolocation API to retrieve detailed information about your visitors.
 * **Custom DB**: Use an external database to store all the information about your visitors.
 * **Extended Overview**: Add custom columns to the User Overview widget and export file.

--- a/src/Services/GeoService.php
+++ b/src/Services/GeoService.php
@@ -75,7 +75,7 @@ class GeoService
 
     public function isJsDelivrEnabled()
     {
-        return 'no' == $this->enableMaxmind;
+        return 'dbip' === \wp_slimstat::resolve_geolocation_provider();
     }
 
     public function getUserIP()

--- a/src/Services/GeoService.php
+++ b/src/Services/GeoService.php
@@ -64,12 +64,13 @@ class GeoService
 
     public function isGeoIPEnabled()
     {
-        return 'disable' != $this->enableMaxmind;
+        $provider = \wp_slimstat::resolve_geolocation_provider();
+        return false !== $provider && 'cloudflare' !== $provider;
     }
 
     public function isMaxMindEnabled()
     {
-        return 'on' == $this->enableMaxmind;
+        return 'maxmind' === \wp_slimstat::resolve_geolocation_provider();
     }
 
     public function isJsDelivrEnabled()
@@ -100,7 +101,10 @@ class GeoService
 	public function download()
 	{
 		try {
-			$provider = \wp_slimstat::$settings['geolocation_provider'] ?? 'maxmind';
+			$provider = \wp_slimstat::resolve_geolocation_provider();
+			if (false === $provider) {
+				return ['status' => false, 'error' => __('Geolocation is disabled.', 'wp-slimstat')];
+			}
 			if (in_array($provider, ['maxmind', 'dbip'], true)) {
                 // GeolocationService reads settings automatically
                 $service = new \SlimStat\Services\Geolocation\GeolocationService($provider, []);
@@ -123,7 +127,10 @@ class GeoService
 	public function checkDatabase()
 	{
 		try {
-			$provider = \wp_slimstat::$settings['geolocation_provider'] ?? 'maxmind';
+			$provider = \wp_slimstat::resolve_geolocation_provider();
+			if (false === $provider) {
+				return ['status' => false, 'notice' => __('Geolocation is disabled.', 'wp-slimstat')];
+			}
             // GeolocationService reads settings automatically
             $service = new \SlimStat\Services\Geolocation\GeolocationService($provider, []);
             $dbPath  = $service->getProvider()->getDbPath();
@@ -165,7 +172,10 @@ class GeoService
 
 	public function deleteDatabaseFile()
 	{
-		$provider = \wp_slimstat::$settings['geolocation_provider'] ?? 'maxmind';
+		$provider = \wp_slimstat::resolve_geolocation_provider();
+		if (false === $provider) {
+			return;
+		}
         // GeolocationService reads settings automatically
         $service = new \SlimStat\Services\Geolocation\GeolocationService($provider, []);
         $dbPath  = $service->getProvider()->getDbPath();

--- a/src/Services/GeoService.php
+++ b/src/Services/GeoService.php
@@ -6,6 +6,9 @@ use SlimStat\Dependencies\GeoIp2\Database\Reader;
 
 class GeoService
 {
+    /** Providers that require a local GeoIP database file */
+    const DB_PROVIDERS = ['maxmind', 'dbip'];
+
     private $update = false;
 
     private $pack = '';
@@ -37,7 +40,7 @@ class GeoService
         if (!empty($this->pack)) {
             return $this->pack;
         }
-        return ('on' == \wp_slimstat::$settings['geolocation_country']) ? 'country' : 'city';
+        return \wp_slimstat::get_geolocation_precision();
     }
 
     public function setEnableMaxmind($enableMaxmind = false)
@@ -65,7 +68,7 @@ class GeoService
     public function isGeoIPEnabled()
     {
         $provider = \wp_slimstat::resolve_geolocation_provider();
-        return false !== $provider && 'cloudflare' !== $provider;
+        return false !== $provider;
     }
 
     public function isMaxMindEnabled()
@@ -105,7 +108,7 @@ class GeoService
 			if (false === $provider) {
 				return ['status' => false, 'error' => __('Geolocation is disabled.', 'wp-slimstat')];
 			}
-			if (in_array($provider, ['maxmind', 'dbip'], true)) {
+			if (in_array($provider, self::DB_PROVIDERS, true)) {
                 // GeolocationService reads settings automatically
                 $service = new \SlimStat\Services\Geolocation\GeolocationService($provider, []);
                 $ok      = $service->updateDatabase();
@@ -114,7 +117,7 @@ class GeoService
                     'notice' => $ok ? __('GeoIP Database Successfully Updated!', 'wp-slimstat') : __('Failed to update GeoIP Database.', 'wp-slimstat'),
                 ];
             }
-            return [ 'status' => false, 'error' => __('GeoIP is disabled. Please choose a DB-based provider and save settings.', 'wp-slimstat') ];
+            return [ 'status' => true, 'notice' => __('This provider does not use a local database.', 'wp-slimstat') ];
         } catch (\Exception $exception) {
             $this->logError($exception->getMessage());
             return [ 'status' => false, 'error' => $exception->getMessage() ];
@@ -130,6 +133,9 @@ class GeoService
 			$provider = \wp_slimstat::resolve_geolocation_provider();
 			if (false === $provider) {
 				return ['status' => false, 'notice' => __('Geolocation is disabled.', 'wp-slimstat')];
+			}
+			if (!in_array($provider, self::DB_PROVIDERS, true)) {
+				return ['status' => true, 'notice' => __('This provider does not use a local database.', 'wp-slimstat')];
 			}
             // GeolocationService reads settings automatically
             $service = new \SlimStat\Services\Geolocation\GeolocationService($provider, []);
@@ -174,6 +180,9 @@ class GeoService
 	{
 		$provider = \wp_slimstat::resolve_geolocation_provider();
 		if (false === $provider) {
+			return;
+		}
+		if (!in_array($provider, self::DB_PROVIDERS, true)) {
 			return;
 		}
         // GeolocationService reads settings automatically

--- a/src/Services/Geolocation/Provider/CloudflareGeolocationProvider.php
+++ b/src/Services/Geolocation/Provider/CloudflareGeolocationProvider.php
@@ -80,7 +80,7 @@ class CloudflareGeolocationProvider implements GeoServiceProviderInterface
 
         // Only include city-level data when precision is set to 'city'
         if ('city' === $precision) {
-            $result['region']       = $region;
+            $result['subdivision']  = $region;
             $result['city']         = $city;
             $result['latitude']     = $latitude;
             $result['longitude']    = $longitude;

--- a/src/Tracker/Processor.php
+++ b/src/Tracker/Processor.php
@@ -5,7 +5,6 @@ namespace SlimStat\Tracker;
 use SlimStat\Utils\Query;
 use SlimStat\Services\Browscap;
 use SlimStat\Services\Privacy;
-use SlimStat\Services\GeoService;
 use SlimStat\Services\Geolocation\GeolocationService;
 use SlimStat\Providers\IPHashProvider;
 use SlimStat\Utils\Consent;
@@ -235,11 +234,10 @@ class Processor
         }
 
         // GeoIP lookup requires PII consent (GeoIP data is PII)
-        $geographicProvider = new GeoService();
-        if ($geographicProvider->isGeoIPEnabled() && Consent::piiAllowed()) {
+        $provider = \wp_slimstat::resolve_geolocation_provider();
+        if (false !== $provider && Consent::piiAllowed()) {
             try {
-                $provider = $geographicProvider->isMaxMindEnabled() ? 'maxmind' : 'dbip';
-                $precision = $geographicProvider->getPack();
+                $precision = \wp_slimstat::get_geolocation_precision();
                 $geoService = new GeolocationService($provider, ['precision' => $precision]);
                 $geolocation_data = $geoService->locate($originalIpForGeo);
             } catch (\Exception $e) {
@@ -503,11 +501,10 @@ class Processor
                         // Perform GeoIP lookup if enabled and PII allowed
                         // Only do GeoIP lookup if we're updating IP (not keeping hash)
                         if (!$hashIpEnabled && !empty($update_data['ip'])) {
-                            $geographicProvider = new GeoService();
-                            if ($geographicProvider->isGeoIPEnabled()) {
+                            $provider = \wp_slimstat::resolve_geolocation_provider();
+                            if (false !== $provider) {
                                 try {
-                                    $provider = $geographicProvider->isMaxMindEnabled() ? 'maxmind' : 'dbip';
-                                    $precision = $geographicProvider->getPack();
+                                    $precision = \wp_slimstat::get_geolocation_precision();
                                     $geoService = new GeolocationService($provider, ['precision' => $precision]);
                                     $geolocation_data = $geoService->locate($realIp);
                                     if (!empty($geolocation_data) && !empty($geolocation_data['country_code']) && 'xx' != $geolocation_data['country_code']) {

--- a/tests/e2e/geoip-ajax-loop.spec.ts
+++ b/tests/e2e/geoip-ajax-loop.spec.ts
@@ -140,27 +140,6 @@ test.describe('GeoIP AJAX loop prevention (admin)', () => {
     await page.waitForTimeout(1000);
     clearAjaxLog(); // Clear any AJAX from the page load itself
 
-    // Extract nonce from the page — SlimStat injects it
-    // We'll generate one by hitting a page that outputs wpnonce
-    const nonce = await page.evaluate(async () => {
-      // Fetch a fresh nonce via admin-ajax approach
-      const res = await fetch('/wp-admin/admin-ajax.php', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: 'action=slimstat_update_geoip_database&security=invalid_nonce',
-      });
-      return null; // We'll use a different approach
-    });
-
-    // Direct POST using Playwright's request context (carries auth cookies)
-    // The nonce check will fail with invalid nonce, but the handler IS invoked
-    // (check_ajax_referer dies on failure, so the mu-plugin at priority 1
-    // runs BEFORE the die). Actually, check_ajax_referer calls wp_die on failure.
-    // The mu-plugin runs at priority 1, before SlimStat's handler.
-    // But wp_ajax_ fires both — the action fires, then SlimStat's callback runs.
-
-    // Actually, for a valid test we need a real nonce.
-    // Let's get it by parsing a page that contains it.
     await clearGeoipTimestamp();
     clearAjaxLog();
 

--- a/tests/e2e/geoip-ajax-loop.spec.ts
+++ b/tests/e2e/geoip-ajax-loop.spec.ts
@@ -134,6 +134,7 @@ test.describe('GeoIP AJAX loop prevention (admin)', () => {
   });
 
   test('Test 6: direct AJAX POST — no self-recursion', async ({ page }) => {
+    test.setTimeout(60_000);
     // First, visit an admin page to get a valid nonce
     await page.goto('/wp-admin/');
     await page.waitForTimeout(1000);
@@ -209,9 +210,8 @@ test.describe('GeoIP AJAX loop prevention (author)', () => {
 
     const log = readAjaxLog();
     expect(log.length).toBe(0);
-
-    // current_user_can() check blocks the fallback for non-admin users
-    const ts = await getGeoipTimestamp();
-    expect(ts).toBeNull();
+    // The AJAX log being empty proves the author didn't trigger the fallback.
+    // We don't check slimstat_last_geoip_dl here because a prior admin test's
+    // async wp_safe_remote_post may set it after this test's clearGeoipTimestamp().
   });
 });

--- a/tests/e2e/geoip-ajax-loop.spec.ts
+++ b/tests/e2e/geoip-ajax-loop.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * E2E tests: GeoIP AJAX infinite loop prevention (PR #166)
+ *
+ * Verifies that the fallback GeoIP update mechanism fires at most once
+ * when DISABLE_WP_CRON is true, instead of infinite self-replicating AJAX.
+ *
+ * Oracle: mu-plugin logger writes to wp-content/geoip-ajax-calls.log
+ * each time the wp_ajax_slimstat_update_geoip_database handler is invoked.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  setupTest,
+  teardownTest,
+  readAjaxLog,
+  clearAjaxLog,
+  getGeoipTimestamp,
+  clearGeoipTimestamp,
+  setProviderDisabled,
+  closeDb,
+  enableDisableWpCron,
+  restoreWpConfig,
+  installMuPlugin,
+  uninstallMuPlugin,
+} from './helpers/setup';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// All tests run sequentially (workers: 1) because they share wp-config.php and DB state.
+
+test.describe('GeoIP AJAX loop prevention (admin)', () => {
+  test.beforeEach(async () => {
+    await setupTest();
+  });
+
+  test.afterEach(async () => {
+    await teardownTest();
+  });
+
+  test.afterAll(async () => {
+    await closeDb();
+  });
+
+  test('Test 1: single admin page load triggers at most 1 AJAX call', async ({ page }) => {
+    await page.goto('/wp-admin/');
+    // Wait for the non-blocking wp_safe_remote_post to complete
+    await page.waitForTimeout(4000);
+
+    const log = readAjaxLog();
+    // The key assertion: at most 1 AJAX call, not a cascade
+    expect(log.length).toBeLessThanOrEqual(1);
+    // Note: slimstat_last_geoip_dl may NOT be set if the download fails
+    // (no GeoIP license key configured). That's OK — we're testing the
+    // loop prevention, not the download success.
+  });
+
+  test('Test 2: 5 successive admin loads — no multiplication', async ({ page }) => {
+    test.setTimeout(90_000);
+    const pages = [
+      '/wp-admin/',
+      '/wp-admin/plugins.php',
+      '/wp-admin/options-general.php',
+      '/wp-admin/edit.php',
+      '/wp-admin/upload.php',
+    ];
+
+    for (const url of pages) {
+      await page.goto(url);
+      // Brief wait between navigations — simulates fast admin browsing
+      await page.waitForTimeout(1000);
+    }
+
+    // Final wait for any async requests to settle
+    await page.waitForTimeout(3000);
+
+    const log = readAjaxLog();
+    // First load may trigger 1 AJAX call.
+    // Subsequent loads should see slimstat_last_geoip_dl already set.
+    // Under the old bug, this would be 5+ (each load triggers its own AJAX).
+    expect(log.length).toBeLessThanOrEqual(1);
+  });
+
+  test('Test 3: 3 concurrent tabs — bounded count (not exponential)', async ({ context }) => {
+    test.setTimeout(120_000);
+    // Open 3 pages simultaneously (reduced from 5 for local dev server stability)
+    const urls = [
+      '/wp-admin/',
+      '/wp-admin/plugins.php',
+      '/wp-admin/edit.php',
+    ];
+
+    const pagePromises = urls.map(async (url) => {
+      const p = await context.newPage();
+      await p.goto(url, { waitUntil: 'domcontentloaded' });
+      return p;
+    });
+
+    const openPages = await Promise.all(pagePromises);
+
+    // Wait for all async wp_safe_remote_post calls to complete
+    await openPages[0].waitForTimeout(5000);
+
+    const log = readAjaxLog();
+
+    // Race condition: all 3 PHP processes may check before any AJAX completes.
+    // Each fires one AJAX → up to 3. But NOT 9, 27, etc. (infinite loop).
+    // The key assertion: count is bounded by the number of concurrent loads.
+    expect(log.length).toBeLessThanOrEqual(3);
+
+    // Under the old bug, a second generation would fire, producing 3 more,
+    // then 3 more, etc. With a 5-second wait, we'd see 9-15+ entries.
+    // The fix ensures each AJAX request does NOT re-trigger itself.
+
+    // Close extra pages
+    for (const p of openPages) {
+      await p.close();
+    }
+  });
+
+  test('Test 5: provider disabled — 0 AJAX calls', async ({ page }) => {
+    await setProviderDisabled();
+
+    await page.goto('/wp-admin/');
+    await page.waitForTimeout(3000);
+
+    const log = readAjaxLog();
+    expect(log.length).toBe(0);
+
+    // resolve_geolocation_provider() returns false → guard condition fails
+    const ts = await getGeoipTimestamp();
+    expect(ts).toBeNull();
+  });
+
+  test('Test 6: direct AJAX POST — no self-recursion', async ({ page }) => {
+    // First, visit an admin page to get a valid nonce
+    await page.goto('/wp-admin/');
+    await page.waitForTimeout(1000);
+    clearAjaxLog(); // Clear any AJAX from the page load itself
+
+    // Extract nonce from the page — SlimStat injects it
+    // We'll generate one by hitting a page that outputs wpnonce
+    const nonce = await page.evaluate(async () => {
+      // Fetch a fresh nonce via admin-ajax approach
+      const res = await fetch('/wp-admin/admin-ajax.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'action=slimstat_update_geoip_database&security=invalid_nonce',
+      });
+      return null; // We'll use a different approach
+    });
+
+    // Direct POST using Playwright's request context (carries auth cookies)
+    // The nonce check will fail with invalid nonce, but the handler IS invoked
+    // (check_ajax_referer dies on failure, so the mu-plugin at priority 1
+    // runs BEFORE the die). Actually, check_ajax_referer calls wp_die on failure.
+    // The mu-plugin runs at priority 1, before SlimStat's handler.
+    // But wp_ajax_ fires both — the action fires, then SlimStat's callback runs.
+
+    // Actually, for a valid test we need a real nonce.
+    // Let's get it by parsing a page that contains it.
+    await clearGeoipTimestamp();
+    clearAjaxLog();
+
+    // Navigate to an admin page where SlimStat might inject the nonce
+    await page.goto('/wp-admin/admin.php?page=slimstat');
+    await page.waitForTimeout(1000);
+    clearAjaxLog(); // Clear page-load AJAX
+
+    // Use page.request (inherits browser cookies) to POST directly
+    const response = await page.request.post('/wp-admin/admin-ajax.php', {
+      form: {
+        action: 'slimstat_update_geoip_database',
+        security: 'test_invalid', // Will fail nonce, but tests the path
+      },
+    });
+
+    await page.waitForTimeout(2000);
+
+    const log = readAjaxLog();
+    // The mu-plugin fires at priority 1 (before nonce check at priority 10)
+    // so we should see exactly 1 entry even if the nonce fails
+    expect(log.length).toBe(1);
+    // The important thing: it's 1, not 2+. No self-recursion.
+  });
+});
+
+// ─── Separate test for non-admin user (uses 'author' project) ──────
+
+test.describe('GeoIP AJAX loop prevention (author)', () => {
+  test.use({ storageState: path.join(__dirname, '.auth/author.json') });
+
+  test.beforeEach(async () => {
+    await setupTest();
+  });
+
+  test.afterEach(async () => {
+    await teardownTest();
+  });
+
+  test.afterAll(async () => {
+    await closeDb();
+  });
+
+  test('Test 4: author (non-admin) gets 0 AJAX calls', async ({ page }) => {
+    await page.goto('/wp-admin/');
+    await page.waitForTimeout(3000);
+
+    const log = readAjaxLog();
+    expect(log.length).toBe(0);
+
+    // current_user_can() check blocks the fallback for non-admin users
+    const ts = await getGeoipTimestamp();
+    expect(ts).toBeNull();
+  });
+});

--- a/tests/e2e/geolocation-provider.spec.ts
+++ b/tests/e2e/geolocation-provider.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * E2E tests: Geolocation provider pipeline verification.
+ *
+ * Validates that all provider types (DB-IP, Cloudflare, MaxMind, Disabled)
+ * work end-to-end through the Processor tracking pipeline.
+ * Also covers fresh install defaults and legacy upgrade backward compatibility.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  installOptionMutator,
+  uninstallOptionMutator,
+  setSlimstatOption,
+  deleteSlimstatOption,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+  clearStatsTable,
+  getLatestStat,
+  simulateFreshInstall,
+  simulateLegacyUpgrade,
+  closeDb,
+} from './helpers/setup';
+
+test.describe('Geolocation Provider Pipeline', () => {
+  test.beforeAll(async () => {
+    installOptionMutator();
+  });
+
+  test.beforeEach(async () => {
+    await snapshotSlimstatOptions();
+    await clearStatsTable();
+  });
+
+  test.afterEach(async () => {
+    await restoreSlimstatOptions();
+  });
+
+  test.afterAll(async () => {
+    uninstallOptionMutator();
+    await closeDb();
+  });
+
+  // ─── Test 1: Fresh install defaults to DB-IP ────────────────────
+
+  test('fresh install sets geolocation_provider to dbip', async ({ page }) => {
+    await simulateFreshInstall();
+
+    // Visit admin to trigger wp_slimstat::init() fresh-install branch
+    await page.goto('/wp-admin/');
+    await page.waitForURL('**/wp-admin/**');
+
+    // The page loaded without error — init() recreated the options
+    await expect(page).toHaveTitle(/Dashboard/);
+
+    // Verify the settings page shows DB-IP as selected provider
+    await page.goto('/wp-admin/admin.php?page=slimconfig&tab=5');
+    const providerSelect = page.locator('select[name="geolocation_provider"]');
+    if (await providerSelect.count() > 0) {
+      await expect(providerSelect).toHaveValue('dbip');
+    }
+  });
+
+  // ─── Test 2: Legacy upgrade — enable_maxmind='on' → maxmind ────
+
+  test('legacy upgrade with enable_maxmind=on resolves to maxmind', async ({ page }) => {
+    await simulateLegacyUpgrade(page, 'on');
+
+    // Visit a frontend page — should not crash even without MaxMind DB
+    const response = await page.goto('/?legacy-maxmind-test');
+    expect(response?.status()).toBeLessThan(500);
+
+    // Admin page also loads fine
+    await page.goto('/wp-admin/');
+    await expect(page).toHaveTitle(/Dashboard/);
+  });
+
+  // ─── Test 3: Legacy upgrade — enable_maxmind='no' → dbip ───────
+
+  test('legacy upgrade with enable_maxmind=no resolves to dbip', async ({ page }) => {
+    await simulateLegacyUpgrade(page, 'no');
+
+    const marker = `legacy-dbip-${Date.now()}`;
+    await page.goto(`/?p=${marker}`);
+    await page.waitForTimeout(3000);
+
+    // DB-IP with a local IP may not resolve country (private IP ranges)
+    // The key assertion: no crash, tracking ran without error
+    const adminResponse = await page.goto('/wp-admin/');
+    expect(adminResponse?.status()).toBeLessThan(500);
+  });
+
+  // ─── Test 4: Legacy upgrade — enable_maxmind='disable' → off ───
+
+  test('legacy upgrade with enable_maxmind=disable skips geolocation', async ({ page }) => {
+    await simulateLegacyUpgrade(page, 'disable');
+
+    const marker = `legacy-disable-${Date.now()}`;
+    await page.goto(`/?p=${marker}`);
+    await page.waitForTimeout(3000);
+
+    const stat = await getLatestStat(marker);
+    if (stat) {
+      expect(!stat.country || stat.country === '').toBeTruthy();
+    }
+  });
+
+  // ─── Test 5: DB-IP tracks country correctly ────────────────────
+
+  test('DB-IP provider tracks without crashing', async ({ page }) => {
+    await setSlimstatOption(page, 'geolocation_provider', 'dbip');
+
+    const marker = `dbip-e2e-${Date.now()}`;
+    await page.goto(`/?p=${marker}`);
+    await page.waitForTimeout(3000);
+
+    // DB-IP with a local IP may not resolve country (private IP ranges)
+    // but the pipeline should not crash
+    const response = await page.goto('/wp-admin/');
+    expect(response?.status()).toBeLessThan(500);
+  });
+
+  // ─── Test 6: Cloudflare tracks city+subdivision with CF headers ─
+
+  test('Cloudflare provider tracks city+subdivision with CF headers', async ({ page, context }) => {
+    await setSlimstatOption(page, 'geolocation_provider', 'cloudflare');
+    await setSlimstatOption(page, 'geolocation_country', 'no'); // city precision
+    await setSlimstatOption(page, 'gdpr_enabled', 'off'); // Disable GDPR so PII (geolocation) is allowed
+
+    // Inject Cloudflare headers — distinct city ("Munich") vs region ("Bavaria")
+    // to prove the region→subdivision mapping works (city stored as "Munich (Bavaria)")
+    await context.setExtraHTTPHeaders({
+      'CF-Ray': 'test-e2e-ray-001',
+      'CF-IPCountry': 'DE',
+      'CF-IPContinent': 'EU',
+      'CF-IPCity': 'Munich',
+      'CF-Region': 'Bavaria',
+      'CF-IPLatitude': '48.1351',
+      'CF-IPLongitude': '11.5820',
+    });
+
+    const marker = `cf-test-${Date.now()}`;
+    await page.goto(`/?p=${marker}`);
+    await page.waitForTimeout(4000);
+
+    const stat = await getLatestStat(marker);
+    expect(stat).toBeTruthy();
+    expect(stat!.country).toBe('de');
+    expect(stat!.city).toBe('Munich (Bavaria)'); // Proves region→subdivision mapping
+    expect(stat!.location).toContain('48.1351'); // Proves lat/lng stored
+  });
+
+  // ─── Test 7: Disabled provider skips geolocation ───────────────
+
+  test('disabled provider skips geolocation tracking', async ({ page }) => {
+    await setSlimstatOption(page, 'geolocation_provider', 'disable');
+
+    const marker = `disabled-${Date.now()}`;
+    await page.goto(`/?p=${marker}`);
+    await page.waitForTimeout(3000);
+
+    const stat = await getLatestStat(marker);
+    if (stat) {
+      expect(!stat.country || stat.country === '').toBeTruthy();
+    }
+  });
+
+  // ─── Test 8: Admin pages load for all providers ────────────────
+
+  test('admin pages load without error for all provider types', async ({ page }) => {
+    const providers = ['dbip', 'cloudflare', 'maxmind', 'disable'];
+
+    for (const provider of providers) {
+      await setSlimstatOption(page, 'geolocation_provider', provider);
+
+      const response = await page.goto('/wp-admin/');
+      expect(response?.status()).toBeLessThan(500);
+      await expect(page).toHaveTitle(/Dashboard/);
+    }
+  });
+});

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,63 @@
+/**
+ * Global setup: authenticates admin and author users, saves browser state.
+ * Reuses cached auth files if they are less than 30 minutes old.
+ */
+import { chromium, FullConfig } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const AUTH_DIR = path.join(__dirname, '.auth');
+const MAX_AGE_MS = 30 * 60 * 1000; // 30 minutes
+
+function isAuthFresh(statePath: string): boolean {
+  if (!fs.existsSync(statePath)) return false;
+  const stat = fs.statSync(statePath);
+  return Date.now() - stat.mtimeMs < MAX_AGE_MS;
+}
+
+async function loginAndSave(
+  baseURL: string,
+  username: string,
+  password: string,
+  statePath: string
+): Promise<void> {
+  if (isAuthFresh(statePath)) return; // reuse cached auth
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ baseURL });
+  const page = await context.newPage();
+
+  await page.goto('/wp-login.php');
+  await page.fill('#user_login', username);
+  await page.fill('#user_pass', password);
+  await page.click('#wp-submit');
+  await page.waitForURL('**/wp-admin/**', { timeout: 60_000 });
+
+  await context.storageState({ path: statePath });
+  await browser.close();
+}
+
+export default async function globalSetup(config: FullConfig): Promise<void> {
+  const baseURL = 'http://localhost:10003';
+
+  fs.mkdirSync(AUTH_DIR, { recursive: true });
+
+  // Login as admin (parhumm)
+  await loginAndSave(
+    baseURL,
+    'parhumm',
+    'testpass123',
+    path.join(AUTH_DIR, 'admin.json')
+  );
+
+  // Login as author (dordane)
+  await loginAndSave(
+    baseURL,
+    'dordane',
+    'testpass123',
+    path.join(AUTH_DIR, 'author.json')
+  );
+}

--- a/tests/e2e/helpers/ajax-logger-mu-plugin.php
+++ b/tests/e2e/helpers/ajax-logger-mu-plugin.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * MU-Plugin: GeoIP AJAX call logger for QA testing.
+ * Installed temporarily by Playwright tests to count AJAX handler invocations.
+ *
+ * Logs to wp-content/geoip-ajax-calls.log with JSON entries.
+ */
+add_action('wp_ajax_slimstat_update_geoip_database', function () {
+    $entry = json_encode([
+        'time'    => microtime(true),
+        'user'    => get_current_user_id(),
+        'referer' => isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '',
+        'ip'      => isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '',
+    ]) . "\n";
+    file_put_contents(WP_CONTENT_DIR . '/geoip-ajax-calls.log', $entry, FILE_APPEND | LOCK_EX);
+}, 1); // priority 1: runs before SlimStat's handler

--- a/tests/e2e/helpers/option-mutator-mu-plugin.php
+++ b/tests/e2e/helpers/option-mutator-mu-plugin.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * MU-plugin: Safe slimstat_options mutator for E2E tests.
+ *
+ * Provides a WP AJAX endpoint that uses WordPress's native get_option/update_option
+ * to safely manipulate PHP serialized data. Eliminates fragile regex-based manipulation.
+ *
+ * POST /wp-admin/admin-ajax.php?action=test_set_slimstat_option
+ * Body: key=<key>&value=<value>       — set a key
+ * Body: key=<key>&delete=1            — delete a key
+ */
+add_action('wp_ajax_test_set_slimstat_option', function () {
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error('forbidden');
+    }
+
+    $key    = sanitize_text_field($_POST['key'] ?? '');
+    $value  = sanitize_text_field($_POST['value'] ?? '');
+    $delete = !empty($_POST['delete']);
+
+    if (empty($key)) {
+        wp_send_json_error('missing key');
+    }
+
+    $opts = get_option('slimstat_options', []);
+
+    if ($delete) {
+        unset($opts[$key]);
+    } else {
+        $opts[$key] = $value;
+    }
+
+    update_option('slimstat_options', $opts);
+    wp_send_json_success(['key' => $key, 'value' => $value, 'delete' => $delete]);
+});

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -190,3 +190,97 @@ export async function setProviderDisabled(): Promise<void> {
   }
   await setSlimstatSetting('geolocation_provider', 'disable');
 }
+
+// ─── Option mutator mu-plugin (safe WP-native serialization) ────
+
+const OPTION_MUTATOR_SRC = path.join(__dirname, 'option-mutator-mu-plugin.php');
+const OPTION_MUTATOR_DEST = path.join(MU_PLUGINS, 'option-mutator-mu-plugin.php');
+const BASE_URL = 'http://localhost:10003';
+
+export function installOptionMutator(): void {
+  fs.mkdirSync(MU_PLUGINS, { recursive: true });
+  fs.copyFileSync(OPTION_MUTATOR_SRC, OPTION_MUTATOR_DEST);
+}
+
+export function uninstallOptionMutator(): void {
+  if (fs.existsSync(OPTION_MUTATOR_DEST)) fs.unlinkSync(OPTION_MUTATOR_DEST);
+}
+
+/**
+ * Set a slimstat option using WordPress's native serialization.
+ * Requires the option-mutator mu-plugin to be installed and an authenticated page context.
+ */
+export async function setSlimstatOption(page: import('@playwright/test').Page, key: string, value: string): Promise<void> {
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'test_set_slimstat_option', key, value },
+  });
+  if (!res.ok()) {
+    throw new Error(`setSlimstatOption(${key}, ${value}) failed: ${res.status()}`);
+  }
+}
+
+/**
+ * Delete a slimstat option key using WordPress's native serialization.
+ */
+export async function deleteSlimstatOption(page: import('@playwright/test').Page, key: string): Promise<void> {
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'test_set_slimstat_option', key, delete: '1' },
+  });
+  if (!res.ok()) {
+    throw new Error(`deleteSlimstatOption(${key}) failed: ${res.status()}`);
+  }
+}
+
+// ─── Full settings snapshot/restore ──────────────────────────────
+
+let savedOptionsSnapshot: string | null = null;
+
+export async function snapshotSlimstatOptions(): Promise<void> {
+  const [rows] = await getPool().execute(
+    "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_options'"
+  ) as any;
+  savedOptionsSnapshot = rows.length > 0 ? rows[0].option_value : null;
+}
+
+export async function restoreSlimstatOptions(): Promise<void> {
+  if (savedOptionsSnapshot === null) return;
+  // Upsert: works whether the row exists, was deleted by simulateFreshInstall(),
+  // or the test failed before WordPress could recreate it
+  await getPool().execute(
+    "INSERT INTO wp_options (option_name, option_value, autoload) VALUES ('slimstat_options', ?, 'yes') ON DUPLICATE KEY UPDATE option_value = VALUES(option_value)",
+    [savedOptionsSnapshot]
+  );
+  savedOptionsSnapshot = null;
+}
+
+// ─── Stats table helpers ─────────────────────────────────────────
+
+export async function clearStatsTable(): Promise<void> {
+  await getPool().execute("TRUNCATE TABLE wp_slim_stats");
+}
+
+export async function getLatestStat(testMarker: string): Promise<{ country: string; city: string; location: string } | null> {
+  const [rows] = await getPool().execute(
+    "SELECT country, city, location FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id DESC LIMIT 1",
+    [`%${testMarker}%`]
+  ) as any;
+  return rows.length > 0 ? rows[0] : null;
+}
+
+export async function getLatestStatByIp(): Promise<{ country: string; city: string; location: string } | null> {
+  const [rows] = await getPool().execute(
+    "SELECT country, city, location FROM wp_slim_stats ORDER BY id DESC LIMIT 1"
+  ) as any;
+  return rows.length > 0 ? rows[0] : null;
+}
+
+// ─── Scenario helpers ────────────────────────────────────────────
+
+export async function simulateFreshInstall(): Promise<void> {
+  await getPool().execute("DELETE FROM wp_options WHERE option_name = 'slimstat_options'");
+}
+
+export async function simulateLegacyUpgrade(page: import('@playwright/test').Page, enableMaxmind: string): Promise<void> {
+  await setSlimstatOption(page, 'enable_maxmind', enableMaxmind);
+  await deleteSlimstatOption(page, 'geolocation_provider');
+}

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -1,0 +1,192 @@
+/**
+ * Shared test helpers for wp-config toggling, mu-plugin management,
+ * DB access, and AJAX log reading.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import * as mysql from 'mysql2/promise';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ─── Path constants ────────────────────────────────────────────────
+
+const WP_ROOT = '/Users/parhumm/Local Sites/test/app/public';
+const WP_CONFIG = path.join(WP_ROOT, 'wp-config.php');
+const WP_CONTENT = path.join(WP_ROOT, 'wp-content');
+const MU_PLUGINS = path.join(WP_CONTENT, 'mu-plugins');
+const AJAX_LOG = path.join(WP_CONTENT, 'geoip-ajax-calls.log');
+const LOGGER_SRC = path.join(__dirname, 'ajax-logger-mu-plugin.php');
+const LOGGER_DEST = path.join(MU_PLUGINS, 'geoip-ajax-logger.php');
+const CRON_LINE = "define('DISABLE_WP_CRON', true);";
+
+const MYSQL_SOCKET = '/Users/parhumm/Library/Application Support/Local/run/X-JdmZXIa/mysql/mysqld.sock';
+
+// ─── wp-config.php toggler ─────────────────────────────────────────
+
+let wpConfigBackup: string | null = null;
+
+export function enableDisableWpCron(): void {
+  const content = fs.readFileSync(WP_CONFIG, 'utf8');
+  wpConfigBackup = content;
+  if (content.includes('DISABLE_WP_CRON')) return; // already set
+  const marker = "/* That's all, stop editing!";
+  const idx = content.indexOf(marker);
+  if (idx === -1) throw new Error('Cannot find stop-editing marker in wp-config.php');
+  const updated = content.slice(0, idx) + CRON_LINE + '\n' + content.slice(idx);
+  fs.writeFileSync(WP_CONFIG, updated, 'utf8');
+}
+
+export function restoreWpConfig(): void {
+  if (wpConfigBackup !== null) {
+    fs.writeFileSync(WP_CONFIG, wpConfigBackup, 'utf8');
+    wpConfigBackup = null;
+  }
+}
+
+// ─── MU-Plugin manager ─────────────────────────────────────────────
+
+export function installMuPlugin(): void {
+  fs.mkdirSync(MU_PLUGINS, { recursive: true });
+  fs.copyFileSync(LOGGER_SRC, LOGGER_DEST);
+}
+
+export function uninstallMuPlugin(): void {
+  if (fs.existsSync(LOGGER_DEST)) fs.unlinkSync(LOGGER_DEST);
+}
+
+// ─── AJAX log reader ───────────────────────────────────────────────
+
+export function clearAjaxLog(): void {
+  if (fs.existsSync(AJAX_LOG)) fs.unlinkSync(AJAX_LOG);
+}
+
+export interface AjaxLogEntry {
+  time: number;
+  user: number;
+  referer: string;
+  ip: string;
+}
+
+export function readAjaxLog(): AjaxLogEntry[] {
+  if (!fs.existsSync(AJAX_LOG)) return [];
+  const raw = fs.readFileSync(AJAX_LOG, 'utf8').trim();
+  if (!raw) return [];
+  return raw.split('\n').filter(Boolean).map((line) => JSON.parse(line));
+}
+
+// ─── MySQL helper ──────────────────────────────────────────────────
+
+let pool: mysql.Pool | null = null;
+
+function getPool(): mysql.Pool {
+  if (!pool) {
+    pool = mysql.createPool({
+      socketPath: MYSQL_SOCKET,
+      user: 'root',
+      password: 'root',
+      database: 'local',
+      waitForConnections: true,
+      connectionLimit: 5,
+    });
+  }
+  return pool;
+}
+
+export async function closeDb(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}
+
+export async function clearGeoipTimestamp(): Promise<void> {
+  await getPool().execute(
+    "DELETE FROM wp_options WHERE option_name = 'slimstat_last_geoip_dl'"
+  );
+}
+
+export async function getGeoipTimestamp(): Promise<number | null> {
+  const [rows] = await getPool().execute(
+    "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_last_geoip_dl'"
+  ) as any;
+  if (rows.length === 0) return null;
+  return parseInt(rows[0].option_value, 10);
+}
+
+export async function getSlimstatSettings(): Promise<Record<string, any>> {
+  const [rows] = await getPool().execute(
+    "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_options'"
+  ) as any;
+  if (rows.length === 0) return {};
+  // PHP serialized — we'll use a simple regex for the key we need
+  return { _raw: rows[0].option_value };
+}
+
+export async function setSlimstatSetting(key: string, value: string): Promise<void> {
+  // Read current serialized settings, do a targeted string replacement
+  const [rows] = await getPool().execute(
+    "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_options'"
+  ) as any;
+  if (rows.length === 0) return;
+  let raw: string = rows[0].option_value;
+
+  // PHP serialized format: s:<len>:"key";s:<len>:"value";
+  const keyPattern = new RegExp(
+    `s:\\d+:"${key}";s:\\d+:"[^"]*"`,
+    'g'
+  );
+  const replacement = `s:${key.length}:"${key}";s:${value.length}:"${value}"`;
+
+  if (keyPattern.test(raw)) {
+    keyPattern.lastIndex = 0; // Reset after test() advanced it
+    raw = raw.replace(keyPattern, replacement);
+  } else {
+    // Key not present — not safe to inject into PHP serialized without full parser.
+    // For testing, we only modify existing keys.
+    console.warn(`Key "${key}" not found in slimstat_options, skipping`);
+    return;
+  }
+
+  // Fix the total count in the serialized array header (a:<count>:{...})
+  // The count doesn't change since we're replacing, not adding
+  await getPool().execute(
+    "UPDATE wp_options SET option_value = ? WHERE option_name = 'slimstat_options'",
+    [raw]
+  );
+}
+
+// ─── Combined setup/teardown ───────────────────────────────────────
+
+let savedProviderValue: string | null = null;
+
+export async function setupTest(): Promise<void> {
+  enableDisableWpCron();
+  installMuPlugin();
+  clearAjaxLog();
+  await clearGeoipTimestamp();
+}
+
+export async function teardownTest(): Promise<void> {
+  restoreWpConfig();
+  uninstallMuPlugin();
+  clearAjaxLog();
+  if (savedProviderValue !== null) {
+    await setSlimstatSetting('geolocation_provider', savedProviderValue);
+    savedProviderValue = null;
+  }
+}
+
+export async function setProviderDisabled(): Promise<void> {
+  // Save current value for restore
+  const [rows] = await getPool().execute(
+    "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_options'"
+  ) as any;
+  if (rows.length > 0) {
+    const raw: string = rows[0].option_value;
+    const match = raw.match(/s:\d+:"geolocation_provider";s:\d+:"([^"]*)"/);
+    savedProviderValue = match ? match[1] : null;
+  }
+  await setSlimstatSetting('geolocation_provider', 'disable');
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: '**/*.spec.ts',
+  timeout: 30_000,
+  retries: 0,
+  fullyParallel: false, // Tests modify shared state (wp-config, DB options)
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: path.join(__dirname, 'playwright-report') }]],
+  use: {
+    baseURL: 'http://localhost:10003',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  globalSetup: path.join(__dirname, 'global-setup.ts'),
+  projects: [
+    {
+      name: 'admin',
+      use: { storageState: path.join(__dirname, '.auth/admin.json') },
+    },
+    {
+      name: 'author',
+      use: { storageState: path.join(__dirname, '.auth/author.json') },
+      testMatch: '**/*author*.spec.ts',
+    },
+  ],
+});

--- a/tests/e2e/upgrade-data-integrity.spec.ts
+++ b/tests/e2e/upgrade-data-integrity.spec.ts
@@ -1,0 +1,325 @@
+/**
+ * E2E tests: Upgrade data integrity verification.
+ *
+ * Ensures that after the geolocation refactor (PR #166), existing user
+ * tracking data remains intact, countries don't become "unknown" or empty,
+ * and new tracking still produces valid geolocation data.
+ *
+ * All tests snapshot and restore data — no permanent changes to the DB.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  installOptionMutator,
+  uninstallOptionMutator,
+  setSlimstatOption,
+  deleteSlimstatOption,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+  clearStatsTable,
+  getLatestStat,
+  simulateLegacyUpgrade,
+  closeDb,
+} from './helpers/setup';
+import * as mysql from 'mysql2/promise';
+
+const MYSQL_SOCKET = '/Users/parhumm/Library/Application Support/Local/run/X-JdmZXIa/mysql/mysqld.sock';
+
+let pool: mysql.Pool;
+
+function getPool(): mysql.Pool {
+  if (!pool) {
+    pool = mysql.createPool({
+      socketPath: MYSQL_SOCKET,
+      user: 'root',
+      password: 'root',
+      database: 'local',
+      waitForConnections: true,
+      connectionLimit: 5,
+    });
+  }
+  return pool;
+}
+
+// ─── Seed helpers ────────────────────────────────────────────────
+
+interface SeedRow {
+  ip: string;
+  country: string;
+  city: string;
+  resource: string;
+  dt: number;
+  visit_id: number;
+}
+
+async function seedStatsRows(rows: SeedRow[]): Promise<number[]> {
+  const ids: number[] = [];
+  for (const row of rows) {
+    const [result] = await getPool().execute(
+      `INSERT INTO wp_slim_stats (ip, country, city, resource, dt, visit_id)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [row.ip, row.country, row.city, row.resource, row.dt, row.visit_id]
+    ) as any;
+    ids.push(result.insertId);
+  }
+  return ids;
+}
+
+async function getStatsRows(ids: number[]): Promise<any[]> {
+  if (ids.length === 0) return [];
+  const placeholders = ids.map(() => '?').join(',');
+  const [rows] = await getPool().execute(
+    `SELECT id, ip, country, city, resource, dt, visit_id
+     FROM wp_slim_stats WHERE id IN (${placeholders}) ORDER BY id`,
+    ids
+  ) as any;
+  return rows;
+}
+
+async function deleteStatsRows(ids: number[]): Promise<void> {
+  if (ids.length === 0) return;
+  const placeholders = ids.map(() => '?').join(',');
+  await getPool().execute(
+    `DELETE FROM wp_slim_stats WHERE id IN (${placeholders})`,
+    ids
+  );
+}
+
+async function getAllStatsCountries(): Promise<string[]> {
+  const [rows] = await getPool().execute(
+    `SELECT DISTINCT country FROM wp_slim_stats WHERE country IS NOT NULL AND country != '' ORDER BY country`
+  ) as any;
+  return rows.map((r: any) => r.country);
+}
+
+// ─── Test data ───────────────────────────────────────────────────
+
+const KNOWN_COUNTRIES: SeedRow[] = [
+  { ip: '203.0.113.1', country: 'us', city: 'New York', resource: '/upgrade-test/page-1', dt: Math.floor(Date.now() / 1000) - 86400, visit_id: 9001 },
+  { ip: '203.0.113.2', country: 'de', city: 'Berlin', resource: '/upgrade-test/page-2', dt: Math.floor(Date.now() / 1000) - 86400, visit_id: 9002 },
+  { ip: '203.0.113.3', country: 'jp', city: 'Tokyo', resource: '/upgrade-test/page-3', dt: Math.floor(Date.now() / 1000) - 86400, visit_id: 9003 },
+  { ip: '203.0.113.4', country: 'br', city: 'São Paulo', resource: '/upgrade-test/page-4', dt: Math.floor(Date.now() / 1000) - 86400, visit_id: 9004 },
+  { ip: '203.0.113.5', country: 'gb', city: 'London', resource: '/upgrade-test/page-5', dt: Math.floor(Date.now() / 1000) - 86400, visit_id: 9005 },
+  { ip: '203.0.113.6', country: 'fr', city: 'Paris', resource: '/upgrade-test/page-6', dt: Math.floor(Date.now() / 1000) - 86400, visit_id: 9006 },
+  { ip: '203.0.113.7', country: 'au', city: 'Sydney', resource: '/upgrade-test/page-7', dt: Math.floor(Date.now() / 1000) - 86400, visit_id: 9007 },
+  { ip: '203.0.113.8', country: 'ca', city: 'Toronto', resource: '/upgrade-test/page-8', dt: Math.floor(Date.now() / 1000) - 86400, visit_id: 9008 },
+  { ip: '203.0.113.9', country: 'in', city: 'Mumbai', resource: '/upgrade-test/page-9', dt: Math.floor(Date.now() / 1000) - 86400, visit_id: 9009 },
+  { ip: '203.0.113.10', country: 'kr', city: 'Seoul', resource: '/upgrade-test/page-10', dt: Math.floor(Date.now() / 1000) - 86400, visit_id: 9010 },
+];
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+test.describe('Upgrade Data Integrity', () => {
+  let seededIds: number[] = [];
+
+  test.beforeAll(async () => {
+    installOptionMutator();
+  });
+
+  test.beforeEach(async () => {
+    await snapshotSlimstatOptions();
+  });
+
+  test.afterEach(async () => {
+    await restoreSlimstatOptions();
+    // Clean up seeded rows
+    if (seededIds.length > 0) {
+      await deleteStatsRows(seededIds);
+      seededIds = [];
+    }
+  });
+
+  test.afterAll(async () => {
+    uninstallOptionMutator();
+    if (pool) {
+      await pool.end();
+    }
+    await closeDb();
+  });
+
+  // ─── Test 1: Existing country data survives upgrade ────────────
+
+  test('existing rows with known countries remain intact after admin page load', async ({ page }) => {
+    // Seed 10 rows with known countries
+    seededIds = await seedStatsRows(KNOWN_COUNTRIES);
+    expect(seededIds).toHaveLength(10);
+
+    // Load admin pages (triggers init(), resolve_geolocation_provider(), lazy migration)
+    await page.goto('/wp-admin/');
+    await page.waitForURL('**/wp-admin/**');
+    await expect(page).toHaveTitle(/Dashboard/);
+
+    // Load the SlimStat reports page (triggers report queries)
+    const response = await page.goto('/wp-admin/admin.php?page=slimstat');
+    expect(response?.status()).toBeLessThan(500);
+
+    // Verify all 10 rows still have their original country codes
+    const rows = await getStatsRows(seededIds);
+    expect(rows).toHaveLength(10);
+
+    for (let i = 0; i < KNOWN_COUNTRIES.length; i++) {
+      const original = KNOWN_COUNTRIES[i];
+      const current = rows[i];
+      expect(current.country).toBe(original.country);
+      expect(current.city).toBe(original.city);
+      expect(current.ip).toBe(original.ip);
+      expect(current.resource).toBe(original.resource);
+    }
+  });
+
+  // ─── Test 2: Legacy MaxMind users' existing data preserved ─────
+
+  test('legacy enable_maxmind=on: existing data preserved, new tracking works', async ({ page }) => {
+    // Seed some pre-upgrade data
+    seededIds = await seedStatsRows([
+      { ip: '198.51.100.1', country: 'us', city: 'Chicago', resource: '/legacy-maxmind-test', dt: Math.floor(Date.now() / 1000) - 172800, visit_id: 8001 },
+      { ip: '198.51.100.2', country: 'de', city: 'Munich', resource: '/legacy-maxmind-test-2', dt: Math.floor(Date.now() / 1000) - 172800, visit_id: 8002 },
+    ]);
+
+    // Simulate legacy state: enable_maxmind=on, no geolocation_provider key
+    await simulateLegacyUpgrade(page, 'on');
+
+    // Trigger upgrade path by loading admin
+    await page.goto('/wp-admin/');
+    await expect(page).toHaveTitle(/Dashboard/);
+
+    // Verify pre-existing data untouched
+    const rows = await getStatsRows(seededIds);
+    expect(rows[0].country).toBe('us');
+    expect(rows[0].city).toBe('Chicago');
+    expect(rows[1].country).toBe('de');
+    expect(rows[1].city).toBe('Munich');
+
+    // Track a new pageview — should not crash even without MaxMind DB
+    const marker = `post-upgrade-maxmind-${Date.now()}`;
+    const response = await page.goto(`/?p=${marker}`);
+    expect(response?.status()).toBeLessThan(500);
+  });
+
+  // ─── Test 3: Legacy DB-IP users' existing data preserved ───────
+
+  test('legacy enable_maxmind=no: existing data preserved, new tracking works', async ({ page }) => {
+    seededIds = await seedStatsRows([
+      { ip: '198.51.100.3', country: 'fr', city: 'Lyon', resource: '/legacy-dbip-test', dt: Math.floor(Date.now() / 1000) - 172800, visit_id: 8003 },
+      { ip: '198.51.100.4', country: 'jp', city: 'Osaka', resource: '/legacy-dbip-test-2', dt: Math.floor(Date.now() / 1000) - 172800, visit_id: 8004 },
+    ]);
+
+    await simulateLegacyUpgrade(page, 'no');
+
+    await page.goto('/wp-admin/');
+    await expect(page).toHaveTitle(/Dashboard/);
+
+    // Pre-existing data untouched
+    const rows = await getStatsRows(seededIds);
+    expect(rows[0].country).toBe('fr');
+    expect(rows[0].city).toBe('Lyon');
+    expect(rows[1].country).toBe('jp');
+    expect(rows[1].city).toBe('Osaka');
+
+    // Track a new pageview
+    const marker = `post-upgrade-dbip-${Date.now()}`;
+    const response = await page.goto(`/?p=${marker}`);
+    expect(response?.status()).toBeLessThan(500);
+  });
+
+  // ─── Test 4: New tracking with DB-IP doesn't produce empty country ──
+
+  test('new tracking after upgrade does not produce empty or unknown country', async ({ page }) => {
+    await setSlimstatOption(page, 'geolocation_provider', 'dbip');
+
+    const marker = `new-track-${Date.now()}`;
+    await page.goto(`/?p=${marker}`);
+    await page.waitForTimeout(4000);
+
+    const stat = await getLatestStat(marker);
+    // For local/private IPs, DB-IP may not resolve a country — that's OK.
+    // The key assertion: if a country IS stored, it must be a valid 2-letter code, not "unknown".
+    if (stat && stat.country) {
+      expect(stat.country).toMatch(/^[a-z]{2}$/);
+      expect(stat.country).not.toBe('unknown');
+      expect(stat.country).not.toBe('xx');
+    }
+    // Pipeline didn't crash (we reached this point)
+  });
+
+  // ─── Test 5: Cloudflare tracking produces valid country ────────
+
+  test('Cloudflare provider produces valid country, not unknown', async ({ page, context }) => {
+    await setSlimstatOption(page, 'geolocation_provider', 'cloudflare');
+    await setSlimstatOption(page, 'geolocation_country', 'no'); // city precision
+    await setSlimstatOption(page, 'gdpr_enabled', 'off'); // Ensure tracking not blocked by GDPR
+
+    // Clear stats so we get a clean read
+    await getPool().execute('TRUNCATE TABLE wp_slim_stats');
+
+    // Inject CF headers for a known location
+    await context.setExtraHTTPHeaders({
+      'CF-IPCountry': 'IT',
+      'CF-IPCity': 'Rome',
+      'CF-Region': 'Lazio',
+      'CF-IPLatitude': '41.9028',
+      'CF-IPLongitude': '12.4964',
+    });
+
+    const marker = `cf-upgrade-${Date.now()}`;
+    await page.goto(`/?p=${marker}`);
+    await page.waitForTimeout(5000);
+
+    const stat = await getLatestStat(marker);
+    if (stat) {
+      // Country must be a valid code or null — never "unknown"
+      if (stat.country) {
+        expect(stat.country).toBe('it');
+        expect(stat.country).not.toBe('unknown');
+      }
+      if (stat.city) {
+        expect(stat.city).toContain('Rome');
+      }
+    }
+    // Pipeline didn't crash regardless of whether row was tracked
+  });
+
+  // ─── Test 6: Admin reports page loads with mixed data ──────────
+
+  test('admin reports page displays mixed-country data without errors', async ({ page }) => {
+    // Seed diverse country data
+    seededIds = await seedStatsRows(KNOWN_COUNTRIES);
+
+    // Load the main reports page
+    const response = await page.goto('/wp-admin/admin.php?page=slimstat');
+    expect(response?.status()).toBeLessThan(500);
+
+    // Check page doesn't contain PHP fatal errors or warnings
+    const bodyText = await page.textContent('body');
+    expect(bodyText).not.toContain('Fatal error');
+    expect(bodyText).not.toContain('Warning:');
+    expect(bodyText).not.toContain('Unknown country');
+
+    // Load the settings page
+    const settingsResponse = await page.goto('/wp-admin/admin.php?page=slimconfig');
+    expect(settingsResponse?.status()).toBeLessThan(500);
+  });
+
+  // ─── Test 7: Settings page shows correct provider after migration ──
+
+  test('settings page shows correct provider after legacy migration', async ({ page }) => {
+    // Start with legacy state
+    await simulateLegacyUpgrade(page, 'no');
+
+    // Visit admin — triggers lazy migration in admin/config/index.php
+    await page.goto('/wp-admin/');
+    await expect(page).toHaveTitle(/Dashboard/);
+
+    // Go to settings page — should show the migrated provider
+    const response = await page.goto('/wp-admin/admin.php?page=slimconfig&tab=5');
+    expect(response?.status()).toBeLessThan(500);
+
+    // The provider select should exist and have a valid value (not empty, not "unknown")
+    const providerSelect = page.locator('select[name="geolocation_provider"]');
+    if (await providerSelect.count() > 0) {
+      const value = await providerSelect.inputValue();
+      expect(['dbip', 'maxmind', 'cloudflare', 'disable']).toContain(value);
+      // Legacy enable_maxmind=no should map to dbip
+      expect(value).toBe('dbip');
+    }
+  });
+});

--- a/tests/geoservice-provider-resolution-test.php
+++ b/tests/geoservice-provider-resolution-test.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * Tests for GeoService::isGeoIPEnabled() and isMaxMindEnabled()
+ *
+ * Covers: PR #166 — wiring GeoService to resolve_geolocation_provider()
+ * Source: src/Services/GeoService.php:65-74
+ *
+ * Run: php tests/geoservice-provider-resolution-test.php
+ */
+
+declare(strict_types=1);
+
+namespace SlimStat\Dependencies\GeoIp2\Database {
+    // Stub the Reader class so GeoService.php can be loaded
+    class Reader
+    {
+    }
+}
+
+namespace {
+    $assertions = 0;
+
+    function assert_same($expected, $actual, string $message): void
+    {
+        global $assertions;
+        $assertions++;
+
+        if ($expected !== $actual) {
+            fwrite(STDERR, "FAIL: {$message} (expected " . var_export($expected, true) . ', got ' . var_export($actual, true) . ")\n");
+            exit(1);
+        }
+    }
+
+    // WordPress function mocks
+    function sanitize_text_field($str)
+    {
+        $str = (string) $str;
+        $str = strip_tags($str);
+        $str = trim($str);
+        $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
+        return $str;
+    }
+
+    function wp_unslash($value)
+    {
+        return $value;
+    }
+
+    // wp_slimstat stub with real resolver logic
+    class wp_slimstat
+    {
+        public static $settings = [];
+
+        public static function resolve_geolocation_provider()
+        {
+            if (isset(self::$settings['geolocation_provider'])) {
+                $p = sanitize_text_field(self::$settings['geolocation_provider']);
+                if ('disable' === $p) {
+                    return false;
+                }
+                if (in_array($p, ['maxmind', 'dbip', 'cloudflare'], true)) {
+                    return $p;
+                }
+            }
+            $em = self::$settings['enable_maxmind'] ?? 'disable';
+            if ('on' === $em) {
+                return 'maxmind';
+            }
+            if ('no' === $em) {
+                return 'dbip';
+            }
+            return false;
+        }
+    }
+
+    // Load real GeoService
+    require_once __DIR__ . '/../src/Services/GeoService.php';
+
+    use SlimStat\Services\GeoService;
+
+    function set_and_create(array $settings): GeoService
+    {
+        $settings += ['enable_maxmind' => 'disable', 'maxmind_license_key' => '', 'geolocation_country' => 'on'];
+        wp_slimstat::$settings = $settings;
+        return new GeoService();
+    }
+
+    // ─── MaxMind provider ──────────────────────────────────────────
+
+    $svc = set_and_create(['geolocation_provider' => 'maxmind', 'enable_maxmind' => 'on']);
+    assert_same(true, $svc->isGeoIPEnabled(), 'maxmind: isGeoIPEnabled should be true');
+    assert_same(true, $svc->isMaxMindEnabled(), 'maxmind: isMaxMindEnabled should be true');
+
+    // ─── DB-IP provider ────────────────────────────────────────────
+
+    $svc = set_and_create(['geolocation_provider' => 'dbip', 'enable_maxmind' => 'no']);
+    assert_same(true, $svc->isGeoIPEnabled(), 'dbip: isGeoIPEnabled should be true');
+    assert_same(false, $svc->isMaxMindEnabled(), 'dbip: isMaxMindEnabled should be false');
+
+    // ─── Cloudflare provider (no DB needed) ────────────────────────
+
+    $svc = set_and_create(['geolocation_provider' => 'cloudflare', 'enable_maxmind' => 'no']);
+    assert_same(false, $svc->isGeoIPEnabled(), 'cloudflare: isGeoIPEnabled should be false (no DB to query)');
+    assert_same(false, $svc->isMaxMindEnabled(), 'cloudflare: isMaxMindEnabled should be false');
+
+    // ─── Disabled ──────────────────────────────────────────────────
+
+    $svc = set_and_create(['geolocation_provider' => 'disable', 'enable_maxmind' => 'disable']);
+    assert_same(false, $svc->isGeoIPEnabled(), 'disabled: isGeoIPEnabled should be false');
+    assert_same(false, $svc->isMaxMindEnabled(), 'disabled: isMaxMindEnabled should be false');
+
+    // ─── Legacy MaxMind (no geolocation_provider) ──────────────────
+
+    $svc = set_and_create(['enable_maxmind' => 'on']);
+    assert_same(true, $svc->isGeoIPEnabled(), 'legacy maxmind: isGeoIPEnabled should be true');
+    assert_same(true, $svc->isMaxMindEnabled(), 'legacy maxmind: isMaxMindEnabled should be true');
+
+    // ─── Legacy DB-IP ──────────────────────────────────────────────
+
+    $svc = set_and_create(['enable_maxmind' => 'no']);
+    assert_same(true, $svc->isGeoIPEnabled(), 'legacy dbip: isGeoIPEnabled should be true');
+    assert_same(false, $svc->isMaxMindEnabled(), 'legacy dbip: isMaxMindEnabled should be false');
+
+    // ─── Legacy disabled ───────────────────────────────────────────
+
+    $svc = set_and_create(['enable_maxmind' => 'disable']);
+    assert_same(false, $svc->isGeoIPEnabled(), 'legacy disabled: isGeoIPEnabled should be false');
+    assert_same(false, $svc->isMaxMindEnabled(), 'legacy disabled: isMaxMindEnabled should be false');
+
+    // ─── Fresh install ─────────────────────────────────────────────
+
+    $svc = set_and_create([]);
+    assert_same(false, $svc->isGeoIPEnabled(), 'fresh install: isGeoIPEnabled should be false');
+    assert_same(false, $svc->isMaxMindEnabled(), 'fresh install: isMaxMindEnabled should be false');
+
+    echo "All {$assertions} assertions passed in geoservice-provider-resolution-test.php\n";
+}

--- a/tests/geoservice-provider-resolution-test.php
+++ b/tests/geoservice-provider-resolution-test.php
@@ -101,7 +101,7 @@ namespace {
     // ─── Cloudflare provider (no DB needed) ────────────────────────
 
     $svc = set_and_create(['geolocation_provider' => 'cloudflare', 'enable_maxmind' => 'no']);
-    assert_same(false, $svc->isGeoIPEnabled(), 'cloudflare: isGeoIPEnabled should be false (no DB to query)');
+    assert_same(true, $svc->isGeoIPEnabled(), 'cloudflare: isGeoIPEnabled should be true (Cloudflare is a valid geolocation provider)');
     assert_same(false, $svc->isMaxMindEnabled(), 'cloudflare: isMaxMindEnabled should be false');
 
     // ─── Disabled ──────────────────────────────────────────────────

--- a/tests/lazy-migration-test.php
+++ b/tests/lazy-migration-test.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Tests for lazy migration of geolocation_provider from legacy enable_maxmind.
+ *
+ * Covers: PR #166 — admin/config/index.php:17-22
+ * When geolocation_provider is not set, the lazy migration populates it
+ * from the resolver for correct <select> rendering on the settings page.
+ *
+ * Run: php tests/lazy-migration-test.php
+ */
+
+declare(strict_types=1);
+
+$assertions = 0;
+
+function assert_same($expected, $actual, string $message): void
+{
+    global $assertions;
+    $assertions++;
+
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message} (expected " . var_export($expected, true) . ', got ' . var_export($actual, true) . ")\n");
+        exit(1);
+    }
+}
+
+function sanitize_text_field($str)
+{
+    $str = (string) $str;
+    $str = strip_tags($str);
+    $str = trim($str);
+    $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
+    return $str;
+}
+
+class wp_slimstat
+{
+    public static $settings = [];
+
+    public static function resolve_geolocation_provider()
+    {
+        if (isset(self::$settings['geolocation_provider'])) {
+            $p = sanitize_text_field(self::$settings['geolocation_provider']);
+            if ('disable' === $p) {
+                return false;
+            }
+            if (in_array($p, ['maxmind', 'dbip', 'cloudflare'], true)) {
+                return $p;
+            }
+        }
+        $em = self::$settings['enable_maxmind'] ?? 'disable';
+        if ('on' === $em) {
+            return 'maxmind';
+        }
+        if ('no' === $em) {
+            return 'dbip';
+        }
+        return false;
+    }
+}
+
+/**
+ * Replicates the lazy migration logic from admin/config/index.php:17-22.
+ * Populates geolocation_provider in $settings if not already set.
+ */
+function lazy_migrate(): void
+{
+    if (!isset(wp_slimstat::$settings['geolocation_provider'])) {
+        $resolved = wp_slimstat::resolve_geolocation_provider();
+        wp_slimstat::$settings['geolocation_provider'] = false !== $resolved ? $resolved : 'disable';
+    }
+}
+
+// ─── Legacy MaxMind → migrates to 'maxmind' ───────────────────────
+
+wp_slimstat::$settings = ['enable_maxmind' => 'on'];
+lazy_migrate();
+assert_same('maxmind', wp_slimstat::$settings['geolocation_provider'], 'legacy on migrates to maxmind');
+
+// ─── Legacy DB-IP → migrates to 'dbip' ────────────────────────────
+
+wp_slimstat::$settings = ['enable_maxmind' => 'no'];
+lazy_migrate();
+assert_same('dbip', wp_slimstat::$settings['geolocation_provider'], 'legacy no migrates to dbip');
+
+// ─── Legacy disabled → migrates to 'disable' ──────────────────────
+
+wp_slimstat::$settings = ['enable_maxmind' => 'disable'];
+lazy_migrate();
+assert_same('disable', wp_slimstat::$settings['geolocation_provider'], 'legacy disable migrates to disable');
+
+// ─── Fresh install (no settings) → migrates to 'disable' ──────────
+
+wp_slimstat::$settings = [];
+lazy_migrate();
+assert_same('disable', wp_slimstat::$settings['geolocation_provider'], 'fresh install migrates to disable');
+
+// ─── Already set → does NOT overwrite ──────────────────────────────
+
+wp_slimstat::$settings = ['geolocation_provider' => 'dbip', 'enable_maxmind' => 'on'];
+lazy_migrate();
+assert_same('dbip', wp_slimstat::$settings['geolocation_provider'], 'existing geolocation_provider is not overwritten');
+
+// ─── Already set to disable → preserved ────────────────────────────
+
+wp_slimstat::$settings = ['geolocation_provider' => 'disable', 'enable_maxmind' => 'on'];
+lazy_migrate();
+assert_same('disable', wp_slimstat::$settings['geolocation_provider'], 'existing disable is preserved even with legacy on');
+
+echo "All {$assertions} assertions passed in lazy-migration-test.php\n";

--- a/tests/legacy-sync-mapping-test.php
+++ b/tests/legacy-sync-mapping-test.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Tests for legacy enable_maxmind ↔ geolocation_provider sync mapping.
+ *
+ * Covers: PR #166 — admin/config/index.php:857-864
+ * The config save handler syncs enable_maxmind when geolocation_provider is saved.
+ * This test validates the mapping contract that the sync code must follow.
+ *
+ * Run: php tests/legacy-sync-mapping-test.php
+ */
+
+declare(strict_types=1);
+
+$assertions = 0;
+
+function assert_same($expected, $actual, string $message): void
+{
+    global $assertions;
+    $assertions++;
+
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message} (expected " . var_export($expected, true) . ', got ' . var_export($actual, true) . ")\n");
+        exit(1);
+    }
+}
+
+/**
+ * Replicates the sync logic from admin/config/index.php:857-864.
+ * If this logic changes in the source, this function must be updated too.
+ *
+ * @param string $provider The geolocation_provider value being saved
+ * @return string The enable_maxmind value that should be synced
+ */
+function sync_enable_maxmind(string $provider): string
+{
+    if ('maxmind' === $provider) {
+        return 'on';
+    } elseif ('dbip' === $provider || 'cloudflare' === $provider) {
+        return 'no';
+    } elseif ('disable' === $provider) {
+        return 'disable';
+    }
+    // Unknown provider — should not happen with allowlist, but return current default
+    return 'disable';
+}
+
+// ─── Forward sync: geolocation_provider → enable_maxmind ───────────
+
+assert_same('on', sync_enable_maxmind('maxmind'), 'maxmind should sync to enable_maxmind=on');
+assert_same('no', sync_enable_maxmind('dbip'), 'dbip should sync to enable_maxmind=no');
+assert_same('no', sync_enable_maxmind('cloudflare'), 'cloudflare should sync to enable_maxmind=no');
+assert_same('disable', sync_enable_maxmind('disable'), 'disable should sync to enable_maxmind=disable');
+
+// ─── Reverse contract: enable_maxmind → resolver output ────────────
+// Validates that legacy → resolver → sync produces a stable round-trip.
+
+function sanitize_text_field($str)
+{
+    $str = (string) $str;
+    $str = strip_tags($str);
+    $str = trim($str);
+    $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
+    return $str;
+}
+
+class wp_slimstat
+{
+    public static $settings = [];
+
+    public static function resolve_geolocation_provider()
+    {
+        if (isset(self::$settings['geolocation_provider'])) {
+            $p = sanitize_text_field(self::$settings['geolocation_provider']);
+            if ('disable' === $p) {
+                return false;
+            }
+            if (in_array($p, ['maxmind', 'dbip', 'cloudflare'], true)) {
+                return $p;
+            }
+        }
+        $em = self::$settings['enable_maxmind'] ?? 'disable';
+        if ('on' === $em) {
+            return 'maxmind';
+        }
+        if ('no' === $em) {
+            return 'dbip';
+        }
+        return false;
+    }
+}
+
+// Round-trip: legacy enable_maxmind → resolver → sync → enable_maxmind should be stable
+$round_trips = [
+    'on'      => 'on',       // on → maxmind → sync → on
+    'no'      => 'no',       // no → dbip → sync → no
+    'disable' => 'disable',  // disable → false → (handled by disable branch) → disable
+];
+
+foreach ($round_trips as $legacy_value => $expected_synced) {
+    wp_slimstat::$settings = ['enable_maxmind' => $legacy_value];
+    $resolved = wp_slimstat::resolve_geolocation_provider();
+
+    // Map resolver output to provider string for sync function
+    $provider_for_sync = false === $resolved ? 'disable' : $resolved;
+    $synced = sync_enable_maxmind($provider_for_sync);
+
+    assert_same($expected_synced, $synced, "round-trip: enable_maxmind={$legacy_value} → resolve → sync should produce {$expected_synced}");
+}
+
+echo "All {$assertions} assertions passed in legacy-sync-mapping-test.php\n";

--- a/tests/perf/geoip-load.js
+++ b/tests/perf/geoip-load.js
@@ -1,0 +1,136 @@
+/**
+ * k6 load test: GeoIP AJAX loop prevention under high admin traffic.
+ *
+ * Simulates many admin users hitting admin pages with DISABLE_WP_CRON=true.
+ * Under the old bug, each page load would spawn a cascading AJAX storm.
+ * Under the fix, AJAX fires at most once per monthly update window.
+ *
+ * Pre-requisites:
+ *   - DISABLE_WP_CRON must be added to wp-config.php
+ *   - mu-plugin logger must be installed
+ *   - slimstat_last_geoip_dl option must be deleted
+ *
+ * Run: k6 run tests/perf/geoip-load.js
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+
+// Custom metrics
+const ajaxErrors = new Counter('geoip_ajax_errors');
+const adminDuration = new Trend('admin_page_duration', true);
+
+export const options = {
+  scenarios: {
+    // Steady-state: 20 admin page loads per second for 2 minutes
+    steady_state: {
+      executor: 'constant-arrival-rate',
+      rate: 20,
+      timeUnit: '1s',
+      duration: '2m',
+      preAllocatedVUs: 30,
+      maxVUs: 50,
+    },
+    // Spike: ramp from 5 to 50 RPS, hold, then back down
+    spike: {
+      executor: 'ramping-arrival-rate',
+      startRate: 5,
+      timeUnit: '1s',
+      stages: [
+        { duration: '15s', target: 50 },
+        { duration: '30s', target: 50 },
+        { duration: '15s', target: 5 },
+      ],
+      preAllocatedVUs: 60,
+      maxVUs: 100,
+      startTime: '2m30s', // starts after steady_state + 30s gap
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.05'],          // < 5% error rate
+    http_req_duration: ['p(95)<5000'],       // p95 < 5s
+    admin_page_duration: ['p(99)<8000'],     // p99 < 8s
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:10003';
+const WP_USER = __ENV.WP_USER || 'parhumm';
+const WP_PASS = __ENV.WP_PASS || 'testpass123';
+
+const ADMIN_PAGES = [
+  '/wp-admin/',
+  '/wp-admin/plugins.php',
+  '/wp-admin/options-general.php',
+  '/wp-admin/edit.php',
+  '/wp-admin/upload.php',
+  '/wp-admin/users.php',
+  '/wp-admin/tools.php',
+];
+
+export function setup() {
+  // Authenticate by POSTing to wp-login.php
+  const loginPage = http.get(`${BASE_URL}/wp-login.php`);
+
+  const loginRes = http.post(`${BASE_URL}/wp-login.php`, {
+    log: WP_USER,
+    pwd: WP_PASS,
+    'wp-submit': 'Log In',
+    redirect_to: `${BASE_URL}/wp-admin/`,
+    testcookie: '1',
+  }, {
+    redirects: 0, // Don't follow redirect, just capture cookies
+  });
+
+  // Verify login succeeded (302 redirect to admin)
+  const loginOk = loginRes.status === 302 || loginRes.status === 200;
+  if (!loginOk) {
+    console.error(`Login failed with status ${loginRes.status}`);
+  }
+
+  return { loginOk };
+}
+
+export default function (_data) {
+  // Pick a random admin page
+  const page = ADMIN_PAGES[Math.floor(Math.random() * ADMIN_PAGES.length)];
+
+  const res = http.get(`${BASE_URL}${page}`, {
+    tags: { page_type: 'admin', page_name: page },
+  });
+
+  const ok = check(res, {
+    'status is 200': (r) => r.status === 200,
+    'not 500 error': (r) => r.status < 500,
+    'body is not empty': (r) => r.body && r.body.length > 100,
+    'contains wp-admin content': (r) => r.body && r.body.includes('wp-admin'),
+  });
+
+  adminDuration.add(res.timings.duration);
+
+  if (!ok || res.status >= 500) {
+    ajaxErrors.add(1);
+  }
+
+  // Minimal think time — we want high load
+  sleep(0.05);
+}
+
+export function teardown(_data) {
+  // Try to read the AJAX log via direct HTTP (if accessible)
+  const logRes = http.get(`${BASE_URL}/wp-content/geoip-ajax-calls.log`);
+  if (logRes.status === 200 && logRes.body) {
+    const lines = logRes.body.trim().split('\n').filter((l) => l.length > 0);
+    console.log(`\n========================================`);
+    console.log(`GeoIP AJAX handler invocations: ${lines.length}`);
+    console.log(`Expected: 0-1 (fix working) or 0 (provider disabled)`);
+    console.log(`Old bug would produce: hundreds to thousands`);
+    console.log(`========================================\n`);
+
+    if (lines.length > 10) {
+      console.warn(`WARNING: ${lines.length} AJAX calls detected — possible regression!`);
+    }
+  } else {
+    console.log('Could not read AJAX log (may not be HTTP-accessible). Check file directly.');
+  }
+}

--- a/tests/resolve-geolocation-provider-test.php
+++ b/tests/resolve-geolocation-provider-test.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * Tests for wp_slimstat::resolve_geolocation_provider()
+ *
+ * Covers: PR #166 — GeoIP infinite AJAX loop fix
+ * Source: wp-slimstat.php:359-379
+ *
+ * Run: php tests/resolve-geolocation-provider-test.php
+ */
+
+declare(strict_types=1);
+
+$assertions = 0;
+
+function assert_same($expected, $actual, string $message): void
+{
+    global $assertions;
+    $assertions++;
+
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message} (expected " . var_export($expected, true) . ', got ' . var_export($actual, true) . ")\n");
+        exit(1);
+    }
+}
+
+// Mock WordPress sanitize_text_field: strip tags, trim whitespace, remove extra spaces
+function sanitize_text_field($str)
+{
+    $str = (string) $str;
+    $str = strip_tags($str);
+    $str = trim($str);
+    $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
+    return $str;
+}
+
+/**
+ * Minimal wp_slimstat stub with the real resolve_geolocation_provider() logic.
+ * Copied from wp-slimstat.php:359-379 (commit 7ba56338).
+ */
+class wp_slimstat
+{
+    public static $settings = [];
+
+    public static function resolve_geolocation_provider()
+    {
+        if (isset(self::$settings['geolocation_provider'])) {
+            $p = sanitize_text_field(self::$settings['geolocation_provider']);
+            if ('disable' === $p) {
+                return false;
+            }
+            if (in_array($p, ['maxmind', 'dbip', 'cloudflare'], true)) {
+                return $p;
+            }
+            // Invalid/empty value — fall through to legacy flag
+        }
+        $em = self::$settings['enable_maxmind'] ?? 'disable';
+        if ('on' === $em) {
+            return 'maxmind';
+        }
+        if ('no' === $em) {
+            return 'dbip';
+        }
+        return false;
+    }
+}
+
+// Helper to reset settings between tests
+function set_settings(array $settings): void
+{
+    wp_slimstat::$settings = $settings;
+}
+
+// ─── New geolocation_provider setting (explicit) ───────────────────
+
+set_settings(['geolocation_provider' => 'maxmind', 'enable_maxmind' => 'on']);
+assert_same('maxmind', wp_slimstat::resolve_geolocation_provider(), 'explicit maxmind returns maxmind');
+
+set_settings(['geolocation_provider' => 'dbip', 'enable_maxmind' => 'no']);
+assert_same('dbip', wp_slimstat::resolve_geolocation_provider(), 'explicit dbip returns dbip');
+
+set_settings(['geolocation_provider' => 'cloudflare', 'enable_maxmind' => 'no']);
+assert_same('cloudflare', wp_slimstat::resolve_geolocation_provider(), 'explicit cloudflare returns cloudflare');
+
+set_settings(['geolocation_provider' => 'disable', 'enable_maxmind' => 'disable']);
+assert_same(false, wp_slimstat::resolve_geolocation_provider(), 'explicit disable returns false');
+
+// ─── New setting takes priority over legacy flag ───────────────────
+
+set_settings(['geolocation_provider' => 'dbip', 'enable_maxmind' => 'on']);
+assert_same('dbip', wp_slimstat::resolve_geolocation_provider(), 'new setting overrides legacy: dbip over on');
+
+set_settings(['geolocation_provider' => 'disable', 'enable_maxmind' => 'on']);
+assert_same(false, wp_slimstat::resolve_geolocation_provider(), 'new setting overrides legacy: disable over on');
+
+// ─── Invalid / malformed geolocation_provider falls to legacy ──────
+
+set_settings(['geolocation_provider' => '', 'enable_maxmind' => 'on']);
+assert_same('maxmind', wp_slimstat::resolve_geolocation_provider(), 'empty string falls through to legacy on');
+
+set_settings(['geolocation_provider' => '', 'enable_maxmind' => 'no']);
+assert_same('dbip', wp_slimstat::resolve_geolocation_provider(), 'empty string falls through to legacy no');
+
+set_settings(['geolocation_provider' => 'invalid_value', 'enable_maxmind' => 'on']);
+assert_same('maxmind', wp_slimstat::resolve_geolocation_provider(), 'invalid value falls through to legacy on');
+
+set_settings(['geolocation_provider' => 'invalid_value', 'enable_maxmind' => 'disable']);
+assert_same(false, wp_slimstat::resolve_geolocation_provider(), 'invalid value + disabled legacy returns false');
+
+set_settings(['geolocation_provider' => '<script>alert(1)</script>', 'enable_maxmind' => 'no']);
+assert_same('dbip', wp_slimstat::resolve_geolocation_provider(), 'XSS payload is sanitized and falls through to legacy');
+
+set_settings(['geolocation_provider' => 'MAXMIND', 'enable_maxmind' => 'on']);
+assert_same('maxmind', wp_slimstat::resolve_geolocation_provider(), 'uppercase MAXMIND is not in allowlist, falls to legacy on');
+
+set_settings(['geolocation_provider' => 'MAXMIND', 'enable_maxmind' => 'disable']);
+assert_same(false, wp_slimstat::resolve_geolocation_provider(), 'uppercase MAXMIND + disabled legacy returns false');
+
+// ─── Whitespace trimming (sanitize_text_field trims) ───────────────
+
+set_settings(['geolocation_provider' => ' maxmind ', 'enable_maxmind' => 'no']);
+assert_same('maxmind', wp_slimstat::resolve_geolocation_provider(), 'whitespace-padded maxmind is trimmed and matched');
+
+set_settings(['geolocation_provider' => ' disable ', 'enable_maxmind' => 'on']);
+assert_same(false, wp_slimstat::resolve_geolocation_provider(), 'whitespace-padded disable is trimmed and returns false');
+
+// ─── Legacy flag only (no geolocation_provider set) ────────────────
+
+set_settings(['enable_maxmind' => 'on']);
+assert_same('maxmind', wp_slimstat::resolve_geolocation_provider(), 'legacy on returns maxmind');
+
+set_settings(['enable_maxmind' => 'no']);
+assert_same('dbip', wp_slimstat::resolve_geolocation_provider(), 'legacy no returns dbip');
+
+set_settings(['enable_maxmind' => 'disable']);
+assert_same(false, wp_slimstat::resolve_geolocation_provider(), 'legacy disable returns false');
+
+// ─── Fresh install (neither setting exists) ────────────────────────
+
+set_settings([]);
+assert_same(false, wp_slimstat::resolve_geolocation_provider(), 'empty settings (fresh install) returns false');
+
+set_settings(['some_other_setting' => 'value']);
+assert_same(false, wp_slimstat::resolve_geolocation_provider(), 'unrelated settings only returns false');
+
+// ─── Edge: enable_maxmind has unexpected value ─────────────────────
+
+set_settings(['enable_maxmind' => 'yes']);
+assert_same(false, wp_slimstat::resolve_geolocation_provider(), 'unexpected legacy value "yes" returns false');
+
+set_settings(['enable_maxmind' => '']);
+assert_same(false, wp_slimstat::resolve_geolocation_provider(), 'empty legacy value returns false');
+
+// ─── Edge: geolocation_provider is set but not a string ────────────
+// sanitize_text_field casts to string, so numeric values become strings
+
+set_settings(['geolocation_provider' => 0, 'enable_maxmind' => 'on']);
+assert_same('maxmind', wp_slimstat::resolve_geolocation_provider(), 'numeric 0 is set (isset=true), sanitized to "0", not in allowlist, falls to legacy');
+
+set_settings(['geolocation_provider' => null]);
+// null makes isset() return false, so falls to legacy
+assert_same(false, wp_slimstat::resolve_geolocation_provider(), 'null geolocation_provider: isset returns false, falls to legacy default');
+
+echo "All {$assertions} assertions passed in resolve-geolocation-provider-test.php\n";

--- a/tests/run-qa.sh
+++ b/tests/run-qa.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# Orchestrates the full QA simulation for PR #166 (GeoIP infinite AJAX loop fix).
+# Manages DISABLE_WP_CRON, mu-plugin logger, DB state, and runs both Playwright and k6.
+#
+# Usage: bash tests/run-qa.sh [--e2e-only | --perf-only]
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
+WP_ROOT="/Users/parhumm/Local Sites/test/app/public"
+WP_CONFIG="$WP_ROOT/wp-config.php"
+MU_PLUGINS="$WP_ROOT/wp-content/mu-plugins"
+AJAX_LOG="$WP_ROOT/wp-content/geoip-ajax-calls.log"
+MYSQL_SOCKET="/Users/parhumm/Library/Application Support/Local/run/X-JdmZXIa/mysql/mysqld.sock"
+
+RUN_E2E=true
+RUN_PERF=true
+if [[ "${1:-}" == "--e2e-only" ]]; then RUN_PERF=false; fi
+if [[ "${1:-}" == "--perf-only" ]]; then RUN_E2E=false; fi
+
+# Colors
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; NC='\033[0m'
+
+echo -e "${YELLOW}=== GeoIP AJAX Loop QA Simulation ===${NC}"
+echo "Plugin: $PLUGIN_DIR"
+echo "WP Root: $WP_ROOT"
+echo ""
+
+# ─── Phase 0: Verify site is running ─────────────────────────────────
+
+echo -n "Checking site availability... "
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:10003/wp-login.php 2>/dev/null || echo "000")
+if [[ "$HTTP_CODE" != "200" ]]; then
+  echo -e "${RED}FAIL${NC} (HTTP $HTTP_CODE)"
+  echo "Start Local by Flywheel first."
+  exit 1
+fi
+echo -e "${GREEN}OK${NC} (HTTP $HTTP_CODE)"
+
+# ─── Phase 1: Backup wp-config.php ───────────────────────────────────
+
+echo -n "Backing up wp-config.php... "
+cp "$WP_CONFIG" "$WP_CONFIG.qa-backup"
+echo -e "${GREEN}OK${NC}"
+
+# Cleanup trap: always restore on exit
+cleanup() {
+  echo ""
+  echo -e "${YELLOW}=== Cleanup ===${NC}"
+  if [[ -f "$WP_CONFIG.qa-backup" ]]; then
+    mv "$WP_CONFIG.qa-backup" "$WP_CONFIG"
+    echo "Restored wp-config.php"
+  fi
+  rm -f "$MU_PLUGINS/geoip-ajax-logger.php"
+  echo "Removed mu-plugin logger"
+  rm -f "$AJAX_LOG"
+  echo "Cleared AJAX log"
+}
+trap cleanup EXIT
+
+# ─── Phase 2: Run Playwright E2E tests ───────────────────────────────
+# Playwright tests manage their own DISABLE_WP_CRON, mu-plugin, and DB state
+# via beforeEach/afterEach, so we run them on a clean environment first.
+
+E2E_EXIT=0
+if $RUN_E2E; then
+  echo ""
+  echo -e "${YELLOW}=== Running Playwright E2E Tests ===${NC}"
+  cd "$PLUGIN_DIR"
+  npx playwright test --config=tests/e2e/playwright.config.ts || E2E_EXIT=$?
+
+  if [[ $E2E_EXIT -eq 0 ]]; then
+    echo -e "${GREEN}Playwright admin tests PASSED${NC}"
+  else
+    echo -e "${RED}Playwright admin tests FAILED (exit $E2E_EXIT)${NC}"
+  fi
+
+  # Print AJAX log state after E2E
+  echo ""
+  echo "AJAX calls after E2E:"
+  if [[ -f "$AJAX_LOG" ]]; then
+    AJAX_COUNT=$(wc -l < "$AJAX_LOG" | tr -d ' ')
+    echo "  Logged invocations: $AJAX_COUNT"
+    if [[ "$AJAX_COUNT" -gt 10 ]]; then
+      echo -e "  ${RED}WARNING: Excessive AJAX calls!${NC}"
+    fi
+  else
+    echo "  No AJAX log (0 calls)"
+  fi
+fi
+
+# ─── Phase 3: Prepare environment for k6 ─────────────────────────────
+
+echo -n "Adding DISABLE_WP_CRON to wp-config.php... "
+if ! grep -q "DISABLE_WP_CRON" "$WP_CONFIG"; then
+  sed -i '' "/That's all, stop editing/i\\
+define('DISABLE_WP_CRON', true);
+" "$WP_CONFIG"
+fi
+echo -e "${GREEN}OK${NC}"
+
+echo -n "Installing mu-plugin AJAX logger... "
+mkdir -p "$MU_PLUGINS"
+cp "$SCRIPT_DIR/e2e/helpers/ajax-logger-mu-plugin.php" "$MU_PLUGINS/geoip-ajax-logger.php"
+echo -e "${GREEN}OK${NC}"
+
+echo -n "Clearing state for k6... "
+rm -f "$AJAX_LOG"
+mysql --socket="$MYSQL_SOCKET" -u root -proot local -e \
+  "DELETE FROM wp_options WHERE option_name = 'slimstat_last_geoip_dl';" 2>/dev/null
+echo -e "${GREEN}OK${NC}"
+
+# ─── Phase 4: Run k6 load test ───────────────────────────────────────
+
+K6_EXIT=0
+if $RUN_PERF; then
+  echo ""
+  echo -e "${YELLOW}=== Running k6 Load Test ===${NC}"
+  cd "$PLUGIN_DIR"
+  k6 run tests/perf/geoip-load.js || K6_EXIT=$?
+
+  if [[ $K6_EXIT -eq 0 ]]; then
+    echo -e "${GREEN}k6 load test PASSED${NC}"
+  else
+    echo -e "${RED}k6 load test FAILED (exit $K6_EXIT)${NC}"
+  fi
+fi
+
+# ─── Phase 7: Post-test DB verification ──────────────────────────────
+
+echo ""
+echo -e "${YELLOW}=== Post-Test Verification ===${NC}"
+
+echo "slimstat_last_geoip_dl:"
+mysql --socket="$MYSQL_SOCKET" -u root -proot local -e \
+  "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_last_geoip_dl';" 2>/dev/null || echo "  (not set)"
+
+echo ""
+echo "AJAX handler invocations:"
+if [[ -f "$AJAX_LOG" ]]; then
+  FINAL_COUNT=$(wc -l < "$AJAX_LOG" | tr -d ' ')
+  echo "  Total: $FINAL_COUNT"
+  if [[ "$FINAL_COUNT" -gt 10 ]]; then
+    echo -e "  ${RED}FAIL: Excessive AJAX calls detected — possible infinite loop regression${NC}"
+  else
+    echo -e "  ${GREEN}PASS: AJAX count is bounded${NC}"
+  fi
+else
+  echo -e "  Total: 0 — ${GREEN}PASS${NC}"
+fi
+
+# ─── Phase 8: Summary ────────────────────────────────────────────────
+
+echo ""
+echo -e "${YELLOW}=== Summary ===${NC}"
+TOTAL_EXIT=$((E2E_EXIT + K6_EXIT))
+if [[ $TOTAL_EXIT -eq 0 ]]; then
+  echo -e "${GREEN}All QA tests PASSED${NC}"
+else
+  echo -e "${RED}Some tests FAILED (E2E=$E2E_EXIT, k6=$K6_EXIT)${NC}"
+fi
+
+exit $TOTAL_EXIT

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -166,8 +166,9 @@ class wp_slimstat
         }
 
         if (empty(self::$settings)) {
-            // Save the default values in the database
-            self::update_option('slimstat_options', self::init_options());
+            // Fresh install: set defaults including geolocation_provider=dbip
+            self::$settings = self::get_fresh_defaults();
+            self::update_option('slimstat_options', self::$settings);
         }
 
         self::$settings = array_merge(self::init_options(), self::$settings);
@@ -805,6 +806,25 @@ class wp_slimstat
         return $date;
     }
     // end date_i18n
+
+    /**
+     * Returns default options with fresh-install additions (e.g. geolocation_provider).
+     * Used by init() for new installs and by admin reset-settings.
+     */
+    public static function get_fresh_defaults()
+    {
+        $defaults = self::init_options();
+        $defaults['geolocation_provider'] = 'dbip';
+        return $defaults;
+    }
+
+    /**
+     * Returns the current geolocation precision ('country' or 'city').
+     */
+    public static function get_geolocation_precision()
+    {
+        return ('on' == self::$settings['geolocation_country']) ? 'country' : 'city';
+    }
 
     /**
      * Sets the default values for all the options

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -359,8 +359,14 @@ class wp_slimstat
     public static function resolve_geolocation_provider()
     {
         if (isset(self::$settings['geolocation_provider'])) {
-            $p = self::$settings['geolocation_provider'];
-            return 'disable' === $p ? false : $p;
+            $p = sanitize_text_field(self::$settings['geolocation_provider']);
+            if ('disable' === $p) {
+                return false;
+            }
+            if (in_array($p, ['maxmind', 'dbip', 'cloudflare'], true)) {
+                return $p;
+            }
+            // Invalid/empty value — fall through to legacy flag
         }
         $em = self::$settings['enable_maxmind'] ?? 'disable';
         if ('on' === $em) {

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -349,6 +349,30 @@ class wp_slimstat
     }
 
     /**
+     * Resolve the active geolocation provider.
+     *
+     * New UI sets 'geolocation_provider' explicitly (incl. 'disable').
+     * Legacy installs only have 'enable_maxmind' (tri-state: 'on', 'no', 'disable').
+     *
+     * @return string|false  'maxmind', 'dbip', 'cloudflare', or false if disabled
+     */
+    public static function resolve_geolocation_provider()
+    {
+        if (isset(self::$settings['geolocation_provider'])) {
+            $p = self::$settings['geolocation_provider'];
+            return 'disable' === $p ? false : $p;
+        }
+        $em = self::$settings['enable_maxmind'] ?? 'disable';
+        if ('on' === $em) {
+            return 'maxmind';
+        }
+        if ('no' === $em) {
+            return 'dbip';
+        }
+        return false;
+    }
+
+    /**
      * Decodes the permalink
      */
     public static function get_request_uri()
@@ -1204,7 +1228,10 @@ class wp_slimstat
         if ($last_update < $this_update) {
 
             // Determine which geolocation provider to use
-            $provider = self::$settings['geolocation_provider'] ?? 'dbip';
+            $provider = self::resolve_geolocation_provider();
+            if (false === $provider) {
+                return;
+            }
 
             $geographicProvider = new \SlimStat\Services\Geolocation\GeolocationService($provider, []);
 


### PR DESCRIPTION
## Summary

Closes #164

This PR fixes the infinite GeoIP AJAX loop when WP-Cron is disabled, wires the Cloudflare geolocation provider into the tracking pipeline, and fixes several related geolocation bugs that affected fresh installs, legacy upgrades, and admin page stability.

## What changed for users

### Fresh installs
- Geolocation now works out of the box — defaults to DB-IP provider (previously no provider was set, silently disabling geolocation)

### Existing installs (upgrading)
- Sites with legacy `enable_maxmind` setting are automatically migrated to the new `geolocation_provider` setting
- `enable_maxmind=on` maps to `maxmind`, `enable_maxmind=no` maps to `dbip`, `enable_maxmind=disable` maps to `disable`
- No action required from the user

### Cloudflare users
- Cloudflare geolocation provider now fully works end-to-end — country, city, subdivision, and coordinates are tracked when Cloudflare headers are present
- Previously, selecting Cloudflare in settings had no effect on tracking

### Sites with WP-Cron disabled
- Fixed infinite AJAX loop that could generate hundreds of thousands of requests per minute
- GeoIP update fallback now fires at most once, with proper guards against recursion

### Admin stability
- Settings pages no longer crash (fatal error) when a non-database provider like Cloudflare or Disabled is selected
- "Update Database" and "Check Database" buttons gracefully handle non-DB providers

## Bugs fixed

| # | Bug | Impact | Fix |
|---|-----|--------|-----|
| A | GeoIP AJAX fallback fires on every `init` when cron disabled | Server overload, infinite loop | Guard: `is_admin() && !wp_doing_ajax() && current_user_can()` |
| B | AJAX handler never updates `slimstat_last_geoip_dl` timestamp | Loop never stops | `update_option('slimstat_last_geoip_dl', time())` on success |
| C | 12+ inconsistent provider defaults (`?? 'maxmind'` / `?? 'dbip'`) | Wrong provider used in different code paths | Centralized `resolve_geolocation_provider()` |
| D | Fresh installs have no `geolocation_provider` default | Geolocation silently disabled | `get_fresh_defaults()` sets `geolocation_provider=dbip` |
| E | `isGeoIPEnabled()` excluded Cloudflare | Cloudflare provider never ran | Removed Cloudflare exclusion |
| F | Processor hardcoded `'maxmind'` or `'dbip'` | Cloudflare/disable never passed to factory | Uses `resolve_geolocation_provider()` directly |
| G | `checkDatabase()`/`deleteDatabaseFile()` called `getDbPath()` on Cloudflare | Fatal error on admin pages | Guard with `DB_PROVIDERS` constant |
| H | Cloudflare returns `region` key, Processor reads `subdivision` | Region data lost in city precision mode | `region` mapped to `subdivision` |
| I | Cloudflare early return skips timestamp update | Loop continues for Cloudflare users | Timestamp set before `wp_send_json_success` |
| J | Legacy `enable_maxmind` not migrated on upgrade | Wrong provider in settings dropdown | Lazy migration in `resolve_geolocation_provider()` |

## Code architecture changes

- **`resolve_geolocation_provider()`** — single source of truth for active provider, handles legacy migration
- **`get_fresh_defaults()`** — centralized install defaults, used in both `init()` and admin reset
- **`get_geolocation_precision()`** — eliminates duplicated country/city precision logic
- **`DB_PROVIDERS` constant** — `['maxmind', 'dbip']` used everywhere to guard DB-specific operations
- **Processor hot path** — removed unnecessary `GeoService` object instantiation per pageview

## Files changed (33 files, +2411 / -110)

**Core plugin:**
- `wp-slimstat.php` — `resolve_geolocation_provider()`, `get_fresh_defaults()`, `get_geolocation_precision()`, init() fix
- `src/Tracker/Processor.php` — Direct resolver usage, removed GeoService dependency
- `src/Services/GeoService.php` — `DB_PROVIDERS` constant, guards, fixed `isGeoIPEnabled()`
- `src/Services/Geolocation/Provider/CloudflareGeolocationProvider.php` — region to subdivision mapping

**Admin:**
- `admin/index.php` — Provider-aware AJAX handlers, DB_PROVIDERS guards
- `admin/config/index.php` — Lazy migration, save sync, reset uses `get_fresh_defaults()`
- `admin/view/index.php` — Provider-aware GeoIP notice
- `admin/view/wp-slimstat-reports.php` — Provider-aware GeoIP notice

**Tests (new):**
- 5 PHP unit test files (67 assertions): provider resolution, GeoService, legacy sync, lazy migration, license tags
- 8 E2E tests: geolocation provider pipeline (fresh install, 3 legacy upgrades, DB-IP, Cloudflare with header injection, disabled, admin pages)
- 6 E2E tests: GeoIP AJAX loop prevention
- k6 load test for AJAX loop verification
- Test infrastructure: option-mutator mu-plugin, AJAX logger, Playwright config

## Test results

All tests passing — see [test results comment](https://github.com/wp-slimstat/wp-slimstat/pull/166#issuecomment-4039236169) for details.

- 67 PHP unit assertions across 5 test files
- 8 E2E geolocation provider pipeline tests
- 6 E2E AJAX loop regression tests
