### PR TITLE
fix(geoip): prevent infinite AJAX loop when WP-Cron is disabled (#164)

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -293,7 +293,7 @@ class wp_slimstat_admin
         // Fallback: if WP-Cron is disabled or scheduling failed, trigger a non-blocking direct update
         // This ensures environments with DISABLE_WP_CRON still receive GeoIP database updates
         $cron_disabled = (defined('DISABLE_WP_CRON') && DISABLE_WP_CRON) || !wp_next_scheduled('wp_slimstat_update_geoip_database');
-        if ($cron_disabled) {
+        if ($cron_disabled && !wp_doing_ajax()) {
             // Update if DB is missing or last update is older than the most recent past scheduled window
             $last_update = (int) get_option('slimstat_last_geoip_dl', 0);
 
@@ -2035,6 +2035,7 @@ class wp_slimstat_admin
             $ok      = $service->updateDatabase();
 
 			if ($ok) {
+                update_option('slimstat_last_geoip_dl', time());
                 wp_send_json_success(__('GeoIP Database Successfully Updated!', 'wp-slimstat'));
             } else {
                 // Log the error for debugging


### PR DESCRIPTION
Root cause: When DISABLE_WP_CRON is true, the GeoIP fallback fires on every admin page load. Each AJAX request triggers another request (no recursion guard), and the timestamp never updates, creating an infinite loop.

Fix:
1. Add !wp_doing_ajax() guard to prevent fallback from firing during AJAX requests
2. Update slimstat_last_geoip_dl timestamp after successful download so the condition becomes false

### Describe your changes
...

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the GeoIP database update mechanism to prevent redundant update attempts that may occur during simultaneous background processing operations, ensuring more efficient system resource utilization and better performance
  * Implemented automatic timestamp tracking for all successful GeoIP database updates, providing better visibility and audit capability for database maintenance activities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->