### PR TITLE
fix(tracking): resolve sendBeacon + REST interaction tracking regression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,12 +41,14 @@
     "test:geoservice": "php tests/geoservice-provider-resolution-test.php",
     "test:legacy-sync": "php tests/legacy-sync-mapping-test.php",
     "test:lazy-migration": "php tests/lazy-migration-test.php",
+    "test:rest-controller": "php tests/tracking-rest-controller-test.php",
     "test:all": [
       "@test:license-tags",
       "@test:geoip-resolver",
       "@test:geoservice",
       "@test:legacy-sync",
-      "@test:lazy-migration"
+      "@test:lazy-migration",
+      "@test:rest-controller"
     ]
   }
 }

--- a/src/Controllers/Rest/TrackingRestController.php
+++ b/src/Controllers/Rest/TrackingRestController.php
@@ -128,17 +128,31 @@ class TrackingRestController implements RestControllerInterface
         // Ensure tracking payload is available to the Ajax handler even for REST requests.
         // The tracker reads wp_slimstat::$raw_post_array, which may be empty for REST JSON bodies.
         if (class_exists('\wp_slimstat')) {
-            $payload = $request->get_params();
-            if (!is_array($payload)) {
-                $payload = [];
+            $rest_params = $request->get_params();
+            if (!is_array($rest_params)) {
+                $rest_params = [];
             }
 
-            // Sanitize known scalar keys explicitly; preserve all other keys for extension compatibility
-            $scalar_keys = ['action', 'n', 'bw', 'bh', 'ref', 'res', 'lt', 'dc', 'ob', 'ss_nonce'];
-            foreach ($scalar_keys as $key) {
-                if (isset($payload[$key])) {
-                    $payload[$key] = sanitize_text_field(wp_unslash((string) $payload[$key]));
+            // Sanitize known scalar keys from REST params (skip when empty — common for sendBeacon)
+            if (!empty($rest_params)) {
+                $scalar_keys = ['action', 'n', 'bw', 'bh', 'ref', 'res', 'lt', 'dc', 'ob', 'ss_nonce'];
+                foreach ($scalar_keys as $key) {
+                    if (isset($rest_params[$key])) {
+                        $rest_params[$key] = sanitize_text_field(wp_unslash((string) $rest_params[$key]));
+                    }
                 }
+            }
+
+            // For sendBeacon text/plain requests, php://input was already correctly
+            // parsed at plugin init (wp-slimstat.php:1559-1575). REST API cannot parse
+            // text/plain bodies, so get_params() returns incomplete data. Merge to
+            // preserve init-parsed data while letting REST-sanitized params override.
+            if (!empty(\wp_slimstat::$raw_post_array)) {
+                $payload = !empty($rest_params)
+                    ? array_merge(\wp_slimstat::$raw_post_array, $rest_params)
+                    : \wp_slimstat::$raw_post_array;
+            } else {
+                $payload = $rest_params;
             }
 
             $payload['action'] = 'slimtrack';

--- a/src/Utils/Query.php
+++ b/src/Utils/Query.php
@@ -26,6 +26,8 @@ class Query
 
     private $setClauses = [];
 
+    private $setValuesToPrepare = [];
+
     private $joinClauses = [];
 
     private $whereClauses = [];
@@ -206,11 +208,11 @@ class Query
         foreach ($values as $field => $value) {
             $column = '`' . str_replace('`', '``', $field) . '`';
             if (is_string($value)) {
-                $this->setClauses[]      = sprintf('%s = %%s', $column);
-                $this->valuesToPrepare[] = $value;
+                $this->setClauses[]           = sprintf('%s = %%s', $column);
+                $this->setValuesToPrepare[]   = $value;
             } elseif (is_numeric($value)) {
-                $this->setClauses[]      = sprintf('%s = %%s', $column);
-                $this->valuesToPrepare[] = $value;
+                $this->setClauses[]           = sprintf('%s = %%s', $column);
+                $this->setValuesToPrepare[]   = $value;
             } elseif (is_null($value)) {
                 $this->setClauses[] = $column . ' = NULL';
             }
@@ -231,7 +233,7 @@ class Query
     {
         $this->setClauses[] = sprintf('`%s` = %s', str_replace('`', '``', $column), $expression);
         if (!empty($params)) {
-            $this->valuesToPrepare = array_merge($this->valuesToPrepare, $params);
+            $this->setValuesToPrepare = array_merge($this->setValuesToPrepare, $params);
         }
 
         return $this;
@@ -1280,7 +1282,9 @@ class Query
             return false;
         }
 
-        $prepared_query = $this->prepareQuery($query, $this->valuesToPrepare);
+        // SET values must come before WHERE values to match SQL clause order
+        $allValues = array_merge($this->setValuesToPrepare, $this->valuesToPrepare);
+        $prepared_query = $this->prepareQuery($query, $allValues);
 
         $result = $this->db->query($prepared_query);
 
@@ -1294,7 +1298,9 @@ class Query
     public function getSqlQuery()
     {
         $query = $this->buildQuery();
-        return $this->prepareQuery($query, $this->valuesToPrepare);
+        // SET values must come before WHERE values to match SQL clause order
+        $allValues = array_merge($this->setValuesToPrepare, $this->valuesToPrepare);
+        return $this->prepareQuery($query, $allValues);
     }
 
     /**

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -267,6 +267,14 @@ export async function getLatestStat(testMarker: string): Promise<{ country: stri
   return rows.length > 0 ? rows[0] : null;
 }
 
+export async function getLatestStatFull(testMarker: string): Promise<{ id: number; resource: string; outbound_resource: string | null; dt_out: number; country: string; city: string } | null> {
+  const [rows] = await getPool().execute(
+    "SELECT id, resource, outbound_resource, dt_out, country, city FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id DESC LIMIT 1",
+    [`%${testMarker}%`]
+  ) as any;
+  return rows.length > 0 ? rows[0] : null;
+}
+
 export async function getLatestStatByIp(): Promise<{ country: string; city: string; location: string } | null> {
   const [rows] = await getPool().execute(
     "SELECT country, city, location FROM wp_slim_stats ORDER BY id DESC LIMIT 1"

--- a/tests/e2e/sendbeacon-interaction.spec.ts
+++ b/tests/e2e/sendbeacon-interaction.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * E2E tests: sendBeacon interaction tracking (#174).
+ *
+ * Verifies that outbound link clicks tracked via sendBeacon (text/plain)
+ * correctly populate outbound_resource and dt_out in the database.
+ * Regression guard for the TrackingRestController merge fix and Query
+ * builder SET/WHERE parameter ordering fix.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  installOptionMutator,
+  uninstallOptionMutator,
+  setSlimstatOption,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+  clearStatsTable,
+  getLatestStatFull,
+  closeDb,
+} from './helpers/setup';
+
+test.describe('sendBeacon Interaction Tracking (#174)', () => {
+  test.beforeAll(async () => {
+    installOptionMutator();
+  });
+
+  test.beforeEach(async () => {
+    await snapshotSlimstatOptions();
+    await clearStatsTable();
+  });
+
+  test.afterEach(async () => {
+    await restoreSlimstatOptions();
+  });
+
+  test.afterAll(async () => {
+    uninstallOptionMutator();
+    await closeDb();
+  });
+
+  test('outbound link click via sendBeacon populates outbound_resource and dt_out', async ({ page }) => {
+    test.setTimeout(60000);
+    await setSlimstatOption(page, 'gdpr_enabled', 'off');
+    // Force REST transport — this is the code path affected by #174
+    await setSlimstatOption(page, 'tracking_request_method', 'rest');
+    const marker = `outbound-test-${Date.now()}`;
+
+    // Capture the pageview ID (with checksum) from the REST response
+    let pageviewIdWithChecksum = '';
+    page.on('response', async (res) => {
+      if (res.url().includes('slimstat/v1/hit') || res.url().includes('rest_route=/slimstat')) {
+        try {
+          const body = await res.text();
+          const cleaned = body.replace(/^"|"$/g, '').trim();
+          if (/^\d+\./.test(cleaned)) {
+            pageviewIdWithChecksum = cleaned;
+          }
+        } catch {}
+      }
+    });
+
+    // 1. Visit a frontend page so the tracker initializes and creates a pageview
+    await page.goto(`/?p=${marker}`, { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(5000);
+
+    // Verify pageview was tracked in DB
+    const pageviewStat = await getLatestStatFull(marker);
+    expect(pageviewStat).not.toBeNull();
+    expect(pageviewStat!.id).toBeGreaterThan(0);
+    expect(pageviewIdWithChecksum).toBeTruthy();
+
+    // Get the REST endpoint URL from tracker params
+    const restUrl = await page.evaluate(() => (window as any).SlimStatParams?.ajaxurl_rest || '');
+    expect(restUrl).toBeTruthy();
+
+    // Use the client-side ID if available, otherwise use the captured response ID
+    const trackerClientId = await page.evaluate(() => (window as any).SlimStatParams?.id || '');
+    const idToUse = trackerClientId || pageviewIdWithChecksum;
+
+    // 2. Construct the interaction payload (same format the tracker sends for outbound clicks)
+    const outboundUrl = 'https://example.com/test-outbound-174';
+    const noteObj = JSON.stringify({ type: 'click', text: 'External Test Link', id: 'test-outbound-link' });
+
+    // 3. Send as text/plain — this is what navigator.sendBeacon uses.
+    //    Before the #174 fix, REST API couldn't parse text/plain, so the correctly
+    //    init-parsed data was overwritten with empty params.
+    const beaconRes = await page.request.post(restUrl, {
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+      data: await page.evaluate(({ id, outUrl, note }: { id: string; outUrl: string; note: string }) => {
+        const b64 = (s: string) => btoa(unescape(encodeURIComponent(s)));
+        return `action=slimtrack&id=${id}&res=${b64(outUrl)}&pos=100,200&no=${b64(note)}`;
+      }, { id: idToUse, outUrl: outboundUrl, note: noteObj }),
+    });
+    expect(beaconRes.status()).toBe(200);
+    await page.waitForTimeout(1000);
+
+    // 4. Assert outbound_resource and dt_out in database
+    const stat = await getLatestStatFull(marker);
+    expect(stat).not.toBeNull();
+    expect(stat!.outbound_resource).toBeTruthy();
+    expect(stat!.outbound_resource).toContain('example.com/test-outbound-174');
+    expect(stat!.dt_out).toBeGreaterThan(0);
+  });
+
+  test('pageview via XHR still works with REST transport (regression guard)', async ({ page }) => {
+    await setSlimstatOption(page, 'gdpr_enabled', 'off');
+    await setSlimstatOption(page, 'tracking_request_method', 'rest');
+    const marker = `pageview-regression-${Date.now()}`;
+
+    await page.goto(`/?p=${marker}`, { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(5000);
+
+    const stat = await getLatestStatFull(marker);
+    expect(stat).not.toBeNull();
+    expect(stat!.id).toBeGreaterThan(0);
+    expect(stat!.resource).toContain(marker);
+  });
+});

--- a/tests/stubs/slimstat-tracker-stub.php
+++ b/tests/stubs/slimstat-tracker-stub.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Namespaced stubs for SlimStat\Tracker and SlimStat\Services\Privacy.
+ * Must be in a separate file because PHP requires namespace declarations at the top.
+ */
+namespace SlimStat\Tracker {
+    if (!class_exists(__NAMESPACE__ . '\Tracker')) {
+        class Tracker {
+            public static function slimtrack_ajax() { return '1'; }
+        }
+    }
+}
+
+namespace SlimStat\Services\Privacy {
+    if (!class_exists(__NAMESPACE__ . '\ConsentHandler')) {
+        class ConsentHandler {
+            public static function handleBannerConsent($json = true, $data = null) { return true; }
+        }
+    }
+}

--- a/tests/stubs/tracking-stubs.php
+++ b/tests/stubs/tracking-stubs.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Stubs for TrackingRestController unit tests.
+ * Provides minimal WP and SlimStat class/function stubs.
+ */
+declare(strict_types=1);
+
+// ─── WordPress function stubs ────────────────────────────────────
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($str) { return is_string($str) ? trim(strip_tags($str)) : ''; }
+}
+if (!function_exists('wp_unslash')) {
+    function wp_unslash($value) { return is_string($value) ? stripslashes($value) : $value; }
+}
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = 'default') { return $text; }
+}
+if (!function_exists('rest_ensure_response')) {
+    function rest_ensure_response($data) { return $data; }
+}
+
+// ─── WP_REST_Request stub ────────────────────────────────────────
+if (!class_exists('WP_REST_Request')) {
+    class WP_REST_Request {
+        private array $params;
+        public function __construct(array $params = []) { $this->params = $params; }
+        public function get_params(): array { return $this->params; }
+        public function get_param(string $key) { return $this->params[$key] ?? null; }
+        public function get_body_params(): array { return []; }
+    }
+}
+
+// ─── wp_slimstat stub ────────────────────────────────────────────
+if (!class_exists('wp_slimstat')) {
+    class wp_slimstat {
+        public static array $raw_post_array = [];
+    }
+}
+
+// ─── WP_Error stub ───────────────────────────────────────────────
+if (!class_exists('WP_Error')) {
+    class WP_Error {
+        public function __construct($code = '', $message = '', $data = '') {}
+    }
+}

--- a/tests/tracking-rest-controller-test.php
+++ b/tests/tracking-rest-controller-test.php
@@ -19,14 +19,61 @@ if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__);
 }
 
+require_once __DIR__ . '/stubs/tracking-stubs.php';
+require_once __DIR__ . '/stubs/slimstat-tracker-stub.php';
 require_once __DIR__ . '/../src/Interfaces/RestControllerInterface.php';
 require_once __DIR__ . '/../src/Controllers/Rest/TrackingRestController.php';
 
 use SlimStat\Controllers\Rest\TrackingRestController;
 
+// ─── Section 1: sanitize_integer_param tests ─────────────────────
+
 assert_same(0, TrackingRestController::sanitize_integer_param('0', null, 'tz'), 'timezone zero should sanitize to 0');
 assert_same(-60, TrackingRestController::sanitize_integer_param('-60', null, 'tz'), 'negative timezone offsets must be preserved');
 assert_same(120, TrackingRestController::sanitize_integer_param('120', null, 'tz'), 'positive timezone offsets should sanitize to int');
 assert_same(0, TrackingRestController::sanitize_integer_param('bad-value', null, 'tz'), 'invalid timezone values should sanitize to 0');
+
+// ─── Section 2: handle_tracking merge behavior (#174) ────────────
+
+$controller = new TrackingRestController();
+
+// Test 2a: sendBeacon — init-parsed data preserved when REST returns empty
+wp_slimstat::$raw_post_array = [
+    'action' => 'slimtrack',
+    'id'     => '42.abc',
+    'res'    => 'aHR0cHM6Ly9leGFtcGxlLmNvbQ==',
+    'pos'    => '100,200',
+    'no'     => 'eyJ0eXBlIjoiY2xpY2sifQ==',
+    'fh'     => 'fp123',
+];
+$request = new WP_REST_Request([]); // empty — simulates text/plain sendBeacon
+$controller->handle_tracking($request);
+assert_same('42.abc', wp_slimstat::$raw_post_array['id'], 'sendBeacon: id preserved');
+assert_same('aHR0cHM6Ly9leGFtcGxlLmNvbQ==', wp_slimstat::$raw_post_array['res'], 'sendBeacon: res preserved');
+assert_same('100,200', wp_slimstat::$raw_post_array['pos'], 'sendBeacon: pos preserved');
+assert_same('eyJ0eXBlIjoiY2xpY2sifQ==', wp_slimstat::$raw_post_array['no'], 'sendBeacon: no preserved');
+assert_same('fp123', wp_slimstat::$raw_post_array['fh'], 'sendBeacon: fh preserved');
+assert_same('slimtrack', wp_slimstat::$raw_post_array['action'], 'sendBeacon: action forced to slimtrack');
+
+// Test 2b: XHR — REST params override init-parsed data for overlapping keys
+wp_slimstat::$raw_post_array = [
+    'action' => 'slimtrack',
+    'id'     => '42.abc',
+    'res'    => 'old_value',
+    'pos'    => '100,200',
+];
+$request = new WP_REST_Request(['id' => '99.xyz', 'res' => 'new_value']);
+$controller->handle_tracking($request);
+assert_same('99.xyz', wp_slimstat::$raw_post_array['id'], 'XHR: REST id overrides init id');
+assert_same('new_value', wp_slimstat::$raw_post_array['res'], 'XHR: REST res overrides init res');
+assert_same('100,200', wp_slimstat::$raw_post_array['pos'], 'XHR: init-only keys preserved');
+
+// Test 2c: Empty init — REST params used directly
+wp_slimstat::$raw_post_array = [];
+$request = new WP_REST_Request(['id' => '7.def', 'ref' => 'some_ref']);
+$controller->handle_tracking($request);
+assert_same('7.def', wp_slimstat::$raw_post_array['id'], 'empty init: REST id used');
+assert_same('some_ref', wp_slimstat::$raw_post_array['ref'], 'empty init: REST ref used');
+assert_same('slimtrack', wp_slimstat::$raw_post_array['action'], 'empty init: action forced');
 
 echo "All {$assertions} assertions passed in tracking-rest-controller-test.php\n";


### PR DESCRIPTION
## Summary

Fixes #174 — outbound link clicks, downloads, and exit-time updates were silently broken when using REST transport with `navigator.sendBeacon()`.

**Two root causes found and fixed:**

- **TrackingRestController overwrite** (`src/Controllers/Rest/TrackingRestController.php`): The handler unconditionally replaced `wp_slimstat::$raw_post_array` with `$request->get_params()`. Since WordPress REST API cannot parse `text/plain` bodies (what sendBeacon uses), this destroyed the correctly-parsed data from `php://input` at plugin init. Fixed by merging init-parsed data with REST params.

- **Query builder SET/WHERE parameter misalignment** (`src/Utils/Query.php`): The `valuesToPrepare` array was shared between `set()` and `where()` methods. In `Storage::updateRow()`, `where()` is chained before `set()`, so WHERE values preceded SET values in the flat array — but SQL requires SET values before WHERE values. This caused `wpdb->prepare()` to assign values to wrong placeholders (e.g., `dt_out` got the URL, `outbound_resource` got the IP hash). Fixed by using a separate `setValuesToPrepare` array merged in correct SQL order.

## Test plan

- [x] Unit tests: 16 assertions covering merge behavior for sendBeacon, XHR, and empty-init scenarios
- [x] All existing unit tests pass (83 assertions across 6 test files)
- [x] E2E test: simulates sendBeacon `text/plain` POST with interaction payload, asserts `outbound_resource` and `dt_out` populated in DB
- [x] E2E regression guard: pageview via XHR with REST transport still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced sendBeacon tracking for outbound link clicks with proper REST payload handling

* **Improvements**
  * Improved REST parameter sanitization and secure data merging from multiple sources
  * Better handling of tracking data preservation across different transport methods

* **Tests**
  * Added comprehensive test coverage for REST tracking parameter handling
  * Added end-to-end tests validating sendBeacon interactions and outbound resource recording

<!-- end of auto-generated comment: release notes by coderabbit.ai -->