### PR TITLE
Fix: Prevent missing dependency error when WP Consent API is not inst…

### DIFF
--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -1095,7 +1095,10 @@ class wp_slimstat
         // Add dependencies for consent integrations (e.g., WP Consent API)
         $dependencies = [];
         if ((self::$settings['consent_integration'] ?? '') === 'wp_consent_api') {
-            $dependencies[] = 'wp-consent-api';
+            // Only add dependency if the WP Consent API script is actually registered
+            if (wp_script_is('wp-consent-api', 'registered') || wp_script_is('wp-consent-api', 'enqueued')) {
+                $dependencies[] = 'wp-consent-api';
+            }
         }
 
         // Register the correct script for adblock bypass, CDN, or default


### PR DESCRIPTION
…alled

Check if wp-consent-api script is registered before adding it as a dependency. This fixes the issue where settings page would not load when consent_integration was set to wp_consent_api but the plugin was not installed.

### Describe your changes
...

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved consent API integration loading behavior to occur only when necessary, enhancing script performance and dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->