### PR TITLE
Fix fatal error on servers without PHP calendar extension

### DIFF
--- a/src/Helpers/DataBuckets.php
+++ b/src/Helpers/DataBuckets.php
@@ -116,7 +116,7 @@ class DataBuckets
         }
 
         // Move start to the next week if it is not the start of the week
-        $start->modify('next ' . $dayNames[$startOfWeek]);
+        $start->modify('next ' . ($dayNames[$startOfWeek] ?? 'Monday'));
         if ($start->getTimestamp() <= $this->start) {
             $start->modify('+1 week');
         }

--- a/src/Helpers/DataBuckets.php
+++ b/src/Helpers/DataBuckets.php
@@ -11,6 +11,8 @@ if (! defined('ABSPATH')) {
 
 class DataBuckets
 {
+    private const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
     private $labels = [];
 
     private $prev_labels = [];
@@ -105,7 +107,6 @@ class DataBuckets
         $start       = (new \DateTime())->setTimestamp($this->start);
         $end         = (new \DateTime())->setTimestamp($this->end);
         $startOfWeek = (int) get_option('start_of_week', 1);
-        $dayNames    = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
         // Adjust start to the first day of the week
         $firstLabel     = $start->format($this->labelFormat);
@@ -116,7 +117,7 @@ class DataBuckets
         }
 
         // Move start to the next week if it is not the start of the week
-        $start->modify('next ' . ($dayNames[$startOfWeek] ?? 'Monday'));
+        $start->modify('next ' . (self::DAY_NAMES[$startOfWeek] ?? 'Monday'));
         if ($start->getTimestamp() <= $this->start) {
             $start->modify('+1 week');
         }

--- a/src/Helpers/DataBuckets.php
+++ b/src/Helpers/DataBuckets.php
@@ -104,7 +104,8 @@ class DataBuckets
     {
         $start       = (new \DateTime())->setTimestamp($this->start);
         $end         = (new \DateTime())->setTimestamp($this->end);
-        $startOfWeek = get_option('start_of_week', 1);
+        $startOfWeek = (int) get_option('start_of_week', 1);
+        $dayNames    = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
         // Adjust start to the first day of the week
         $firstLabel     = $start->format($this->labelFormat);
@@ -115,7 +116,7 @@ class DataBuckets
         }
 
         // Move start to the next week if it is not the start of the week
-        $start->modify('next ' . jddayofweek($startOfWeek - 1, 1));
+        $start->modify('next ' . $dayNames[$startOfWeek]);
         if ($start->getTimestamp() <= $this->start) {
             $start->modify('+1 week');
         }


### PR DESCRIPTION
## Summary

Replace `jddayofweek()` with a pure-PHP array-based day name lookup to avoid dependency on the optional PHP `ext-calendar` extension. This fixes dashboard crashes on Synology NAS, Alpine containers, and minimal PHP builds.

Closes #228

## Changes

**File**: `src/Helpers/DataBuckets.php`

1. **Line 107**: Add `(int)` cast to `get_option('start_of_week', 1)` for type safety (WP stores options as strings)
2. **Line 108**: Add `$dayNames` array — pure-PHP replacement for `jddayofweek()`
3. **Line 119**: Replace `jddayofweek($startOfWeek - 1, 1)` with `($dayNames[$startOfWeek] ?? 'Monday')` — eliminates `ext-calendar` dependency with safe fallback for corrupted values

## Verification

- CTO-verified via [3v4l.org](https://3v4l.org/smp5J#veol): `jddayofweek()` fails on ALL PHP 7.1.20+ through 8.5.3 without `ext-calendar`
- All 7 `start_of_week` values (0–6) produce identical day names to original `jddayofweek()` call
- `DateTime::modify()` only accepts English day names — no i18n impact
- `?? 'Monday'` fallback prevents `Undefined array key` warning on corrupted options (PHP 8.0+) and `DateMalformedStringException` (PHP 8.3+)

## Type of change

- [x] Fix - Fixes an existing bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved week-sequencing logic for more robust and consistent determination of week start days, enhancing label generation across weeks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->