### PR TITLE
Fix GDPR banner CSS breaking third-party lightboxes (#167)

### DIFF
--- a/assets/css/gdpr-banner.css
+++ b/assets/css/gdpr-banner.css
@@ -462,9 +462,13 @@
     }
 }
 
-/* Reduced motion support */
+/* Reduced motion support — scoped to SlimStat elements only (#167) */
 @media (prefers-reduced-motion: reduce) {
-    * {
+    #slimstat-gdpr-banner,
+    #slimstat-gdpr-banner *,
+    .slimstat-gdpr-management,
+    .slimstat-gdpr-management *,
+    .slimstat-consent-status {
         animation-duration: 0.01ms !important;
         animation-iteration-count: 1 !important;
         transition-duration: 0.01ms !important;


### PR DESCRIPTION
## Summary

- Scope `@media (prefers-reduced-motion: reduce)` CSS rule from global `*` selector to SlimStat elements only (`#slimstat-gdpr-banner`, `.slimstat-gdpr-management`, `.slimstat-consent-status`)
- The global `*` selector with `!important` was killing all CSS transitions/animations site-wide, breaking third-party plugins like FancyBox V2 / Firelight Lightbox when the user's OS has reduced-motion accessibility enabled

## Test plan

- [ ] Enable OS reduced motion (macOS: System Settings > Accessibility > Display > Reduce motion)
- [ ] Load a page with SlimStat GDPR banner active — verify banner still skips animations
- [ ] With a transition-heavy plugin (e.g., any lightbox), verify third-party transitions work normally
- [ ] Disable reduced motion — verify no behavioral change

Fixes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the GDPR banner's handling of motion preferences to apply only to relevant banner elements, improving performance and ensuring more targeted respect for user accessibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->