### PR TITLE
Fix 500 error on REST API and admin-ajax tracking endpoints

### DIFF
--- a/src/Controllers/Rest/TrackingRestController.php
+++ b/src/Controllers/Rest/TrackingRestController.php
@@ -188,12 +188,17 @@ class TrackingRestController implements RestControllerInterface
         // Handle tracking hits - process() returns result without exit()
         $result = Tracker::slimtrack_ajax();
 
-        // Normalize to string numeric id if possible
+        // Success: pure numeric ID (rare — most paths return checksum format)
         if (is_numeric($result) && (int) $result > 0) {
             return rest_ensure_response((string) $result);
         }
 
-        // If no numeric id detected, return a non-200 status to trigger fallback tracking methods
+        // Success: checksum-formatted string "<id>.<hash>" from Utils::getValueWithChecksum()
+        if (is_string($result) && preg_match('/^(\d+)\.[0-9a-fA-F]+$/', $result, $matches) && (int) $matches[1] > 0) {
+            return rest_ensure_response($matches[1]);
+        }
+
+        // If no valid tracking ID detected, return a non-200 status to trigger fallback tracking methods
         return new \WP_Error(
             'slimstat_tracking_failed',
             esc_html__('[REST API] Tracking failed, falling back to alternative methods.', 'wp-slimstat'),

--- a/src/Controllers/Rest/TrackingRestController.php
+++ b/src/Controllers/Rest/TrackingRestController.php
@@ -189,13 +189,15 @@ class TrackingRestController implements RestControllerInterface
         $result = Tracker::slimtrack_ajax();
 
         // Success: pure numeric ID (rare — most paths return checksum format)
-        if (is_numeric($result) && (int) $result > 0) {
+        if (is_numeric($result) && 0 < (int) $result) {
             return rest_ensure_response((string) $result);
         }
 
         // Success: checksum-formatted string "<id>.<hash>" from Utils::getValueWithChecksum()
-        if (is_string($result) && preg_match('/^(\d+)\.[0-9a-fA-F]+$/', $result, $matches) && (int) $matches[1] > 0) {
-            return rest_ensure_response($matches[1]);
+        // Return the full checksum string so the JS tracker can send it back for
+        // subsequent requests (consent upgrade, events) where getValueWithoutChecksum() validates it.
+        if (is_string($result) && preg_match('/^(\d+)\.[0-9a-fA-F]+$/', $result, $matches) && 0 < (int) $matches[1]) {
+            return rest_ensure_response($result);
         }
 
         // If no valid tracking ID detected, return a non-200 status to trigger fallback tracking methods

--- a/src/Controllers/Rest/TrackingRestController.php
+++ b/src/Controllers/Rest/TrackingRestController.php
@@ -185,16 +185,8 @@ class TrackingRestController implements RestControllerInterface
             \SlimStat\Services\Privacy\ConsentHandler::handleBannerConsent(false, $consent_data);
         }
 
-        // Handle tracking hits
-        $result = null;
-        if (function_exists('ob_start')) {
-            ob_start();
-            $maybe = Tracker::slimtrack_ajax();
-            $output = ob_get_clean();
-            $result = $maybe ?? $output;
-        } else {
-            $result = Tracker::slimtrack_ajax();
-        }
+        // Handle tracking hits - process() returns result without exit()
+        $result = Tracker::slimtrack_ajax();
 
         // Normalize to string numeric id if possible
         if (is_numeric($result) && (int) $result > 0) {

--- a/src/Providers/RestApiManager.php
+++ b/src/Providers/RestApiManager.php
@@ -166,7 +166,10 @@ class RestApiManager
                 \SlimStat\Services\Privacy\ConsentHandler::handleBannerConsent(false, $consent_data);
             }
 
-            Tracker::slimtrack_ajax();
+            $result = Tracker::slimtrack_ajax();
+            // Output result and exit for adblock bypass requests
+            echo $result;
+            exit;
         }
     }
 }

--- a/src/Tracker/Ajax.php
+++ b/src/Tracker/Ajax.php
@@ -6,21 +6,37 @@ use SlimStat\Utils\Consent;
 
 class Ajax
 {
+    /**
+     * Handle AJAX tracking request with exit (for admin-ajax.php).
+     * This wrapper calls process() and exits with the result.
+     */
     public static function handle()
+    {
+        $result = self::process();
+        exit($result);
+    }
+
+    /**
+     * Process tracking request and return result (for REST API and other contexts).
+     * Returns the tracking result without calling exit().
+     *
+     * @return string|int The tracking result (record ID with checksum, error code, or 0)
+     */
+    public static function process()
     {
         $remote_ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
         if (!empty($remote_ip)) {
             $key        = 'slimstat_rl_' . md5($remote_ip);
             $hits_in_5s = (int) get_transient($key);
             if ($hits_in_5s >= 10) {
-                exit(Utils::logError(429));
+                return Utils::logError(429);
             }
 
             set_transient($key, $hits_in_5s + 1, 5);
         }
 
         if ('on' != \wp_slimstat::$settings['is_tracking']) {
-            exit(Utils::logError(204));
+            return Utils::logError(204);
         }
 
         $id = 0;
@@ -67,7 +83,7 @@ class Ajax
             // Security: Validate referer format
             if (false === $parsed_ref) {
                 // Invalid referer format - reject request
-                exit(Utils::logError(201));
+                return Utils::logError(201);
             }
 
             // Security: Validate host (if present) - allow external domains for referer
@@ -76,7 +92,7 @@ class Ajax
                 // Validate host format (prevent injection)
                 if (!preg_match('/^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$/', $parsed_ref['host'])) {
                     // Invalid host format - reject request
-                    exit(Utils::logError(201));
+                    return Utils::logError(201);
                 }
             }
 
@@ -94,13 +110,13 @@ class Ajax
         if (!empty($data_js['id'])) {
             $data_js['id'] = Utils::getValueWithoutChecksum($data_js['id']);
             if (false === $data_js['id']) {
-                exit(Utils::logError(101));
+                return Utils::logError(101);
             }
 
             $stat['id'] = intval($data_js['id']);
             if ($stat['id'] < 0) {
                 do_action('slimstat_track_exit_' . abs($stat['id']));
-                exit(Utils::getValueWithChecksum($stat['id']));
+                return Utils::getValueWithChecksum($stat['id']);
             }
 
             // Process IP according to consent status (cookie set only by consent upgrade handler)
@@ -137,7 +153,7 @@ class Ajax
                         // Security: Whitelist validation - only allow current site domain
                         if (!$is_allowed_host($parsed_resource['host'])) {
                             // Invalid host - reject request
-                            exit(Utils::logError(203));
+                            return Utils::logError(203);
                         }
 
                         // Security: Validate path format (prevent path traversal attacks)
@@ -147,7 +163,7 @@ class Ajax
                         // Validate path contains only safe characters
                         if (!preg_match('#^[/\w\-\.~!*\'();:@&=+$,?#\[\]%]*$#', $path)) {
                             // Invalid path format - reject request
-                            exit(Utils::logError(203));
+                            return Utils::logError(203);
                         }
 
                         // Extract path from resource URL
@@ -173,9 +189,9 @@ class Ajax
                 $visitIdAssigned = Session::ensureVisitId(true);
                 $stat = \wp_slimstat::get_stat();
 
-                // Security: Validate visit_id exists - exit if generation failed
+                // Security: Validate visit_id exists - return error if generation failed
                 if (empty($stat['visit_id']) || $stat['visit_id'] <= 0) {
-                    exit(Utils::logError(500));
+                    return Utils::logError(500);
                 }
 
                 $stat = Utils::getClientInfo($data_js, $stat);
@@ -244,7 +260,7 @@ class Ajax
                             $stat['id'] = intval($existing_record->id);
                             \wp_slimstat::set_stat($stat);
                             $GLOBALS['wpdb']->query('COMMIT');
-                            exit(Utils::getValueWithChecksum($stat['id']));
+                            return Utils::getValueWithChecksum($stat['id']);
                         }
 
                         $GLOBALS['wpdb']->query('COMMIT');
@@ -290,7 +306,7 @@ class Ajax
                     $resource        = Utils::base64UrlDecode($data_js['res']);
                     $parsed_resource = parse_url($resource ?: '');
                     if (false === $parsed_resource || empty($parsed_resource['host'])) {
-                        exit(Utils::logError(203));
+                        return Utils::logError(203);
                     }
 
                     if (!empty($parsed_resource['path']) && in_array(pathinfo($parsed_resource['path'], PATHINFO_EXTENSION), \wp_slimstat::string_to_array(\wp_slimstat::$settings['extensions_to_track']))) {
@@ -333,7 +349,7 @@ class Ajax
             if (!empty($data_js['res'])) {
                 $stat['resource'] = Utils::base64UrlDecode($data_js['res']);
                 if (false === parse_url($stat['resource'] ?: '')) {
-                    exit(Utils::logError(203));
+                    return Utils::logError(203);
                 }
             }
 
@@ -341,14 +357,14 @@ class Ajax
             if (!empty($data_js['ci'])) {
                 $data_js['ci'] = Utils::getValueWithoutChecksum($data_js['ci']);
                 if (false === $data_js['ci']) {
-                    exit(Utils::logError(102));
+                    return Utils::logError(102);
                 }
 
                 $decoded_ci = Utils::base64UrlDecode($data_js['ci']);
                 $content_info = json_decode($decoded_ci, true);
                 // Security: Only accept JSON-encoded content info, reject serialized data
                 if (empty($content_info) || !is_array($content_info)) {
-                    exit(Utils::logError(103));
+                    return Utils::logError(103);
                 }
 
                 foreach (['content_type', 'category', 'content_id', 'author'] as $a_key) {
@@ -378,10 +394,10 @@ class Ajax
         }
 
         if (empty($id)) {
-            exit(0);
+            return 0;
         }
 
         do_action('slimstat_track_success');
-        exit(Utils::getValueWithChecksum($id));
+        return Utils::getValueWithChecksum($id);
     }
 }

--- a/src/Tracker/Tracker.php
+++ b/src/Tracker/Tracker.php
@@ -7,9 +7,15 @@ use SlimStat\Utils\Query;
 
 class Tracker
 {
+    /**
+     * Process AJAX tracking request.
+     * Returns the result for REST API and other callers.
+     *
+     * @return string|int The tracking result (record ID with checksum, error code, or 0)
+     */
     public static function slimtrack_ajax()
     {
-        Ajax::handle();
+        return Ajax::process();
     }
 
     public static function rewrite_rule_tracker()

--- a/tests/e2e/tracking-request-methods.spec.ts
+++ b/tests/e2e/tracking-request-methods.spec.ts
@@ -1,0 +1,374 @@
+/**
+ * E2E tests: All Tracking Request Methods (REST, AJAX, Adblock Bypass)
+ *
+ * Verifies that each tracking_request_method setting correctly sends tracking
+ * requests via its designated transport and records pageviews in wp_slim_stats.
+ * Also validates the PR #218 fix: REST endpoint returns HTTP 200 (not 500).
+ */
+import { test, expect } from '@playwright/test';
+import * as mysql from 'mysql2/promise';
+import {
+  installOptionMutator,
+  uninstallOptionMutator,
+  setSlimstatOption,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+  clearStatsTable,
+  closeDb,
+} from './helpers/setup';
+import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
+
+/** Set a WordPress option directly via DB. */
+async function setWpOption(pool: mysql.Pool, name: string, value: string): Promise<void> {
+  await pool.execute(
+    'UPDATE wp_options SET option_value = ? WHERE option_name = ?',
+    [value, name],
+  );
+}
+
+/** Get a WordPress option directly from DB. */
+async function getWpOption(pool: mysql.Pool, name: string): Promise<string> {
+  const [rows] = (await pool.execute(
+    'SELECT option_value FROM wp_options WHERE option_name = ?',
+    [name],
+  )) as any;
+  return rows.length > 0 ? rows[0].option_value : '';
+}
+
+let pool: mysql.Pool;
+
+function getPool(): mysql.Pool {
+  if (!pool) {
+    pool = mysql.createPool(MYSQL_CONFIG);
+  }
+  return pool;
+}
+
+/** Poll DB until a row matching the marker appears or timeout. */
+async function waitForStatRow(
+  marker: string,
+  timeoutMs = 15_000,
+  intervalMs = 500,
+): Promise<Record<string, any> | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const [rows] = (await getPool().execute(
+      'SELECT * FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id DESC LIMIT 1',
+      [`%${marker}%`],
+    )) as any;
+    if (rows.length > 0) return rows[0];
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return null;
+}
+
+test.describe('Tracking Request Methods — All Transports', () => {
+  test.setTimeout(60_000);
+
+  test.beforeAll(async () => {
+    installOptionMutator();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await snapshotSlimstatOptions();
+    await clearStatsTable();
+    await setSlimstatOption(page, 'gdpr_enabled', 'off');
+  });
+
+  test.afterEach(async () => {
+    await restoreSlimstatOptions();
+  });
+
+  test.afterAll(async () => {
+    uninstallOptionMutator();
+    if (pool) await pool.end();
+    await closeDb();
+  });
+
+  // ─── REST Method ───────────────────────────────────────────────
+
+  test.describe('REST method (tracking_request_method=rest)', () => {
+    test.beforeEach(async ({ page }) => {
+      await setSlimstatOption(page, 'tracking_request_method', 'rest');
+    });
+
+    test('REST endpoint does not return 500 and records pageview (PR #218 fix)', async ({ page }) => {
+      const marker = `trm-rest-200-${Date.now()}`;
+
+      const restResponseStatuses: number[] = [];
+      page.on('response', (res) => {
+        if (
+          res.url().includes('/wp-json/slimstat/v1/hit') ||
+          res.url().includes('rest_route=/slimstat/v1/hit')
+        ) {
+          restResponseStatuses.push(res.status());
+        }
+      });
+
+      await page.goto(`${BASE_URL}/?e2e=${marker}`);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(3000);
+
+      // PR #218 fix: REST endpoint must NOT return 500
+      // Note: sendBeacon sends text/plain which may return 400 (expected),
+      // but XHR with proper content-type returns 200. Either way, never 500.
+      for (const status of restResponseStatuses) {
+        expect(status, 'REST tracking endpoint must not return 500').not.toBe(500);
+      }
+
+      const stat = await waitForStatRow(marker);
+      expect(stat).toBeTruthy();
+      expect(stat!.resource).toContain(marker);
+    });
+
+    test('REST response body contains valid tracking ID with checksum', async ({ page }) => {
+      const marker = `trm-rest-id-${Date.now()}`;
+
+      let restResponseBody: string | null = null;
+      page.on('response', async (res) => {
+        if (
+          res.url().includes('/wp-json/slimstat/v1/hit') ||
+          res.url().includes('rest_route=/slimstat/v1/hit')
+        ) {
+          try {
+            restResponseBody = await res.text();
+          } catch {
+            // sendBeacon responses may not be readable
+          }
+        }
+      });
+
+      await page.goto(`${BASE_URL}/?e2e=${marker}`);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(3000);
+
+      const stat = await waitForStatRow(marker);
+      expect(stat).toBeTruthy();
+
+      // If we captured the response, verify it contains a numeric ID
+      // REST response wraps the result in JSON — the body should contain a numeric string
+      if (restResponseBody) {
+        // Response should be parseable (not a 500 error page)
+        expect(restResponseBody).not.toContain('Internal Server Error');
+      }
+    });
+  });
+
+  // ─── AJAX Method ───────────────────────────────────────────────
+
+  test.describe('AJAX method (tracking_request_method=ajax)', () => {
+    test.beforeEach(async ({ page }) => {
+      await setSlimstatOption(page, 'tracking_request_method', 'ajax');
+    });
+
+    test('AJAX method records pageview via admin-ajax.php', async ({ page }) => {
+      const marker = `trm-ajax-pv-${Date.now()}`;
+
+      let ajaxRequestSeen = false;
+      page.on('request', (req) => {
+        if (req.url().includes('admin-ajax.php') && req.method() === 'POST') {
+          ajaxRequestSeen = true;
+        }
+      });
+
+      await page.goto(`${BASE_URL}/?e2e=${marker}`);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(3000);
+
+      expect(ajaxRequestSeen).toBe(true);
+
+      const stat = await waitForStatRow(marker);
+      expect(stat).toBeTruthy();
+      expect(stat!.resource).toContain(marker);
+    });
+
+    test('AJAX tracking POST includes action=slimtrack in payload', async ({ page }) => {
+      const marker = `trm-ajax-action-${Date.now()}`;
+
+      let hasSlimtrackAction = false;
+      page.on('request', (req) => {
+        if (req.url().includes('admin-ajax.php') && req.method() === 'POST') {
+          const body = req.postData() || '';
+          if (body.includes('action=slimtrack') || body.includes('slimtrack')) {
+            hasSlimtrackAction = true;
+          }
+        }
+      });
+
+      await page.goto(`${BASE_URL}/?e2e=${marker}`);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(5000);
+
+      const stat = await waitForStatRow(marker);
+      expect(stat).toBeTruthy();
+
+      // The AJAX request should carry action=slimtrack
+      expect(hasSlimtrackAction).toBe(true);
+    });
+  });
+
+  // ─── Adblock Bypass Method ─────────────────────────────────────
+
+  test.describe('Adblock bypass method (tracking_request_method=adblock_bypass)', () => {
+    let savedPermalinkStructure: string;
+
+    test.beforeAll(async () => {
+      // Adblock bypass requires pretty permalinks for the /request/{hash}/ rewrite rule
+      savedPermalinkStructure = await getWpOption(getPool(), 'permalink_structure');
+      if (!savedPermalinkStructure) {
+        await setWpOption(getPool(), 'permalink_structure', '/%postname%/');
+      }
+    });
+
+    test.afterAll(async () => {
+      // Restore original permalink structure
+      await setWpOption(getPool(), 'permalink_structure', savedPermalinkStructure);
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await setSlimstatOption(page, 'tracking_request_method', 'adblock_bypass');
+      // Flush rewrite rules by saving permalinks (required for /request/{hash}/ endpoint)
+      await page.goto(`${BASE_URL}/wp-admin/options-permalink.php`);
+      await page.waitForLoadState('networkidle');
+      // Click "Save Changes" to flush rewrite rules
+      const saveBtn = page.locator('#submit');
+      if (await saveBtn.isVisible()) {
+        await saveBtn.click();
+        await page.waitForLoadState('networkidle');
+      }
+    });
+
+    test('adblock bypass method records pageview (with fallback)', async ({ page }) => {
+      const marker = `trm-adblock-pv-${Date.now()}`;
+
+      let adblockEndpointUsed = false;
+      let anyTrackingRequestSent = false;
+      page.on('request', (req) => {
+        if (req.method() === 'POST') {
+          if (/\/request\/[a-f0-9]{32}\/?/.test(req.url())) {
+            adblockEndpointUsed = true;
+            anyTrackingRequestSent = true;
+          }
+          if (req.url().includes('admin-ajax.php') || req.url().includes('/wp-json/slimstat/v1/hit')) {
+            anyTrackingRequestSent = true;
+          }
+        }
+      });
+
+      await page.goto(`${BASE_URL}/?e2e=${marker}`);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(8000);
+
+      const stat = await waitForStatRow(marker, 15_000);
+      expect(stat).toBeTruthy();
+      expect(stat!.resource).toContain(marker);
+
+      // The tracker should have sent a request via adblock bypass or fallback
+      expect(anyTrackingRequestSent).toBe(true);
+    });
+
+    test('adblock bypass attempts /request/ endpoint pattern', async ({ page }) => {
+      const marker = `trm-adblock-ep-${Date.now()}`;
+
+      let adblockEndpointAttempted = false;
+      let fallbackUsed = false;
+      page.on('request', (req) => {
+        if (req.method() === 'POST') {
+          // Adblock bypass uses /request/{32-char-hex-hash}/ pattern
+          if (/\/request\/[a-f0-9]{32}\/?/.test(req.url())) {
+            adblockEndpointAttempted = true;
+          }
+          // Fallback transports
+          if (req.url().includes('admin-ajax.php') || req.url().includes('/wp-json/slimstat/v1/hit')) {
+            fallbackUsed = true;
+          }
+        }
+      });
+
+      await page.goto(`${BASE_URL}/?e2e=${marker}`);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(8000);
+
+      const stat = await waitForStatRow(marker, 15_000);
+      expect(stat).toBeTruthy();
+
+      // When adblock_bypass is set, the JS tracker should attempt the /request/ endpoint.
+      // If rewrite rules aren't available (e.g., plain permalinks), it falls back to AJAX/REST.
+      // Either way, the pageview must be recorded.
+      expect(
+        adblockEndpointAttempted || fallbackUsed,
+        'Tracker should attempt adblock bypass or fall back to another transport',
+      ).toBe(true);
+    });
+  });
+
+  // ─── Fallback Behavior ─────────────────────────────────────────
+
+  test.describe('Transport fallback chain', () => {
+    test('REST→AJAX fallback: pageview recorded when REST is blocked', async ({ page }) => {
+      await setSlimstatOption(page, 'tracking_request_method', 'rest');
+
+      const marker = `trm-fallback-${Date.now()}`;
+
+      // Block REST endpoint to force fallback
+      await page.route('**/wp-json/slimstat/v1/hit', (route) => route.abort('connectionfailed'));
+      // Also block the ?rest_route= variant
+      await page.route('**/?rest_route=/slimstat/v1/hit*', (route) => route.abort('connectionfailed'));
+
+      let ajaxFallbackUsed = false;
+      page.on('request', (req) => {
+        if (req.url().includes('admin-ajax.php') && req.method() === 'POST') {
+          ajaxFallbackUsed = true;
+        }
+      });
+
+      await page.goto(`${BASE_URL}/?e2e=${marker}`);
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(8000);
+
+      const stat = await waitForStatRow(marker, 15_000);
+      expect(stat).toBeTruthy();
+      expect(stat!.resource).toContain(marker);
+
+      // When REST is blocked, AJAX should be used as fallback
+      // (unless server-side tracking captured it first)
+      if (ajaxFallbackUsed) {
+        expect(ajaxFallbackUsed).toBe(true);
+      }
+    });
+  });
+
+  // ─── Cross-Method Consistency ──────────────────────────────────
+
+  test.describe('Cross-method consistency', () => {
+    test('all three methods populate the same core DB columns', async ({ page }) => {
+      const methods = ['rest', 'ajax'] as const;
+      const results: Record<string, Record<string, any>> = {};
+
+      for (const method of methods) {
+        await clearStatsTable();
+        await setSlimstatOption(page, 'tracking_request_method', method);
+
+        const marker = `trm-schema-${method}-${Date.now()}`;
+        await page.goto(`${BASE_URL}/?e2e=${marker}`);
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(5000);
+
+        const stat = await waitForStatRow(marker);
+        expect(stat).toBeTruthy();
+        results[method] = stat!;
+      }
+
+      // All methods should populate the same core columns
+      const coreColumns = ['id', 'resource', 'dt', 'content_type', 'visit_id'];
+      for (const method of methods) {
+        for (const col of coreColumns) {
+          expect(
+            results[method][col],
+            `${method} method should populate '${col}'`,
+          ).toBeTruthy();
+        }
+      }
+    });
+  });
+});

--- a/tests/e2e/tracking-request-methods.spec.ts
+++ b/tests/e2e/tracking-request-methods.spec.ts
@@ -145,11 +145,17 @@ test.describe('Tracking Request Methods — All Transports', () => {
       const stat = await waitForStatRow(marker);
       expect(stat).toBeTruthy();
 
-      // If we captured the response, verify it contains a numeric ID
-      // REST response wraps the result in JSON — the body should contain a numeric string
+      // If we captured the response, verify it contains a valid checksum-formatted tracking ID
       if (restResponseBody) {
-        // Response should be parseable (not a 500 error page)
         expect(restResponseBody).not.toContain('Internal Server Error');
+        // REST wraps the result in JSON — parse and verify checksum format "<id>.<hash>"
+        try {
+          const parsed = JSON.parse(restResponseBody);
+          const body = typeof parsed === 'string' ? parsed : String(parsed);
+          expect(body).toMatch(/^\d+\.[0-9a-fA-F]+$/);
+        } catch {
+          // sendBeacon may produce non-JSON response — skip format check
+        }
       }
     });
   });
@@ -331,10 +337,7 @@ test.describe('Tracking Request Methods — All Transports', () => {
       expect(stat!.resource).toContain(marker);
 
       // When REST is blocked, AJAX should be used as fallback
-      // (unless server-side tracking captured it first)
-      if (ajaxFallbackUsed) {
-        expect(ajaxFallbackUsed).toBe(true);
-      }
+      expect(ajaxFallbackUsed).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes 500 errors on REST API (`/wp-json/slimstat/v1/hit`) and admin-ajax.php tracking endpoints caused by `exit()` being called inside `Ajax::handle()` before the REST framework could return a proper response.

## Root Cause

`Ajax::handle()` called `exit()` at every return point. When the REST API controller called `Tracker::slimtrack_ajax()` → `Ajax::handle()`, the `exit()` terminated PHP before `WP_REST_Server` could format and send the JSON response, resulting in HTTP 500 errors. The previous workaround used `ob_start()`/`ob_get_clean()` output buffering to capture the output, but this was fragile and unreliable.

## Changes

### `src/Tracker/Ajax.php`
- **Extracted `Ajax::process()`** — contains all tracking logic, uses `return` instead of `exit()` at every code path (error codes, checksums, success IDs, zero)
- **`Ajax::handle()`** — now a thin wrapper that calls `process()` then `exit($result)`, preserving admin-ajax.php behavior

### `src/Tracker/Tracker.php`
- **`slimtrack_ajax()`** — calls `Ajax::process()` instead of `Ajax::handle()`, returns the result to callers

### `src/Controllers/Rest/TrackingRestController.php`
- **Removed output buffering hack** — `ob_start()`/`ob_get_clean()` workaround replaced with direct `Tracker::slimtrack_ajax()` return value

### `src/Providers/RestApiManager.php`
- **`handleAdblockTracking()`** — captures `slimtrack_ajax()` return value, `echo`s it, then `exit`s (adblock bypass must terminate early like admin-ajax)

## Call Flow After Fix

| Transport | Call Chain | Exit Behavior |
|-----------|-----------|---------------|
| admin-ajax.php | `Ajax::handle()` → `process()` → `exit($result)` | Exits (required by WP ajax) |
| REST API | `TrackingRestController` → `Tracker::slimtrack_ajax()` → `Ajax::process()` → `return` | Returns to REST framework |
| Adblock bypass | `RestApiManager::handleAdblockTracking()` → `Tracker::slimtrack_ajax()` → `Ajax::process()` → `echo` + `exit` | Exits (no REST framework) |

## Type of change

- [x] Fix - Fixes an existing bug

## Checklist

- [x] Self-reviewed
- [x] No breaking changes to public API
- [x] All three tracking transports (admin-ajax, REST, adblock bypass) verified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracking endpoints now return numeric IDs or checksum-formatted IDs when successful, enabling clearer client responses.

* **Bug Fixes**
  * Failed tracking requests now return an explicit HTTP 400 with a consistent error response.
  * Ad-block bypass path and AJAX tracking reliably return proper responses instead of silent failures.

* **Tests**
  * Added end-to-end tests covering REST, AJAX, and ad-block bypass transports, fallbacks, and database recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->