### PR TITLE
fix(cron): only update geoip timestamp on successful download

### DIFF
--- a/tests/e2e/helpers/cron-frontend-shim-mu-plugin.php
+++ b/tests/e2e/helpers/cron-frontend-shim-mu-plugin.php
@@ -21,7 +21,7 @@ if (!defined('SLIMSTAT_E2E_TESTING') || SLIMSTAT_E2E_TESTING !== true) {
 // cookie-law-info loads wp-admin/includes/file.php on frontend, which
 // defeats the include-guard test. MU-plugins load before regular plugins,
 // so filtering option_active_plugins prevents it from loading.
-if (!empty($_GET['test_dbip_cron']) && $_GET['test_dbip_cron'] === 'provider') {
+if (!empty($_GET['test_dbip_cron']) && 'provider' === sanitize_text_field($_GET['test_dbip_cron'])) {
     add_filter('option_active_plugins', function ($plugins) {
         return array_values(array_filter($plugins, function ($p) {
             return strpos($p, 'cookie-law-info') === false;
@@ -65,16 +65,16 @@ add_action('template_redirect', function () {
         try {
             $provider = \wp_slimstat::resolve_geolocation_provider();
             if (false === $provider) {
-                echo json_encode(['success' => false, 'error' => 'provider_disabled',
+                echo wp_json_encode(['success' => false, 'error' => 'provider_disabled',
                                    'had_wp_tempnam_before' => $had_wp_tempnam_before]);
                 die();
             }
             $service = new \SlimStat\Services\Geolocation\GeolocationService($provider, []);
             $service->updateDatabase();
-            echo json_encode(['success' => true, 'error' => null,
+            echo wp_json_encode(['success' => true, 'error' => null,
                                'had_wp_tempnam_before' => $had_wp_tempnam_before]);
         } catch (\Throwable $e) {
-            echo json_encode(['success' => false, 'error' => $e->getMessage(),
+            echo wp_json_encode(['success' => false, 'error' => $e->getMessage(),
                                'class' => get_class($e),
                                'had_wp_tempnam_before' => $had_wp_tempnam_before]);
         }
@@ -97,7 +97,7 @@ add_action('template_redirect', function () {
 
         $ts_after = get_option('slimstat_last_geoip_dl', null);
 
-        echo json_encode([
+        echo wp_json_encode([
             'success'    => null === $caught_error,
             'error'      => $caught_error,
             'ts_before'  => $ts_before,
@@ -114,12 +114,12 @@ add_action('template_redirect', function () {
         try {
             \wp_slimstat::wp_slimstat_update_geoip_database();
             // If we get here, the callback caught the \Error internally
-            echo json_encode(['success' => true, 'error' => null,
+            echo wp_json_encode(['success' => true, 'error' => null,
                                'escaped_catch' => false,
                                'had_wp_tempnam_before' => $had_wp_tempnam_before]);
         } catch (\Throwable $e) {
             // If we get here, the callback did NOT catch the \Throwable
-            echo json_encode(['success' => false, 'error' => $e->getMessage(),
+            echo wp_json_encode(['success' => false, 'error' => $e->getMessage(),
                                'class' => get_class($e), 'escaped_catch' => true,
                                'had_wp_tempnam_before' => $had_wp_tempnam_before]);
         }

--- a/tests/e2e/helpers/cron-frontend-shim-mu-plugin.php
+++ b/tests/e2e/helpers/cron-frontend-shim-mu-plugin.php
@@ -78,6 +78,30 @@ add_action('template_redirect', function () {
                                'class' => get_class($e),
                                'had_wp_tempnam_before' => $had_wp_tempnam_before]);
         }
+    } elseif ($mode === 'callback_download_fail') {
+        // Test 4: Cron callback with failed download — tests timestamp NOT updated
+        // Stub HTTP to return WP_Error (download fails, updateDatabase returns false)
+        add_filter('pre_http_request', function () {
+            return new \WP_Error('test_stub', 'HTTP stubbed — simulated download failure');
+        }, 1);
+
+        // Snapshot the timestamp before the callback
+        $ts_before = get_option('slimstat_last_geoip_dl', null);
+
+        try {
+            \wp_slimstat::wp_slimstat_update_geoip_database();
+        } catch (\Throwable $e) {
+            // Should not happen for WP_Error stub, but catch just in case
+        }
+
+        $ts_after = get_option('slimstat_last_geoip_dl', null);
+
+        echo json_encode([
+            'success'    => true,
+            'ts_before'  => $ts_before,
+            'ts_after'   => $ts_after,
+            'ts_changed' => $ts_after !== $ts_before,
+        ]);
     } elseif ($mode === 'callback_throwable') {
         // Test 2: Cron callback with forced \Error — tests \Throwable catch
         // Stub HTTP to throw \Error (not \Exception) — simulates engine-level failure

--- a/tests/e2e/helpers/cron-frontend-shim-mu-plugin.php
+++ b/tests/e2e/helpers/cron-frontend-shim-mu-plugin.php
@@ -55,7 +55,7 @@ add_action('template_redirect', function () {
     // Record whether wp_tempnam was already defined (false-pass detection)
     $had_wp_tempnam_before = function_exists('wp_tempnam');
 
-    if ($mode === 'provider') {
+    if ('provider' === $mode) {
         // Test 1: Direct provider call — tests include guard
         // Stub HTTP to avoid network dependency (returns WP_Error)
         add_filter('pre_http_request', function () {
@@ -78,7 +78,7 @@ add_action('template_redirect', function () {
                                'class' => get_class($e),
                                'had_wp_tempnam_before' => $had_wp_tempnam_before]);
         }
-    } elseif ($mode === 'callback_download_fail') {
+    } elseif ('callback_download_fail' === $mode) {
         // Test 4: Cron callback with failed download — tests timestamp NOT updated
         // Stub HTTP to return WP_Error (download fails, updateDatabase returns false)
         add_filter('pre_http_request', function () {
@@ -87,22 +87,24 @@ add_action('template_redirect', function () {
 
         // Snapshot the timestamp before the callback
         $ts_before = get_option('slimstat_last_geoip_dl', null);
+        $caught_error = null;
 
         try {
             \wp_slimstat::wp_slimstat_update_geoip_database();
         } catch (\Throwable $e) {
-            // Should not happen for WP_Error stub, but catch just in case
+            $caught_error = $e->getMessage();
         }
 
         $ts_after = get_option('slimstat_last_geoip_dl', null);
 
         echo json_encode([
-            'success'    => true,
+            'success'    => null === $caught_error,
+            'error'      => $caught_error,
             'ts_before'  => $ts_before,
             'ts_after'   => $ts_after,
             'ts_changed' => $ts_after !== $ts_before,
         ]);
-    } elseif ($mode === 'callback_throwable') {
+    } elseif ('callback_throwable' === $mode) {
         // Test 2: Cron callback with forced \Error — tests \Throwable catch
         // Stub HTTP to throw \Error (not \Exception) — simulates engine-level failure
         add_filter('pre_http_request', function () {

--- a/tests/e2e/helpers/nonce-helper-mu-plugin.php
+++ b/tests/e2e/helpers/nonce-helper-mu-plugin.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * MU-plugin: Nonce creation helper for E2E tests.
+ *
+ * Provides a WP AJAX endpoint to create nonces for testing AJAX endpoints.
+ *
+ * POST /wp-admin/admin-ajax.php?action=test_create_nonce
+ * Body: nonce_action=<action_name>
+ */
+add_action('wp_ajax_test_create_nonce', function () {
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error('forbidden');
+    }
+
+    $nonce_action = sanitize_text_field($_POST['nonce_action'] ?? '');
+    if (empty($nonce_action)) {
+        wp_send_json_error('missing nonce_action');
+    }
+
+    $nonce = wp_create_nonce($nonce_action);
+    wp_send_json_success(['nonce' => $nonce]);
+});

--- a/tests/e2e/helpers/nonce-helper-mu-plugin.php
+++ b/tests/e2e/helpers/nonce-helper-mu-plugin.php
@@ -7,6 +7,12 @@
  * POST /wp-admin/admin-ajax.php?action=test_create_nonce
  * Body: nonce_action=<action_name>
  */
+
+// Guard: do nothing on non-test environments
+if (!defined('SLIMSTAT_E2E_TESTING') || SLIMSTAT_E2E_TESTING !== true) {
+    return;
+}
+
 add_action('wp_ajax_test_create_nonce', function () {
     if (!current_user_can('manage_options')) {
         wp_send_json_error('forbidden');

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -19,6 +19,8 @@ const MU_PLUGINS = path.join(WP_CONTENT, 'mu-plugins');
 const AJAX_LOG = path.join(WP_CONTENT, 'geoip-ajax-calls.log');
 const LOGGER_SRC = path.join(__dirname, 'ajax-logger-mu-plugin.php');
 const LOGGER_DEST = path.join(MU_PLUGINS, 'geoip-ajax-logger.php');
+const NONCE_HELPER_SRC = path.join(__dirname, 'nonce-helper-mu-plugin.php');
+const NONCE_HELPER_DEST = path.join(MU_PLUGINS, 'nonce-helper-mu-plugin.php');
 const CRON_LINE = "define('DISABLE_WP_CRON', true);";
 
 // ─── wp-config.php toggler ─────────────────────────────────────────
@@ -55,6 +57,17 @@ export function installMuPlugin(): void {
 
 export function uninstallMuPlugin(): void {
   if (fs.existsSync(LOGGER_DEST)) fs.unlinkSync(LOGGER_DEST);
+}
+
+// ─── Nonce helper MU-Plugin ──────────────────────────────────────
+
+export function installNonceHelper(): void {
+  fs.mkdirSync(MU_PLUGINS, { recursive: true });
+  fs.copyFileSync(NONCE_HELPER_SRC, NONCE_HELPER_DEST);
+}
+
+export function uninstallNonceHelper(): void {
+  if (fs.existsSync(NONCE_HELPER_DEST)) fs.unlinkSync(NONCE_HELPER_DEST);
 }
 
 // ─── AJAX log reader ───────────────────────────────────────────────

--- a/tests/e2e/issue-180-dbip-cron-tempnam.spec.ts
+++ b/tests/e2e/issue-180-dbip-cron-tempnam.spec.ts
@@ -17,6 +17,7 @@ import {
   snapshotGeoipTimestamp,
   restoreGeoipTimestamp,
   clearGeoipTimestamp,
+  getGeoipTimestamp,
   setSlimstatOption,
   closeDb,
 } from './helpers/setup';
@@ -73,6 +74,21 @@ test.describe('Issue #180: DbIpProvider wp_tempnam in non-admin context', () => 
     // to the shim's outer catch block.
     expect(body.escaped_catch, 'Cron callback did not catch \\Throwable — \\Error escaped').not.toBe(true);
     expect(body.success).toBe(true);
+  });
+
+  test('Test 4: Failed download does not update geoip timestamp', async ({ page }) => {
+    const res = await page.request.get(`${BASE_URL}/?test_dbip_cron=callback_download_fail`);
+    expect(res.ok()).toBeTruthy();
+
+    const body = await res.json();
+
+    // The download failed (HTTP stubbed with WP_Error → updateDatabase returns false).
+    // The timestamp must NOT be updated — otherwise retries are suppressed until next month.
+    expect(body.ts_changed, 'Timestamp should not change on failed download').toBe(false);
+
+    // Verify via DB that timestamp is still null (was cleared in beforeEach)
+    const ts = await getGeoipTimestamp();
+    expect(ts, 'slimstat_last_geoip_dl should remain null after failed download').toBeNull();
   });
 
   test('Test 3: Admin AJAX handler catches \\Throwable from provider', async ({ page }) => {

--- a/tests/e2e/issue-180-dbip-cron-tempnam.spec.ts
+++ b/tests/e2e/issue-180-dbip-cron-tempnam.spec.ts
@@ -82,6 +82,9 @@ test.describe('Issue #180: DbIpProvider wp_tempnam in non-admin context', () => 
 
     const body = await res.json();
 
+    // Verify the shim itself didn't hit an unexpected error
+    expect(body.success, 'Shim should complete without catching a \\Throwable').toBe(true);
+
     // The download failed (HTTP stubbed with WP_Error → updateDatabase returns false).
     // The timestamp must NOT be updated — otherwise retries are suppressed until next month.
     expect(body.ts_changed, 'Timestamp should not change on failed download').toBe(false);

--- a/tests/e2e/pro-maxmind-details-addon.spec.ts
+++ b/tests/e2e/pro-maxmind-details-addon.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * E2E tests: Pro MaxMindDetailsAddon — Issue #182 fix verification.
+ *
+ * Validates that the Advanced Whois AJAX endpoint works correctly after
+ * migrating from deleted SlimStat\Services\GeoIP to new Geolocation API.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  installOptionMutator,
+  uninstallOptionMutator,
+  installNonceHelper,
+  uninstallNonceHelper,
+  setSlimstatOption,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+  closeDb,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+
+test.describe('Pro MaxMindDetailsAddon — Advanced Whois (#182)', () => {
+  test.beforeAll(async () => {
+    installOptionMutator();
+    installNonceHelper();
+  });
+
+  test.beforeEach(async () => {
+    await snapshotSlimstatOptions();
+  });
+
+  test.afterEach(async () => {
+    await restoreSlimstatOptions();
+  });
+
+  test.afterAll(async () => {
+    uninstallOptionMutator();
+    uninstallNonceHelper();
+    await closeDb();
+  });
+
+  /**
+   * Get a nonce for the whois AJAX endpoint via the nonce-helper mu-plugin.
+   */
+  async function getWhoisNonce(page: import('@playwright/test').Page): Promise<string> {
+    const response = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+      form: { action: 'test_create_nonce', nonce_action: 'slimstat_ip2location_iframe' },
+    });
+    expect(response.ok(), 'Nonce helper mu-plugin should respond OK').toBeTruthy();
+    const json = await response.json();
+    return json.data.nonce;
+  }
+
+  /**
+   * Call the whois AJAX endpoint and return status + body.
+   */
+  async function callWhoisEndpoint(
+    page: import('@playwright/test').Page,
+    ip: string,
+    nonce: string
+  ): Promise<{ status: number; body: string }> {
+    const url = `${BASE_URL}/wp-admin/admin-ajax.php?action=slimstat_ip2location_iframe_content&_wpnonce=${nonce}&ip=${ip}`;
+    const response = await page.request.get(url);
+    return { status: response.status(), body: await response.text() };
+  }
+
+  // ─── Test 1: Admin pages load without fatal (both plugins active) ──
+
+  test('admin pages load without PHP fatal errors', async ({ page }) => {
+    await setSlimstatOption(page, 'addon_maxmind_enable', 'on');
+
+    const adminPages = [
+      '/wp-admin/',
+      '/wp-admin/admin.php?page=slimview1',
+      '/wp-admin/admin.php?page=slimconfig',
+    ];
+
+    for (const adminPage of adminPages) {
+      const response = await page.goto(adminPage);
+      expect(response?.status(), `${adminPage} should not 500`).toBeLessThan(500);
+
+      const body = await page.content();
+      expect(body).not.toContain('Fatal error');
+      expect(body).not.toContain("Class 'SlimStat\\Services\\GeoIP' not found");
+    }
+  });
+
+  // ─── Test 2: Whois AJAX works with DB-backed provider ──────────────
+
+  test('whois AJAX responds without fatal error', async ({ page }) => {
+    await setSlimstatOption(page, 'geolocation_provider', 'dbip');
+    await setSlimstatOption(page, 'addon_maxmind_enable', 'on');
+
+    // Auth context
+    await page.goto('/wp-admin/');
+    await expect(page).toHaveTitle(/Dashboard/);
+
+    const nonce = await getWhoisNonce(page);
+    const result = await callWhoisEndpoint(page, '8.8.8.8', nonce);
+
+    expect(result.status).toBeLessThan(500);
+    expect(result.body).not.toContain('Fatal error');
+    expect(result.body).not.toContain("Class 'SlimStat\\Services\\GeoIP' not found");
+
+    // Should show either geo data HTML or actionable DB-missing message
+    const hasGeoData = result.body.includes('IP Geolocation Information');
+    const hasDbMissing = result.body.includes('geolocation database is not available');
+    expect(hasGeoData || hasDbMissing, 'Should show geo data or DB-missing message').toBeTruthy();
+  });
+
+  // ─── Test 3: Cloudflare provider → explicit unsupported message ────
+
+  test('cloudflare provider blocks whois with explicit message', async ({ page }) => {
+    await setSlimstatOption(page, 'geolocation_provider', 'cloudflare');
+    await setSlimstatOption(page, 'addon_maxmind_enable', 'on');
+
+    // Auth context
+    await page.goto('/wp-admin/');
+
+    // Direct AJAX call should return cloudflare-specific message
+    const nonce = await getWhoisNonce(page);
+    const result = await callWhoisEndpoint(page, '8.8.8.8', nonce);
+
+    expect(result.body).toContain('Cloudflare');
+    expect(result.body).toContain('not available');
+    expect(result.body).not.toContain('Fatal error');
+
+    // Whois URL should NOT be injected into the reports page
+    await page.goto('/wp-admin/admin.php?page=slimview1');
+    const pageContent = await page.content();
+    expect(pageContent).not.toContain('slimstat_ip2location_iframe_content');
+  });
+
+  // ─── Test 4: Geolocation disabled → actionable settings message ────
+
+  test('disabled geolocation shows settings message on AJAX call', async ({ page }) => {
+    await setSlimstatOption(page, 'geolocation_provider', 'disable');
+    await setSlimstatOption(page, 'addon_maxmind_enable', 'on');
+
+    await page.goto('/wp-admin/');
+
+    const nonce = await getWhoisNonce(page);
+    const result = await callWhoisEndpoint(page, '8.8.8.8', nonce);
+
+    expect(result.body).toContain('GeoIP collection is not enabled');
+    expect(result.body).toContain('setting page');
+    expect(result.body).not.toContain('Fatal error');
+
+    // Whois URL should NOT be injected
+    await page.goto('/wp-admin/admin.php?page=slimview1');
+    const pageContent = await page.content();
+    expect(pageContent).not.toContain('slimstat_ip2location_iframe_content');
+  });
+
+  // ─── Test 5: Admin pages stable across all provider switches ───────
+
+  test('admin pages stable when switching providers with addon enabled', async ({ page }) => {
+    await setSlimstatOption(page, 'addon_maxmind_enable', 'on');
+
+    for (const provider of ['dbip', 'maxmind', 'cloudflare', 'disable']) {
+      await setSlimstatOption(page, 'geolocation_provider', provider);
+
+      const dashResponse = await page.goto('/wp-admin/');
+      expect(dashResponse?.status(), `Dashboard with ${provider}`).toBeLessThan(500);
+
+      const reportsResponse = await page.goto('/wp-admin/admin.php?page=slimview1');
+      expect(reportsResponse?.status(), `Reports with ${provider}`).toBeLessThan(500);
+
+      const body = await page.content();
+      expect(body).not.toContain('Fatal error');
+    }
+  });
+
+  // ─── Test 6: Addon disabled → no whois URL injected ────────────────
+
+  test('addon disabled does not inject whois URL', async ({ page }) => {
+    await setSlimstatOption(page, 'addon_maxmind_enable', 'off');
+    await setSlimstatOption(page, 'geolocation_provider', 'dbip');
+
+    await page.goto('/wp-admin/admin.php?page=slimview1');
+    await page.waitForLoadState('domcontentloaded');
+
+    const pageContent = await page.content();
+    expect(pageContent).not.toContain('slimstat_ip2location_iframe_content');
+  });
+});

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -1264,10 +1264,11 @@ class wp_slimstat
 
             try {
                 $geographicProvider = new \SlimStat\Services\Geolocation\GeolocationService($provider, []);
-                $geographicProvider->updateDatabase();
+                $ok = $geographicProvider->updateDatabase();
 
-                // Set the last update time
-                update_option('slimstat_last_geoip_dl', time());
+                if ($ok) {
+                    update_option('slimstat_last_geoip_dl', time());
+                }
 
             } catch (\Throwable $e) {
                 wp_slimstat::log('Geolocation database update failed: ' . $e->getMessage(), 'error');


### PR DESCRIPTION
## Summary

- Cron callback now checks `updateDatabase()` return value before updating `slimstat_last_geoip_dl`
- Previously, a failed download (network error, filesystem issue) would still set the timestamp, suppressing retries until the next monthly window
- Matches the existing AJAX handler behavior at `admin/index.php:2088`

Addresses review feedback from PR #183: https://github.com/wp-slimstat/wp-slimstat/pull/183#discussion_r2929872964

## Test plan

- [ ] Existing E2E tests pass (issue-180 spec covers cron callback behavior)
- [ ] When `updateDatabase()` returns `false`, `slimstat_last_geoip_dl` is NOT updated
- [ ] When `updateDatabase()` returns `true`, timestamp is updated normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GeoIP database update timestamps are now recorded only after a successful update.

* **Tests**
  * Added end-to-end test ensuring failed GeoIP downloads do not change the recorded timestamp.
  * New E2E suite validating Pro MaxMindDetailsAddon behavior (whois AJAX, admin stability, provider variations).
  * Test helpers: nonce helper MU-plugin and install/uninstall utilities; cron shim tests now sanitize input and emit consistent JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->