### PR TITLE
Fix chart data not showing due to incorrect bounds check

### DIFF
--- a/admin/config/index.php
+++ b/admin/config/index.php
@@ -591,7 +591,7 @@ $settings = [
             'ignore_content_types' => [
                 'title'       => __('Content Types', 'wp-slimstat'),
                 'type'        => 'textarea',
-                'description' => __('Enter a list of Slimstat content types that should not be tracked: <code>post, page, attachment, tag, 404, taxonomy, author, archive, search, feed, login</code>, etc. See note at the bottom of this page for more information on how to use wildcards. String should be entered in lowercase.', 'wp-slimstat'),
+                'description' => __('Enter a list of Slimstat content types that should not be tracked: <code>post, page, attachment, tag, 404, taxonomy, author, archive, search, feed, login</code>, etc. For custom post types, use the <code>cpt:</code> prefix (e.g., <code>cpt:product</code>, <code>cpt:portfolio</code>). See note at the bottom of this page for more information on how to use wildcards. Strings are case-insensitive.', 'wp-slimstat'),
             ],
             'wildcards_description' => ['Wildcards',
                 'type'   => 'custom',

--- a/src/Helpers/DataBuckets.php
+++ b/src/Helpers/DataBuckets.php
@@ -206,7 +206,7 @@ class DataBuckets
         }
 
         // Ensure offset is within bounds
-        if ($offset <= $this->points) {
+        if ($offset >= 0 && $offset < $this->points) {
             $target = 'current' === $period ? 'datasets' : 'datasetsPrev';
             if (!isset($this->{$target}['v1'][$offset])) {
                 $this->{$target}['v1'][$offset] = 0;

--- a/tests/e2e/chart-sql-expression-validation.spec.ts
+++ b/tests/e2e/chart-sql-expression-validation.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * E2E: Chart SQL expression validation — validateSqlExpression() whitelist
+ *
+ * Validates the strict whitelist introduced in Chart.php:436–508 (PR #232).
+ * The whitelist accepts only:
+ *   Pattern 1: FUNC(*)            e.g. COUNT(*)
+ *   Pattern 2: FUNC(column)       e.g. COUNT(id), SUM(page_performance)
+ *   Pattern 3: FUNC(DISTINCT col) e.g. COUNT(DISTINCT ip)
+ *
+ * On rejection, ajaxFetchChartData() catches the \Exception and calls
+ * wp_send_json_error() — HTTP 200 with { success: false, data: { message } }.
+ *
+ * Tests:
+ *   1. COUNT(id) — default free-plugin expression → success: true
+ *   2. COUNT( DISTINCT ip ) — default free-plugin expression → success: true
+ *   3. COUNT(*) + 1 — arithmetic, no whitelist pattern matches → success: false
+ *   4. '; DROP TABLE wp_slim_stats-- — SQL injection attempt → success: false
+ *
+ * Source: PR #232 impact analysis / finding 2
+ */
+import { test, expect } from '@playwright/test';
+import {
+  closeDb,
+  installMuPluginByName,
+  uninstallMuPluginByName,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Obtain the chart nonce via the nonce-helper AJAX endpoint.
+ * More reliable than page-scraping slimstat_chart_vars.nonce.
+ */
+async function getChartNonce(page: import('@playwright/test').Page): Promise<string> {
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'test_create_nonce', nonce_action: 'slimstat_chart_nonce' },
+  });
+  if (!res.ok()) throw new Error(`test_create_nonce failed: HTTP ${res.status()}`);
+  const body = await res.json();
+  if (!body?.success || !body?.data?.nonce) {
+    throw new Error(`test_create_nonce returned unexpected body: ${JSON.stringify(body)}`);
+  }
+  return body.data.nonce;
+}
+
+/**
+ * Call slimstat_fetch_chart_data AJAX with a custom data1 expression.
+ * Uses a fixed past range (2026-02-01 → 2026-03-31) — no DB rows needed
+ * because validateSqlExpression() runs before the SQL query.
+ */
+async function callChartWithExpression(
+  page: import('@playwright/test').Page,
+  nonce: string,
+  data1Expression: string
+): Promise<{ status: number; body: any }> {
+  const args = JSON.stringify({
+    start: 1738368000, // 2026-02-01 00:00 UTC
+    end:   1743379199, // 2026-03-31 23:59 UTC
+    chart_data: {
+      data1: data1Expression,
+      data2: 'COUNT( DISTINCT ip )',
+    },
+  });
+
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'slimstat_fetch_chart_data', nonce, args, granularity: 'monthly' },
+  });
+
+  return { status: res.status(), body: res.ok() ? await res.json() : null };
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+test.describe('Chart SQL expression validation — validateSqlExpression() whitelist', () => {
+  test.setTimeout(60_000);
+
+  let sharedNonce: string;
+
+  test.beforeAll(async ({ browser }) => {
+    installMuPluginByName('nonce-helper-mu-plugin.php');
+    // Obtain nonce once for all 4 tests — nonces are valid for several hours
+    const ctx  = await browser.newContext();
+    const page = await ctx.newPage();
+    sharedNonce = await getChartNonce(page);
+    await ctx.close();
+  });
+
+  test.afterAll(async () => {
+    uninstallMuPluginByName('nonce-helper-mu-plugin.php');
+    await closeDb();
+  });
+
+  // ─── Test 1: Default expression COUNT(id) passes whitelist ───────────────
+
+  test('COUNT(id) — default free-plugin expression passes whitelist', async ({ page }) => {
+    const { status, body } = await callChartWithExpression(page, sharedNonce, 'COUNT(id)');
+
+    expect(status).toBe(200);
+    expect(body?.success, `Expected success:true, got: ${JSON.stringify(body?.data)}`).toBe(true);
+
+    console.log('Test 1 PASS — COUNT(id) accepted by whitelist');
+  });
+
+  // ─── Test 2: Default expression COUNT( DISTINCT ip ) passes whitelist ────
+
+  test('COUNT( DISTINCT ip ) — default free-plugin expression passes whitelist', async ({ page }) => {
+    const { status, body } = await callChartWithExpression(page, sharedNonce, 'COUNT( DISTINCT ip )');
+
+    expect(status).toBe(200);
+    expect(body?.success, `Expected success:true, got: ${JSON.stringify(body?.data)}`).toBe(true);
+
+    console.log('Test 2 PASS — COUNT( DISTINCT ip ) accepted by whitelist');
+  });
+
+  // ─── Test 3: Arithmetic expression rejected ───────────────────────────────
+
+  test("COUNT(*) + 1 — arithmetic expression rejected by whitelist → success: false", async ({ page }) => {
+    /**
+     * The whitelist patterns only allow FUNC(*), FUNC(col), FUNC(DISTINCT col).
+     * Arithmetic operators are not part of any pattern — the expression is
+     * rejected before reaching the SQL layer, returning:
+     *   { success: false, data: { message: "Invalid SQL expression..." } }
+     */
+    const { status, body } = await callChartWithExpression(page, sharedNonce, 'COUNT(*) + 1');
+
+    expect(status).toBe(200); // always HTTP 200; success flag carries the error
+    expect(body?.success, 'Arithmetic expression should be rejected').toBe(false);
+    expect(typeof body?.data?.message).toBe('string');
+    expect(body?.data?.message.length).toBeGreaterThan(0);
+
+    console.log(`Test 3 PASS — COUNT(*)+1 rejected: "${body?.data?.message}"`);
+  });
+
+  // ─── Test 4: SQL injection attempt rejected ───────────────────────────────
+
+  test("SQL injection attempt rejected by whitelist → success: false", async ({ page }) => {
+    /**
+     * Classic SQL injection payload. The whitelist regex anchors (^ and $)
+     * with strict character classes prevent any bypass.
+     * Expression is rejected; no SQL query is executed.
+     */
+    const injection = "'; DROP TABLE wp_slim_stats--";
+    const { status, body } = await callChartWithExpression(page, sharedNonce, injection);
+
+    expect(status).toBe(200);
+    expect(body?.success, 'SQL injection should be rejected').toBe(false);
+    expect(typeof body?.data?.message).toBe('string');
+    expect(body?.data?.message.length).toBeGreaterThan(0);
+
+    console.log(`Test 4 PASS — injection rejected: "${body?.data?.message}"`);
+  });
+});

--- a/tests/e2e/databuckets-custom-db-accuracy.spec.ts
+++ b/tests/e2e/databuckets-custom-db-accuracy.spec.ts
@@ -10,13 +10,23 @@
  * Also simulates the slimstat_custom_wpdb filter (used by the external DB addon)
  * to confirm that Query.php's use of global $wpdb creates no read/write split.
  *
+ * How the chart works:
+ *  - Chart data is server-side rendered into `data-data` HTML attribute on
+ *    `[id^="slimstat_chart_data_"]` element (readable without AJAX)
+ *  - `slimstat_fetch_chart_data` AJAX fires only when user changes granularity
+ *  - Both paths go through DataBuckets::addRow() — same fix applies to both
+ *
  * Tests:
- *  1. Weekly chart totals match DB record count (default DB)
- *  2. Weekly chart totals match DB record count (custom DB filter active)
- *  3. Boundary edge case: records in the last week of range still appear
+ *  1. Direct AJAX call returns v1 sum matching DB count (default DB)
+ *  2. Server-rendered chart `data-data` v1 sum >= DB count (default DB)
+ *  3. Out-of-range records are NOT counted in chart
+ *  4. Empty range — zero records, no crash, sum = 0
+ *  5. Custom DB filter active — Query.php still reads from default DB (no split)
+ *  6. Phantom bucket regression — last-week records land in valid bucket
+ *
+ * Source: Support #14684 / GitHub #231
  */
 import { test, expect } from '@playwright/test';
-import * as mysql from 'mysql2/promise';
 import {
   installOptionMutator,
   uninstallOptionMutator,
@@ -33,12 +43,8 @@ import {
 } from './helpers/setup';
 import { BASE_URL } from './helpers/env';
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
+// ─── DB helpers ───────────────────────────────────────────────────────────────
 
-/**
- * Insert N stat rows with a given Unix timestamp directly into wp_slim_stats.
- * Uses a synthetic resource path so rows are identifiable in assertions.
- */
 async function insertRows(timestamp: number, count: number, label: string): Promise<void> {
   const pool = getPool();
   for (let i = 0; i < count; i++) {
@@ -50,7 +56,6 @@ async function insertRows(timestamp: number, count: number, label: string): Prom
   }
 }
 
-/** Count all rows inserted by this test suite. */
 async function countTestRows(): Promise<number> {
   const [rows] = (await getPool().execute(
     "SELECT COUNT(*) as cnt FROM wp_slim_stats WHERE user_agent = 'databuckets-e2e-test'"
@@ -58,74 +63,100 @@ async function countTestRows(): Promise<number> {
   return parseInt(rows[0].cnt, 10);
 }
 
+// ─── Chart AJAX helper ─────────────────────────────────────────────────────────
+
 /**
- * Intercept the slimstat_fetch_chart_data AJAX response to get chart datasets.
- * Navigates to the admin dashboard and waits for the first chart data AJAX response.
- * Returns the parsed JSON response or null if none was captured within timeout.
+ * Navigate to slimview2 and extract the chart nonce.
+ *
+ * Must be called BEFORE any state that could break slimview2 rendering —
+ * specifically before activating the custom DB simulator, which causes
+ * wp_slimstat_db to query a non-existent slimext_slim_stats table.
  */
-async function captureChartData(
-  page: import('@playwright/test').Page,
-  startTs: number,
-  endTs: number,
-  granularity: 'weekly' | 'daily' | 'monthly' = 'weekly'
-): Promise<any> {
-  let chartResponse: any = null;
-
-  // Intercept the AJAX call for chart data
-  page.on('response', async (response) => {
-    if (
-      response.url().includes('admin-ajax.php') &&
-      response.request().method() === 'POST'
-    ) {
-      try {
-        const body = await response.text();
-        if (body.includes('datasets')) {
-          chartResponse = JSON.parse(body);
-        }
-      } catch {
-        // Ignore non-JSON responses
-      }
-    }
+async function extractChartNonce(page: import('@playwright/test').Page): Promise<string> {
+  await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview2`, {
+    waitUntil: 'domcontentloaded',
   });
-
-  // Navigate to the dashboard with a specific date range to trigger chart data load
-  // SlimStat uses start_date / end_date (YYYY-MM-DD) params
-  const fmt = (ts: number) => {
-    const d = new Date(ts * 1000);
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-  };
-  const startDate = fmt(startTs);
-  const endDate = fmt(endTs);
-
-  await page.goto(
-    `${BASE_URL}/wp-admin/admin.php?page=slimview1&start_date=${startDate}&end_date=${endDate}&granularity=${granularity}`,
-    { waitUntil: 'domcontentloaded' }
-  );
-
-  // Wait for chart AJAX response to land
-  await page.waitForTimeout(6000);
-
-  return chartResponse;
+  const nonce = await page.evaluate(() => (window as any).slimstat_chart_vars?.nonce || null);
+  if (!nonce) throw new Error('slimstat_chart_vars.nonce not found — chart JS not loaded on slimview2');
+  return nonce;
 }
 
 /**
- * Sum all v1 values across all datasets buckets in a DataBuckets response.
+ * Call the slimstat_fetch_chart_data AJAX endpoint with a pre-fetched nonce.
+ * Use extractChartNonce() first, especially when page state may break slimview2.
  */
-function sumChartV1(chartData: any): number {
-  if (!chartData?.data?.datasets) return 0;
-  const datasets = chartData.data.datasets;
-  // datasets may be { v1: [...], v2: [...] } or an array — handle both
-  if (datasets.v1 && Array.isArray(datasets.v1)) {
-    return (datasets.v1 as number[]).reduce((a, b) => a + b, 0);
+async function callChartAjaxWithNonce(
+  page: import('@playwright/test').Page,
+  nonce: string,
+  startTs: number,
+  endTs: number,
+  granularity: 'weekly' | 'daily' | 'monthly' | 'hourly' | 'yearly' = 'weekly'
+): Promise<any> {
+  const args = JSON.stringify({
+    start: startTs,
+    end: endTs,
+    chart_data: {
+      data1: 'COUNT(id)',
+      data2: 'COUNT( DISTINCT ip )',
+    },
+  });
+
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'slimstat_fetch_chart_data', nonce, args, granularity },
+  });
+
+  expect(res.ok(), `Chart AJAX returned HTTP ${res.status()}`).toBe(true);
+  return res.json();
+}
+
+/**
+ * Convenience: extract nonce from slimview2 then call chart AJAX.
+ * Only use when slimview2 is guaranteed to render correctly (no custom DB active).
+ */
+async function callChartAjax(
+  page: import('@playwright/test').Page,
+  startTs: number,
+  endTs: number,
+  granularity: 'weekly' | 'daily' | 'monthly' | 'hourly' | 'yearly' = 'weekly'
+): Promise<any> {
+  const nonce = await extractChartNonce(page);
+  return callChartAjaxWithNonce(page, nonce, startTs, endTs, granularity);
+}
+
+/**
+ * Read the server-rendered chart data from the `data-data` HTML attribute.
+ * This is what the page shows on first load (without any AJAX interaction).
+ */
+async function readServerRenderedChart(page: import('@playwright/test').Page): Promise<any> {
+  const raw = await page.evaluate(() => {
+    const el = document.querySelector('[id^="slimstat_chart_data_"]');
+    return el ? el.getAttribute('data-data') : null;
+  });
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
   }
-  // Fallback: iterate all keys
-  let total = 0;
-  for (const key of Object.keys(datasets)) {
-    if (Array.isArray(datasets[key])) {
-      total += (datasets[key] as number[]).reduce((a: number, b: number) => a + b, 0);
-    }
+}
+
+/**
+ * Sum all v1 values in chart datasets.
+ * Handles both AJAX response structure (json.data.data.datasets.v1)
+ * and server-rendered structure (json.datasets.v1).
+ */
+function sumV1(json: any): number {
+  // AJAX response: { success: true, data: { data: { datasets: { v1: [...] } } } }
+  const ajaxDatasets = json?.data?.data?.datasets?.v1;
+  if (Array.isArray(ajaxDatasets)) {
+    return (ajaxDatasets as number[]).reduce((a, b) => a + b, 0);
   }
-  return total;
+  // Server-rendered: { datasets: { v1: [...] } }
+  const serverDatasets = json?.datasets?.v1;
+  if (Array.isArray(serverDatasets)) {
+    return (serverDatasets as number[]).reduce((a, b) => a + b, 0);
+  }
+  return 0;
 }
 
 // ─── Test suite ───────────────────────────────────────────────────────────────
@@ -133,18 +164,18 @@ function sumChartV1(chartData: any): number {
 test.describe('DataBuckets chart accuracy — default and custom DB (Support #14684)', () => {
   test.setTimeout(180_000);
 
-  // 3-week range ending today
+  // 3-week range ending now
   const now = Math.floor(Date.now() / 1000);
   const week = 7 * 24 * 3600;
   const rangeStart = now - 3 * week;
   const rangeEnd = now;
 
   // Timestamps for records in each of 3 weeks
-  const week1Ts = rangeStart + Math.floor(week * 0.5);  // middle of week 1
-  const week2Ts = rangeStart + Math.floor(week * 1.5);  // middle of week 2
-  const week3Ts = rangeStart + Math.floor(week * 2.5);  // middle of week 3 (current)
+  const week1Ts = rangeStart + Math.floor(week * 0.5); // middle of week 1
+  const week2Ts = rangeStart + Math.floor(week * 1.5); // middle of week 2
+  const week3Ts = rangeStart + Math.floor(week * 2.5); // middle of week 3
 
-  test.beforeAll(async () => {
+  test.beforeAll(() => {
     installOptionMutator();
     installMuPluginByName('custom-db-simulator-mu-plugin.php');
   });
@@ -169,118 +200,216 @@ test.describe('DataBuckets chart accuracy — default and custom DB (Support #14
     await restoreOption('slimstat_test_use_custom_db');
   });
 
-  // ─── Test 1: Chart weekly totals match DB (default DB) ────────────────────
+  // ─── Test 1: Direct AJAX — sum matches DB count ──────────────────────────────
 
-  test('weekly chart total matches inserted record count — default DB', async ({ page }) => {
-    // Insert 9 known records across 3 weeks: 3 + 4 + 2
-    await insertRows(week1Ts, 3, 'w1');
-    await insertRows(week2Ts, 4, 'w2');
-    await insertRows(week3Ts, 2, 'w3');
+  test('direct AJAX: weekly chart v1 sum equals inserted record count (default DB)', async ({ page }) => {
+    // Insert 9 records across 3 weeks: 3 + 4 + 2
+    await insertRows(week1Ts, 3, 'ajax-w1');
+    await insertRows(week2Ts, 4, 'ajax-w2');
+    await insertRows(week3Ts, 2, 'ajax-w3');
 
     const dbCount = await countTestRows();
     expect(dbCount).toBe(9);
 
-    const chartData = await captureChartData(page, rangeStart, rangeEnd, 'weekly');
+    const json = await callChartAjax(page, rangeStart, rangeEnd, 'weekly');
 
-    // If chart data was captured via AJAX interception, verify totals
-    if (chartData?.success) {
-      const chartTotal = sumChartV1(chartData);
-      // Chart total should match DB — no records lost to phantom bucket
-      expect(chartTotal).toBeGreaterThanOrEqual(dbCount);
-      console.log(`Test 1: DB=${dbCount}, chart.v1 sum=${chartTotal}`);
-    } else {
-      // Chart AJAX wasn't intercepted — verify page renders without errors as fallback
-      const html = await page.content();
-      expect(html).not.toContain('Fatal error');
-      expect(html).not.toContain('Call to undefined function');
-      console.log(`Test 1: Chart AJAX not intercepted. DB=${dbCount}. Page rendered without errors.`);
+    // AJAX must succeed — nonce validated, no PHP error
+    expect(json.success, `AJAX error: ${JSON.stringify(json.data)}`).toBe(true);
+
+    // Chart v1 (pageviews) sum must equal DB count — no records silently lost
+    const chartSum = sumV1(json);
+    expect(chartSum).toBe(dbCount);
+
+    // Correct number of labels: one per ISO week in range (3 weeks)
+    const labels: string[] = json?.data?.data?.labels ?? [];
+    expect(labels.length).toBeGreaterThanOrEqual(3);
+
+    console.log(`Test 1 PASS — DB=${dbCount}, chart.v1 sum=${chartSum}, labels=${labels.length}`);
+  });
+
+  // ─── Test 2: Server-rendered — sum matches DB count ─────────────────────────
+
+  test('server-rendered chart data-data v1 sum >= inserted record count (default DB)', async ({ page }) => {
+    await insertRows(week1Ts, 3, 'sr-w1');
+    await insertRows(week2Ts, 4, 'sr-w2');
+    await insertRows(week3Ts, 2, 'sr-w3');
+
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(9);
+
+    // Navigate to slimview2 — chart reports (slim_p1_01) are rendered server-side here
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview2`, {
+      waitUntil: 'domcontentloaded',
+    });
+    // Use 'attached' not 'visible' — chart elements may be inside collapsed postboxes
+    await page.waitForSelector('[id^="slimstat_chart_data_"]', { state: 'attached', timeout: 10_000 });
+
+    const chartData = await readServerRenderedChart(page);
+    expect(chartData, 'data-data attribute missing or empty').not.toBeNull();
+
+    // The page has a default date range (usually last 30 days); our records are within it
+    const chartSum = sumV1(chartData);
+    // chartSum >= 9: our 9 records should be in the default date range
+    // (may be > 9 if there is other existing data in the DB for this range)
+    expect(chartSum).toBeGreaterThanOrEqual(dbCount);
+
+    const html = await page.content();
+    expect(html).not.toContain('Fatal error');
+    expect(html).not.toContain('Undefined offset');
+
+    console.log(`Test 2 PASS — DB=${dbCount}, server-rendered sum=${chartSum}`);
+  });
+
+  // ─── Test 3: Out-of-range records are NOT counted ────────────────────────────
+
+  test('records with dt outside the AJAX range are excluded from chart datasets', async ({ page }) => {
+    // Insert 5 records INSIDE the 3-week range
+    await insertRows(week2Ts, 5, 'in-range');
+
+    // Insert 3 records OUTSIDE the range (7 days before rangeStart)
+    const beforeRangeTs = rangeStart - week;
+    await insertRows(beforeRangeTs, 3, 'out-of-range');
+
+    const totalDb = await countTestRows();
+    expect(totalDb).toBe(8); // 5 in + 3 out
+
+    const json = await callChartAjax(page, rangeStart, rangeEnd, 'weekly');
+    expect(json.success).toBe(true);
+
+    const chartSum = sumV1(json);
+    // Chart should only count the 5 in-range records — out-of-range are filtered by DB query
+    expect(chartSum).toBe(5);
+
+    console.log(`Test 3 PASS — total DB=${totalDb}, in-range=5, chart.v1 sum=${chartSum}`);
+  });
+
+  // ─── Test 4: Empty range — zero records, no crash ────────────────────────────
+
+  test('chart AJAX returns success with v1 sum = 0 when no records exist', async ({ page }) => {
+    // DB is cleared in beforeEach — no records at all
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(0);
+
+    const json = await callChartAjax(page, rangeStart, rangeEnd, 'weekly');
+
+    // Must not crash — DataBuckets must handle empty results gracefully
+    expect(json.success, `Expected success, got: ${JSON.stringify(json.data)}`).toBe(true);
+
+    const chartSum = sumV1(json);
+    expect(chartSum).toBe(0);
+
+    // Labels must still be generated (buckets exist even when empty)
+    const labels: string[] = json?.data?.data?.labels ?? [];
+    expect(labels.length).toBeGreaterThanOrEqual(3); // 3 weeks → ≥3 labels
+
+    console.log(`Test 4 PASS — empty range, chart.v1 sum=${chartSum}, labels=${labels.length}`);
+  });
+
+  // ─── Test 5: Custom DB filter active — chart AJAX remains stable ──────────────
+
+  test('chart AJAX succeeds and reads from default wp_slim_stats when slimstat_custom_wpdb filter is active', async ({ page }) => {
+    /**
+     * Regression test: activating the slimstat_custom_wpdb filter must NOT crash
+     * the chart AJAX endpoint. The filter only affects wp_slimstat::$wpdb (used for
+     * tracking writes and admin queries); Chart.php's sqlFor() always uses global $wpdb
+     * via Query.php, so it always reads from wp_slim_stats regardless of the filter.
+     *
+     * Architecture note (confirmed from code):
+     *   - Chart.php:sqlFor()  → Query::select()->from($wpdb->prefix.'slim_stats')
+     *   - Query.__construct()  → $this->db = global $wpdb   ← unchanged by the filter
+     *   - wp_slimstat::$wpdb   → slimext_ prefix            ← only affects admin ops
+     *
+     * This test verifies that:
+     *   1. The AJAX handler returns HTTP 200 (no fatal / no "already closed" error)
+     *   2. Chart data accurately reflects wp_slim_stats contents (data is NOT lost)
+     *   3. The off-by-one fix (DataBuckets.php:209) works correctly under this filter
+     */
+
+    // Create the external DB table (required so wp_slimstat_admin::init() doesn't crash
+    // when it runs SHOW TABLES LIKE 'wp_slim_stats' via wp_slimstat::$wpdb)
+    await getPool().execute('CREATE TABLE IF NOT EXISTS slimext_slim_stats LIKE wp_slim_stats');
+
+    try {
+      // Extract nonce BEFORE activating the filter (safe to do either way, but consistent)
+      const nonce = await extractChartNonce(page);
+
+      // Insert 5 records into wp_slim_stats (the default table Chart.php reads from)
+      await insertRows(week2Ts, 5, 'custom-db-default');
+
+      // Activate the custom DB simulator — wp_slimstat::$wpdb now has prefix 'slimext_'
+      await getPool().execute(
+        "INSERT INTO wp_options (option_name, option_value, autoload) VALUES ('slimstat_test_use_custom_db', 'yes', 'yes') ON DUPLICATE KEY UPDATE option_value = 'yes'"
+      );
+
+      // Chart AJAX must succeed — the custom DB filter must NOT crash the handler
+      const json = await callChartAjaxWithNonce(page, nonce, rangeStart, rangeEnd, 'weekly');
+
+      expect(json.success, `AJAX error: ${JSON.stringify(json.data)}`).toBe(true);
+
+      // Chart reads from wp_slim_stats (global $wpdb path) — our 5 records must be visible
+      const chartSum = sumV1(json);
+      expect(chartSum).toBe(5);
+
+      const labels: string[] = json?.data?.data?.labels ?? [];
+      expect(labels.length).toBeGreaterThanOrEqual(3);
+
+      console.log(`Test 5 PASS — custom DB filter active, chart reads default DB: sum=${chartSum}, labels=${labels.length}`);
+    } finally {
+      // Cleanup external DB table regardless of test outcome
+      await getPool().execute('DROP TABLE IF EXISTS slimext_slim_stats');
     }
   });
 
-  // ─── Test 2: Custom DB filter active — no read/write split ───────────────
+  // ─── Test 6: Phantom bucket regression — boundary records counted correctly ──
 
-  test('weekly chart total matches DB when slimstat_custom_wpdb filter is active', async ({ page }) => {
-    // Activate the custom DB simulator filter
-    // NOTE: Since Query.php uses global $wpdb (not filtered), this confirms
-    // that the filter being active does NOT split reads and writes.
-    await getPool().execute(
-      "INSERT INTO wp_options (option_name, option_value, autoload) VALUES ('slimstat_test_use_custom_db', 'yes', 'yes') ON DUPLICATE KEY UPDATE option_value = 'yes'"
+  test('DataBuckets off-by-one regression: records at last-week boundary land in valid bucket', async ({ page }) => {
+    /**
+     * Regression test for DataBuckets.php:209 off-by-one:
+     *
+     * OLD: `$offset <= $this->points`  → allowed $offset == points → phantom bucket
+     * NEW: `$offset >= 0 && $offset < $this->points` → only [0, points-1] valid
+     *
+     * Scenario: insert records across ALL 3 weeks including specifically in week 3
+     * (the last valid bucket). With the old code, a calculation error could cause
+     * some last-week records to be placed in an out-of-bounds index.
+     *
+     * Assertion: sum(datasets.v1) == count of records inserted within the range.
+     * If any records silently fall into a phantom bucket, the sum will be less
+     * than the DB count — and this test will catch it.
+     */
+
+    // Insert 2 records near the end of the range (last week, close to rangeEnd)
+    // These are the records most likely to trigger the off-by-one
+    const lastWeekTs = rangeEnd - 3600; // 1 hour before end
+    const midLastWeekTs = rangeEnd - Math.floor(week * 0.25); // 1.75 days before end
+    await insertRows(lastWeekTs, 2, 'phantom-end');
+    await insertRows(midLastWeekTs, 3, 'phantom-mid-last');
+
+    // Also insert in weeks 1 and 2 to verify those buckets are fine
+    await insertRows(week1Ts, 1, 'phantom-w1');
+    await insertRows(week2Ts, 1, 'phantom-w2');
+
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(7); // 2 + 3 + 1 + 1
+
+    const json = await callChartAjax(page, rangeStart, rangeEnd, 'weekly');
+    expect(json.success, `AJAX error: ${JSON.stringify(json.data)}`).toBe(true);
+
+    const chartSum = sumV1(json);
+
+    // Critical assertion: ALL valid records must appear in chart.
+    // If the off-by-one bug is present, records near the range boundary
+    // would land in datasets[points] (phantom, no label) and be invisible.
+    expect(chartSum).toBe(dbCount);
+
+    // Verify no extra phantom datasets beyond label count
+    const labels: string[] = json?.data?.data?.labels ?? [];
+    const v1Array: number[] = json?.data?.data?.datasets?.v1 ?? [];
+    // After the fix, v1 array length should match labels length
+    expect(v1Array.length).toBeLessThanOrEqual(labels.length);
+
+    console.log(
+      `Test 6 PASS — DB=${dbCount}, chart.v1 sum=${chartSum}, labels=${labels.length}, v1 array length=${v1Array.length}`
     );
-
-    // Insert 9 records spanning 3 weeks
-    await insertRows(week1Ts, 3, 'custom-w1');
-    await insertRows(week2Ts, 4, 'custom-w2');
-    await insertRows(week3Ts, 2, 'custom-w3');
-
-    const dbCount = await countTestRows();
-    expect(dbCount).toBe(9);
-
-    // Trigger a live pageview to confirm new tracking still writes to the correct DB
-    const ctxAnon = await page.context().browser()!.newContext({ storageState: undefined } as any);
-    const anonPage = await ctxAnon.newPage();
-    await anonPage.goto(`${BASE_URL}/?databuckets-custom-db-live`, { waitUntil: 'domcontentloaded' });
-    await anonPage.waitForTimeout(3000);
-    await anonPage.close();
-    await ctxAnon.close();
-
-    // Count rows again — the live tracking row should be present
-    const [liveRows] = (await getPool().execute(
-      "SELECT COUNT(*) as cnt FROM wp_slim_stats WHERE resource LIKE '%databuckets-custom-db-live%'"
-    )) as any;
-    const liveCount = parseInt(liveRows[0].cnt, 10);
-    // Live tracking may or may not fire depending on settings/user agent filtering
-    // Assert at minimum the 9 inserted rows are still present
-    const totalAfterLive = await countTestRows();
-    expect(totalAfterLive).toBe(9);
-
-    // Navigate to chart
-    const chartData = await captureChartData(page, rangeStart, rangeEnd, 'weekly');
-
-    if (chartData?.success) {
-      const chartTotal = sumChartV1(chartData);
-      // Chart should see at least the 9 DB rows — no split
-      expect(chartTotal).toBeGreaterThanOrEqual(9);
-      console.log(`Test 2 (custom DB): DB=${totalAfterLive}, chart.v1 sum=${chartTotal}, live rows=${liveCount}`);
-    } else {
-      const html = await page.content();
-      expect(html).not.toContain('Fatal error');
-      console.log(`Test 2 (custom DB): Chart AJAX not intercepted. DB=${totalAfterLive}. No fatal error.`);
-    }
-  });
-
-  // ─── Test 3: Boundary edge case — last week of range still counted ────────
-
-  test('records at the last-week boundary are counted in chart, not phantom bucket', async ({ page }) => {
-    // Insert records specifically into the last week of the 3-week range
-    // With the old bug ($offset <= $this->points), records at offset == 3 would
-    // land in datasets[3] with no label and be silently invisible.
-    // After fix ($offset >= 0 && $offset < $this->points), these are correctly
-    // placed at offset 2 (last bucket) or rejected if truly out of bounds.
-    const lastWeekTs = rangeEnd - 3600; // 1 hour before range end
-    await insertRows(lastWeekTs, 5, 'boundary');
-
-    const dbCount = await countTestRows();
-    expect(dbCount).toBe(5);
-
-    const chartData = await captureChartData(page, rangeStart, rangeEnd, 'weekly');
-
-    if (chartData?.success) {
-      const chartTotal = sumChartV1(chartData);
-      // After fix: boundary records counted in valid bucket, not phantom
-      expect(chartTotal).toBeGreaterThanOrEqual(5);
-
-      // Also confirm no PHP error about undefined offset
-      const html = await page.content();
-      expect(html).not.toContain('Undefined offset');
-      expect(html).not.toContain('Fatal error');
-
-      console.log(`Test 3 (boundary): DB=${dbCount}, chart.v1 sum=${chartTotal}`);
-    } else {
-      // Fallback: page must render without errors
-      const html = await page.content();
-      expect(html).not.toContain('Fatal error');
-      expect(html).not.toContain('Undefined offset');
-      console.log(`Test 3 (boundary): Chart AJAX not intercepted. DB=${dbCount}. No errors.`);
-    }
   });
 });

--- a/tests/e2e/databuckets-custom-db-accuracy.spec.ts
+++ b/tests/e2e/databuckets-custom-db-accuracy.spec.ts
@@ -1,0 +1,286 @@
+/**
+ * E2E: DataBuckets chart accuracy — default and custom DB simulation
+ *
+ * Validates the fix for off-by-one bounds check in DataBuckets::addRow().
+ * The bug: `$offset <= $this->points` allowed records to be stored in a
+ * phantom bucket (index == points) with no corresponding label, causing
+ * those records to be silently dropped from chart display.
+ * The fix: `$offset >= 0 && $offset < $this->points`
+ *
+ * Also simulates the slimstat_custom_wpdb filter (used by the external DB addon)
+ * to confirm that Query.php's use of global $wpdb creates no read/write split.
+ *
+ * Tests:
+ *  1. Weekly chart totals match DB record count (default DB)
+ *  2. Weekly chart totals match DB record count (custom DB filter active)
+ *  3. Boundary edge case: records in the last week of range still appear
+ */
+import { test, expect } from '@playwright/test';
+import * as mysql from 'mysql2/promise';
+import {
+  installOptionMutator,
+  uninstallOptionMutator,
+  setSlimstatOption,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+  clearStatsTable,
+  getPool,
+  closeDb,
+  installMuPluginByName,
+  uninstallMuPluginByName,
+  snapshotOption,
+  restoreOption,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Insert N stat rows with a given Unix timestamp directly into wp_slim_stats.
+ * Uses a synthetic resource path so rows are identifiable in assertions.
+ */
+async function insertRows(timestamp: number, count: number, label: string): Promise<void> {
+  const pool = getPool();
+  for (let i = 0; i < count; i++) {
+    await pool.execute(
+      `INSERT INTO wp_slim_stats (dt, ip, resource, browser, browser_version, platform, language, visit_id, user_agent)
+       VALUES (?, '127.0.0.1', ?, 'test', '0', 'test', 'en', 1, 'databuckets-e2e-test')`,
+      [timestamp, `/databuckets-e2e-${label}-${i}`]
+    );
+  }
+}
+
+/** Count all rows inserted by this test suite. */
+async function countTestRows(): Promise<number> {
+  const [rows] = (await getPool().execute(
+    "SELECT COUNT(*) as cnt FROM wp_slim_stats WHERE user_agent = 'databuckets-e2e-test'"
+  )) as any;
+  return parseInt(rows[0].cnt, 10);
+}
+
+/**
+ * Intercept the slimstat_fetch_chart_data AJAX response to get chart datasets.
+ * Navigates to the admin dashboard and waits for the first chart data AJAX response.
+ * Returns the parsed JSON response or null if none was captured within timeout.
+ */
+async function captureChartData(
+  page: import('@playwright/test').Page,
+  startTs: number,
+  endTs: number,
+  granularity: 'weekly' | 'daily' | 'monthly' = 'weekly'
+): Promise<any> {
+  let chartResponse: any = null;
+
+  // Intercept the AJAX call for chart data
+  page.on('response', async (response) => {
+    if (
+      response.url().includes('admin-ajax.php') &&
+      response.request().method() === 'POST'
+    ) {
+      try {
+        const body = await response.text();
+        if (body.includes('datasets')) {
+          chartResponse = JSON.parse(body);
+        }
+      } catch {
+        // Ignore non-JSON responses
+      }
+    }
+  });
+
+  // Navigate to the dashboard with a specific date range to trigger chart data load
+  // SlimStat uses start_date / end_date (YYYY-MM-DD) params
+  const fmt = (ts: number) => {
+    const d = new Date(ts * 1000);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  };
+  const startDate = fmt(startTs);
+  const endDate = fmt(endTs);
+
+  await page.goto(
+    `${BASE_URL}/wp-admin/admin.php?page=slimview1&start_date=${startDate}&end_date=${endDate}&granularity=${granularity}`,
+    { waitUntil: 'domcontentloaded' }
+  );
+
+  // Wait for chart AJAX response to land
+  await page.waitForTimeout(6000);
+
+  return chartResponse;
+}
+
+/**
+ * Sum all v1 values across all datasets buckets in a DataBuckets response.
+ */
+function sumChartV1(chartData: any): number {
+  if (!chartData?.data?.datasets) return 0;
+  const datasets = chartData.data.datasets;
+  // datasets may be { v1: [...], v2: [...] } or an array — handle both
+  if (datasets.v1 && Array.isArray(datasets.v1)) {
+    return (datasets.v1 as number[]).reduce((a, b) => a + b, 0);
+  }
+  // Fallback: iterate all keys
+  let total = 0;
+  for (const key of Object.keys(datasets)) {
+    if (Array.isArray(datasets[key])) {
+      total += (datasets[key] as number[]).reduce((a: number, b: number) => a + b, 0);
+    }
+  }
+  return total;
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+test.describe('DataBuckets chart accuracy — default and custom DB (Support #14684)', () => {
+  test.setTimeout(180_000);
+
+  // 3-week range ending today
+  const now = Math.floor(Date.now() / 1000);
+  const week = 7 * 24 * 3600;
+  const rangeStart = now - 3 * week;
+  const rangeEnd = now;
+
+  // Timestamps for records in each of 3 weeks
+  const week1Ts = rangeStart + Math.floor(week * 0.5);  // middle of week 1
+  const week2Ts = rangeStart + Math.floor(week * 1.5);  // middle of week 2
+  const week3Ts = rangeStart + Math.floor(week * 2.5);  // middle of week 3 (current)
+
+  test.beforeAll(async () => {
+    installOptionMutator();
+    installMuPluginByName('custom-db-simulator-mu-plugin.php');
+  });
+
+  test.afterAll(async () => {
+    uninstallOptionMutator();
+    uninstallMuPluginByName('custom-db-simulator-mu-plugin.php');
+    await closeDb();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await snapshotSlimstatOptions();
+    await snapshotOption('slimstat_test_use_custom_db');
+    await clearStatsTable();
+    await setSlimstatOption(page, 'is_tracking', 'on');
+    await setSlimstatOption(page, 'gdpr_enabled', 'off');
+    await setSlimstatOption(page, 'ignore_wp_users', 'off');
+  });
+
+  test.afterEach(async () => {
+    await restoreSlimstatOptions();
+    await restoreOption('slimstat_test_use_custom_db');
+  });
+
+  // ─── Test 1: Chart weekly totals match DB (default DB) ────────────────────
+
+  test('weekly chart total matches inserted record count — default DB', async ({ page }) => {
+    // Insert 9 known records across 3 weeks: 3 + 4 + 2
+    await insertRows(week1Ts, 3, 'w1');
+    await insertRows(week2Ts, 4, 'w2');
+    await insertRows(week3Ts, 2, 'w3');
+
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(9);
+
+    const chartData = await captureChartData(page, rangeStart, rangeEnd, 'weekly');
+
+    // If chart data was captured via AJAX interception, verify totals
+    if (chartData?.success) {
+      const chartTotal = sumChartV1(chartData);
+      // Chart total should match DB — no records lost to phantom bucket
+      expect(chartTotal).toBeGreaterThanOrEqual(dbCount);
+      console.log(`Test 1: DB=${dbCount}, chart.v1 sum=${chartTotal}`);
+    } else {
+      // Chart AJAX wasn't intercepted — verify page renders without errors as fallback
+      const html = await page.content();
+      expect(html).not.toContain('Fatal error');
+      expect(html).not.toContain('Call to undefined function');
+      console.log(`Test 1: Chart AJAX not intercepted. DB=${dbCount}. Page rendered without errors.`);
+    }
+  });
+
+  // ─── Test 2: Custom DB filter active — no read/write split ───────────────
+
+  test('weekly chart total matches DB when slimstat_custom_wpdb filter is active', async ({ page }) => {
+    // Activate the custom DB simulator filter
+    // NOTE: Since Query.php uses global $wpdb (not filtered), this confirms
+    // that the filter being active does NOT split reads and writes.
+    await getPool().execute(
+      "INSERT INTO wp_options (option_name, option_value, autoload) VALUES ('slimstat_test_use_custom_db', 'yes', 'yes') ON DUPLICATE KEY UPDATE option_value = 'yes'"
+    );
+
+    // Insert 9 records spanning 3 weeks
+    await insertRows(week1Ts, 3, 'custom-w1');
+    await insertRows(week2Ts, 4, 'custom-w2');
+    await insertRows(week3Ts, 2, 'custom-w3');
+
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(9);
+
+    // Trigger a live pageview to confirm new tracking still writes to the correct DB
+    const ctxAnon = await page.context().browser()!.newContext({ storageState: undefined } as any);
+    const anonPage = await ctxAnon.newPage();
+    await anonPage.goto(`${BASE_URL}/?databuckets-custom-db-live`, { waitUntil: 'domcontentloaded' });
+    await anonPage.waitForTimeout(3000);
+    await anonPage.close();
+    await ctxAnon.close();
+
+    // Count rows again — the live tracking row should be present
+    const [liveRows] = (await getPool().execute(
+      "SELECT COUNT(*) as cnt FROM wp_slim_stats WHERE resource LIKE '%databuckets-custom-db-live%'"
+    )) as any;
+    const liveCount = parseInt(liveRows[0].cnt, 10);
+    // Live tracking may or may not fire depending on settings/user agent filtering
+    // Assert at minimum the 9 inserted rows are still present
+    const totalAfterLive = await countTestRows();
+    expect(totalAfterLive).toBe(9);
+
+    // Navigate to chart
+    const chartData = await captureChartData(page, rangeStart, rangeEnd, 'weekly');
+
+    if (chartData?.success) {
+      const chartTotal = sumChartV1(chartData);
+      // Chart should see at least the 9 DB rows — no split
+      expect(chartTotal).toBeGreaterThanOrEqual(9);
+      console.log(`Test 2 (custom DB): DB=${totalAfterLive}, chart.v1 sum=${chartTotal}, live rows=${liveCount}`);
+    } else {
+      const html = await page.content();
+      expect(html).not.toContain('Fatal error');
+      console.log(`Test 2 (custom DB): Chart AJAX not intercepted. DB=${totalAfterLive}. No fatal error.`);
+    }
+  });
+
+  // ─── Test 3: Boundary edge case — last week of range still counted ────────
+
+  test('records at the last-week boundary are counted in chart, not phantom bucket', async ({ page }) => {
+    // Insert records specifically into the last week of the 3-week range
+    // With the old bug ($offset <= $this->points), records at offset == 3 would
+    // land in datasets[3] with no label and be silently invisible.
+    // After fix ($offset >= 0 && $offset < $this->points), these are correctly
+    // placed at offset 2 (last bucket) or rejected if truly out of bounds.
+    const lastWeekTs = rangeEnd - 3600; // 1 hour before range end
+    await insertRows(lastWeekTs, 5, 'boundary');
+
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(5);
+
+    const chartData = await captureChartData(page, rangeStart, rangeEnd, 'weekly');
+
+    if (chartData?.success) {
+      const chartTotal = sumChartV1(chartData);
+      // After fix: boundary records counted in valid bucket, not phantom
+      expect(chartTotal).toBeGreaterThanOrEqual(5);
+
+      // Also confirm no PHP error about undefined offset
+      const html = await page.content();
+      expect(html).not.toContain('Undefined offset');
+      expect(html).not.toContain('Fatal error');
+
+      console.log(`Test 3 (boundary): DB=${dbCount}, chart.v1 sum=${chartTotal}`);
+    } else {
+      // Fallback: page must render without errors
+      const html = await page.content();
+      expect(html).not.toContain('Fatal error');
+      expect(html).not.toContain('Undefined offset');
+      console.log(`Test 3 (boundary): Chart AJAX not intercepted. DB=${dbCount}. No errors.`);
+    }
+  });
+});

--- a/tests/e2e/databuckets-custom-db-accuracy.spec.ts
+++ b/tests/e2e/databuckets-custom-db-accuracy.spec.ts
@@ -412,4 +412,52 @@ test.describe('DataBuckets chart accuracy — default and custom DB (Support #14
       `Test 6 PASS — DB=${dbCount}, chart.v1 sum=${chartSum}, labels=${labels.length}, v1 array length=${v1Array.length}`
     );
   });
+
+  // ─── Test 7: Monthly granularity — sum matches DB count ──────────────────────
+
+  test('chart AJAX with MONTHLY granularity: v1 sum equals inserted record count', async ({ page }) => {
+    /**
+     * Coverage gap for DataBuckets.php:209 fix — MONTH granularity uses a
+     * different offset formula ($diff->y * 12 + $diff->m) from WEEK.
+     * Records before the range start calculate to offset -1 and are rejected
+     * by the >= 0 check (not shifted, just dropped — shiftDatasets() is dead).
+     *
+     * This test verifies that records within a 2-month range all land in valid
+     * buckets and the chart sum equals the DB count.
+     */
+
+    // Fixed 2-month range: 2026-02-01 → 2026-03-31 UTC (past, cache-eligible range)
+    const monthStart = 1738368000; // 2026-02-01 00:00 UTC
+    const monthEnd   = 1743379199; // 2026-03-31 23:59 UTC
+    const feb15Ts    = 1739577600; // 2026-02-15 UTC (mid Feb)
+    const mar10Ts    = 1741564800; // 2026-03-10 UTC (mid Mar)
+
+    await insertRows(feb15Ts, 4, 'month-feb');
+    await insertRows(mar10Ts, 3, 'month-mar');
+
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(7);
+
+    // Clear transients — past ranges are cached; stale cache from other tests would fail this
+    await getPool().execute(
+      "DELETE FROM wp_options WHERE option_name LIKE '_transient_wp_slimstat_%' OR option_name LIKE '_transient_timeout_wp_slimstat_%'"
+    );
+
+    const json = await callChartAjax(page, monthStart, monthEnd, 'monthly');
+    expect(json.success, `AJAX error: ${JSON.stringify(json.data)}`).toBe(true);
+
+    const chartSum = sumV1(json);
+
+    // All 7 records are within the 2-month range; none should fall to offset -1
+    expect(chartSum).toBe(dbCount);
+
+    const labels: string[] = json?.data?.data?.labels ?? [];
+    expect(labels.length).toBeGreaterThanOrEqual(2); // Feb + Mar
+
+    // v1 array length must not exceed label count (no phantom bucket beyond bounds)
+    const v1Array: number[] = json?.data?.data?.datasets?.v1 ?? [];
+    expect(v1Array.length).toBeLessThanOrEqual(labels.length);
+
+    console.log(`Test 7 PASS — monthly: DB=${dbCount}, chart.v1 sum=${chartSum}, labels=${labels.length}`);
+  });
 });

--- a/tests/e2e/databuckets-no-calendar-ext.spec.ts
+++ b/tests/e2e/databuckets-no-calendar-ext.spec.ts
@@ -1,0 +1,302 @@
+/**
+ * E2E: DataBuckets — ext-calendar fallback regression (Issue #228 / v5.4.3)
+ *
+ * Validates that DataBuckets::initSeqWeek() does NOT call jddayofweek(),
+ * which requires PHP's optional ext-calendar extension.
+ *
+ * Background:
+ *   Pre-v5.4.3: initSeqWeek() called jddayofweek() unconditionally from within
+ *   the SlimStat\Helpers namespace. On servers without ext-calendar (Synology NAS,
+ *   minimal PHP installs), this caused a fatal: "Call to undefined function
+ *   SlimStat\Helpers\jddayofweek()" → chart AJAX → HTTP 500 → admin down.
+ *   Source: Support #14684
+ *
+ * Fix (v5.4.3 / PR #229):
+ *   Replaced jddayofweek() with self::DAY_NAMES[], a pure-PHP constant
+ *   requiring no extensions.
+ *
+ * Test strategy:
+ *   The calendar-ext-simulator mu-plugin defines SlimStat\Helpers\jddayofweek()
+ *   to throw a RuntimeException. PHP resolves unqualified jddayofweek() calls
+ *   inside DataBuckets to this stub BEFORE looking at the global ext-calendar
+ *   function — exactly what happens when ext-calendar is absent.
+ *
+ *   Key sequence per test:
+ *     1. Obtain chart nonce via test_create_nonce AJAX (nonce-helper mu-plugin)
+ *     2. Install simulator (now active for subsequent PHP requests)
+ *     3. Call chart AJAX with WEEK granularity
+ *        → If old code: jddayofweek() is called → stub throws → HTTP 500
+ *        → If fixed code: DAY_NAMES used → stub never called → HTTP 200
+ *     4. Uninstall simulator (cleanup)
+ *
+ * Tests:
+ *   1. Chart AJAX with WEEK granularity returns HTTP 200 — no fatal from jddayofweek()
+ *   2. Chart data sum matches DB count — DAY_NAMES produces correct week boundaries
+ *   3. start_of_week = 0 (Sunday) — DAY_NAMES[0] resolves correctly
+ *   4. Corrupted start_of_week option — ?? 'Monday' fallback prevents crash
+ */
+import { test, expect } from '@playwright/test';
+import {
+  clearStatsTable,
+  getPool,
+  closeDb,
+  installMuPluginByName,
+  uninstallMuPluginByName,
+  snapshotOption,
+  restoreOption,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+
+const SIMULATOR = 'calendar-ext-simulator-mu-plugin.php';
+
+// ─── DB helpers ───────────────────────────────────────────────────────────────
+
+async function insertWeeklyRows(timestamp: number, count: number, label: string): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await getPool().execute(
+      `INSERT INTO wp_slim_stats (dt, ip, resource, browser, browser_version, platform, language, visit_id, user_agent)
+       VALUES (?, '127.0.0.1', ?, 'test', '0', 'test', 'en', 1, 'no-cal-ext-e2e')`,
+      [timestamp, `/no-cal-ext-${label}-${i}`]
+    );
+  }
+}
+
+async function countTestRows(): Promise<number> {
+  const [rows] = (await getPool().execute(
+    "SELECT COUNT(*) as cnt FROM wp_slim_stats WHERE user_agent = 'no-cal-ext-e2e'"
+  )) as any;
+  return parseInt(rows[0].cnt, 10);
+}
+
+// ─── Chart AJAX helpers ───────────────────────────────────────────────────────
+
+/**
+ * Obtain the chart nonce via the nonce-helper AJAX endpoint.
+ *
+ * The nonce-helper mu-plugin exposes `test_create_nonce` which calls
+ * wp_create_nonce() server-side for any nonce action. This is more reliable
+ * than scraping slimstat_chart_vars from the page, because the page render may
+ * fail (e.g., corrupted start_of_week, missing chart module, bad date range).
+ *
+ * Requires the nonce-helper mu-plugin to be installed (done in beforeAll).
+ */
+async function extractChartNonce(page: import('@playwright/test').Page): Promise<string> {
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'test_create_nonce', nonce_action: 'slimstat_chart_nonce' },
+  });
+  if (!res.ok()) throw new Error(`test_create_nonce failed: HTTP ${res.status()}`);
+  const body = await res.json();
+  if (!body?.success || !body?.data?.nonce) {
+    throw new Error(`test_create_nonce returned unexpected body: ${JSON.stringify(body)}`);
+  }
+  return body.data.nonce;
+}
+
+async function callChartAjax(
+  page: import('@playwright/test').Page,
+  nonce: string,
+  startTs: number,
+  endTs: number,
+  granularity: 'weekly' | 'daily' | 'monthly' = 'weekly'
+): Promise<{ status: number; body: any }> {
+  const args = JSON.stringify({
+    start: startTs,
+    end: endTs,
+    chart_data: { data1: 'COUNT(id)', data2: 'COUNT( DISTINCT ip )' },
+  });
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'slimstat_fetch_chart_data', nonce, args, granularity },
+  });
+  return { status: res.status(), body: res.ok() ? await res.json() : null };
+}
+
+function sumV1(json: any): number {
+  const v1: number[] = json?.data?.data?.datasets?.v1 ?? [];
+  return v1.reduce((a: number, b: number) => a + b, 0);
+}
+
+// ─── Time anchors ─────────────────────────────────────────────────────────────
+
+// 3-week window anchored to a known Monday (2026-02-02)
+const week1Ts = 1738454400; // 2026-02-02 00:00 UTC (Monday)
+const week2Ts = week1Ts + 7 * 86400;  // 2026-02-09
+const week3Ts = week1Ts + 14 * 86400; // 2026-02-16
+const rangeStart = week1Ts;
+const rangeEnd = week1Ts + 21 * 86400; // 2026-02-23
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+test.describe('DataBuckets — ext-calendar fallback (Issue #228)', () => {
+  test.setTimeout(120_000);
+
+  test.beforeAll(() => {
+    // nonce-helper provides test_create_nonce AJAX action for reliable nonce generation
+    installMuPluginByName('nonce-helper-mu-plugin.php');
+  });
+
+  test.afterAll(async () => {
+    // Safety: ensure simulator and nonce-helper are removed even if a test crashed
+    try { uninstallMuPluginByName(SIMULATOR); } catch {}
+    try { uninstallMuPluginByName('nonce-helper-mu-plugin.php'); } catch {}
+    await closeDb();
+  });
+
+  test.beforeEach(async () => {
+    await clearStatsTable();
+    // Clear chart transients: the chart caches SQL results for past date ranges.
+    // Without this, test 2+ see stale cached counts from test 1.
+    await getPool().execute(
+      "DELETE FROM wp_options WHERE option_name LIKE '_transient_wp_slimstat_%' OR option_name LIKE '_transient_timeout_wp_slimstat_%'"
+    );
+    await snapshotOption('start_of_week');
+  });
+
+  test.afterEach(async () => {
+    // Safety net: remove simulator in case a test left it installed
+    try { uninstallMuPluginByName(SIMULATOR); } catch {}
+    await restoreOption('start_of_week');
+  });
+
+  // ─── Test 1: WEEK granularity returns 200 — no jddayofweek() called ──────
+
+  test('chart AJAX with WEEK granularity returns HTTP 200 when jddayofweek() would throw', async ({ page }) => {
+    /**
+     * Core regression test. The calendar-ext-simulator mu-plugin makes any
+     * call to jddayofweek() inside SlimStat\Helpers throw a RuntimeException.
+     * With the v5.4.3 fix, DAY_NAMES is used → jddayofweek() is never called
+     * → HTTP 200.
+     *
+     * Nonce is obtained via test_create_nonce BEFORE installing the simulator.
+     * The simulator is then installed before the AJAX call — it is active for
+     * that PHP request.
+     */
+    await insertWeeklyRows(week2Ts, 5, 'w2');
+
+    // Step 1: get nonce (simulator not yet active)
+    const nonce = await extractChartNonce(page);
+
+    // Step 2: activate simulator — jddayofweek() now throws if called
+    installMuPluginByName(SIMULATOR);
+    try {
+      const { status, body } = await callChartAjax(page, nonce, rangeStart, rangeEnd, 'weekly');
+
+      expect(
+        status,
+        `Chart AJAX returned HTTP ${status} — jddayofweek() may have been called. ` +
+        'Ensure initSeqWeek() uses DAY_NAMES[] not jddayofweek() (v5.4.3 regression)'
+      ).toBe(200);
+
+      expect(body?.success, `AJAX error: ${JSON.stringify(body?.data)}`).toBe(true);
+
+      console.log(`Test 1 PASS — HTTP ${status}, success=${body?.success} (no jddayofweek() fatal)`);
+    } finally {
+      uninstallMuPluginByName(SIMULATOR);
+    }
+  });
+
+  // ─── Test 2: Chart sum matches DB count — DAY_NAMES produces correct buckets
+
+  test('chart v1 sum matches DB row count — DAY_NAMES week boundaries are correct', async ({ page }) => {
+    /**
+     * Verifies that replacing jddayofweek() with DAY_NAMES[] produces the same
+     * week-boundary labels. If DAY_NAMES has a wrong value, records fall into
+     * the wrong bucket or the phantom bucket (off-by-one), causing sum < DB count.
+     */
+    // 3 records per week × 3 weeks = 9 total
+    await insertWeeklyRows(week1Ts + 86400, 3, 'w1');
+    await insertWeeklyRows(week2Ts + 86400, 3, 'w2');
+    await insertWeeklyRows(week3Ts + 86400, 3, 'w3');
+
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(9);
+
+    const nonce = await extractChartNonce(page);
+    installMuPluginByName(SIMULATOR);
+    try {
+      const { status, body } = await callChartAjax(page, nonce, rangeStart, rangeEnd, 'weekly');
+
+      expect(status).toBe(200);
+      expect(body?.success).toBe(true);
+
+      const chartSum = sumV1(body);
+      const labels: string[] = body?.data?.data?.labels ?? [];
+
+      expect(chartSum).toBe(dbCount);
+      expect(labels.length).toBeGreaterThanOrEqual(3);
+
+      console.log(`Test 2 PASS — DB=${dbCount}, chart.v1 sum=${chartSum}, labels=${labels.length}`);
+    } finally {
+      uninstallMuPluginByName(SIMULATOR);
+    }
+  });
+
+  // ─── Test 3: start_of_week = 0 (Sunday) ──────────────────────────────────
+
+  test('chart works correctly with start_of_week = 0 (Sunday)', async ({ page }) => {
+    /**
+     * DAY_NAMES[0] = 'Sunday'. Verifies that the Sunday start-of-week path
+     * in initSeqWeek() produces valid labels without calling jddayofweek().
+     */
+    await getPool().execute(
+      "INSERT INTO wp_options (option_name, option_value, autoload) VALUES ('start_of_week', '0', 'yes') " +
+      "ON DUPLICATE KEY UPDATE option_value = '0'"
+    );
+
+    await insertWeeklyRows(week2Ts, 4, 'sunday-start');
+
+    const nonce = await extractChartNonce(page);
+    installMuPluginByName(SIMULATOR);
+    try {
+      const { status, body } = await callChartAjax(page, nonce, rangeStart, rangeEnd, 'weekly');
+
+      expect(status).toBe(200);
+      expect(body?.success).toBe(true);
+
+      const chartSum = sumV1(body);
+      const labels: string[] = body?.data?.data?.labels ?? [];
+
+      expect(labels.length).toBeGreaterThanOrEqual(1);
+      expect(chartSum).toBeGreaterThan(0);
+
+      console.log(`Test 3 PASS — start_of_week=0 (Sunday), chart.v1 sum=${chartSum}, labels=${labels.length}`);
+    } finally {
+      uninstallMuPluginByName(SIMULATOR);
+    }
+  });
+
+  // ─── Test 4: Corrupted start_of_week falls back safely ───────────────────
+
+  test('corrupted start_of_week option falls back to Monday — no fatal', async ({ page }) => {
+    /**
+     * Defensive fallback added in v5.4.3 PR #229:
+     *   self::DAY_NAMES[$startOfWeek] ?? 'Monday'
+     * If start_of_week holds an invalid value (corrupted option), the ?? 'Monday'
+     * fallback keeps the chart working rather than crashing.
+     */
+    await getPool().execute(
+      "INSERT INTO wp_options (option_name, option_value, autoload) VALUES ('start_of_week', '99', 'yes') " +
+      "ON DUPLICATE KEY UPDATE option_value = '99'"
+    );
+
+    await insertWeeklyRows(week2Ts, 3, 'corrupted-sow');
+
+    const nonce = await extractChartNonce(page);
+    installMuPluginByName(SIMULATOR);
+    try {
+      const { status, body } = await callChartAjax(page, nonce, rangeStart, rangeEnd, 'weekly');
+
+      expect(
+        status,
+        'Chart crashed on corrupted start_of_week — ?? Monday fallback may be missing'
+      ).toBe(200);
+      expect(body?.success).toBe(true);
+
+      const labels: string[] = body?.data?.data?.labels ?? [];
+      expect(labels.length).toBeGreaterThanOrEqual(1);
+
+      console.log(`Test 4 PASS — corrupted start_of_week=99, fell back safely, labels=${labels.length}`);
+    } finally {
+      uninstallMuPluginByName(SIMULATOR);
+    }
+  });
+});

--- a/tests/e2e/exclusion-filters.spec.ts
+++ b/tests/e2e/exclusion-filters.spec.ts
@@ -43,6 +43,8 @@ add_action('init', function() {
         'supports'     => ['title', 'editor'],
         'show_in_rest' => true,
     ]);
+    // Flush rewrite rules so /product/{slug}/ pretty permalinks resolve immediately.
+    flush_rewrite_rules();
 });
 `;
 
@@ -123,11 +125,13 @@ test.describe('Exclusion Filters (@tracking-exclusions)', () => {
     const anonCtx = await browser.newContext();
     const anonPage = await anonCtx.newPage();
     await anonPage.goto(productUrl, { waitUntil: 'domcontentloaded' });
-    await anonPage.waitForTimeout(4000);
 
-    // Check that no row was tracked for this specific resource
-    const stat = await getRecentStatByResource(slug);
-    expect(stat).toBeNull();
+    // Server-side tracking fires during shutdown (same PHP request), so the DB
+    // state is settled by the time goto() resolves. Poll until consistent null.
+    await expect.poll(
+      () => getRecentStatByResource(slug),
+      { timeout: 6_000, intervals: [500] }
+    ).toBeNull();
 
     await anonPage.close();
     await anonCtx.close();
@@ -155,13 +159,16 @@ test.describe('Exclusion Filters (@tracking-exclusions)', () => {
     const anonCtx = await browser.newContext();
     const anonPage = await anonCtx.newPage();
     await anonPage.goto(productUrl, { waitUntil: 'domcontentloaded' });
-    await anonPage.waitForTimeout(4000);
 
-    // Without cpt: prefix, the exclusion should NOT match — pageview tracked
-    const stat = await getRecentStatByResource(slug);
-    expect(stat).not.toBeNull();
+    // Without cpt: prefix, the exclusion should NOT match — pageview tracked.
+    // Poll until the row appears (expect.poll returns void, so fetch separately for assertions).
+    await expect.poll(
+      () => getRecentStatByResource(slug),
+      { timeout: 10_000, intervals: [500] }
+    ).not.toBeNull();
 
     // Verify the tracked row has content_type starting with 'cpt:'
+    const stat = await getRecentStatByResource(slug);
     expect(stat!.content_type).toMatch(/^cpt:/);
 
     await anonPage.close();
@@ -181,23 +188,27 @@ test.describe('Exclusion Filters (@tracking-exclusions)', () => {
 
     const countBefore = await getStatCount();
 
-    // Visit with Googlebot UA
-    const anonCtx = await browser.newContext({
-      userAgent: 'Googlebot/2.1 (+http://www.google.com/bot.html)',
-    });
-    const anonPage = await anonCtx.newPage();
-    const marker = `e2e-bot-test-${Date.now()}`;
-    await anonPage.goto(`${BASE_URL}/?e2e_marker=${marker}`, { waitUntil: 'domcontentloaded' });
-    await anonPage.waitForTimeout(4000);
+    let anonCtx: import('@playwright/test').BrowserContext | undefined;
+    let anonPage: import('@playwright/test').Page | undefined;
+    try {
+      // Visit with Googlebot UA
+      anonCtx = await browser.newContext({
+        userAgent: 'Googlebot/2.1 (+http://www.google.com/bot.html)',
+      });
+      anonPage = await anonCtx.newPage();
+      const marker = `e2e-bot-test-${Date.now()}`;
+      await anonPage.goto(`${BASE_URL}/?e2e_marker=${marker}`, { waitUntil: 'domcontentloaded' });
 
-    const countAfter = await getStatCount();
-
-    // Bot should be excluded
-    expect(countAfter).toBe(countBefore);
-
-    await anonPage.close();
-    await anonCtx.close();
-    uninstallHeaderInjector();
+      // Bot should be excluded — poll to confirm count stays unchanged
+      await expect.poll(
+        () => getStatCount(),
+        { timeout: 6_000, intervals: [500] }
+      ).toBe(countBefore);
+    } finally {
+      await anonPage?.close();
+      await anonCtx?.close();
+      uninstallHeaderInjector();
+    }
   });
 
   // ────────────────────────────────────────────────────────────────
@@ -213,12 +224,12 @@ test.describe('Exclusion Filters (@tracking-exclusions)', () => {
     const anonCtx = await browser.newContext();
     const anonPage = await anonCtx.newPage();
     await anonPage.goto(`${BASE_URL}/wp-login.php`, { waitUntil: 'domcontentloaded' });
-    await anonPage.waitForTimeout(4000);
 
-    const countAfter = await getStatCount();
-
-    // wp-login.php should be excluded
-    expect(countAfter).toBe(countBefore);
+    // wp-login.php should be excluded — poll to confirm count stays unchanged
+    await expect.poll(
+      () => getStatCount(),
+      { timeout: 6_000, intervals: [500] }
+    ).toBe(countBefore);
 
     await anonPage.close();
     await anonCtx.close();
@@ -246,16 +257,12 @@ test.describe('Exclusion Filters (@tracking-exclusions)', () => {
     // Navigate as logged-in admin to a frontend page with a marker
     const marker = `e2e-user-excl-${Date.now()}`;
     await adminPage.goto(`${BASE_URL}/?e2e_marker=${marker}`, { waitUntil: 'domcontentloaded' });
-    await adminPage.waitForTimeout(4000);
 
-    // Check specifically for a tracked row matching our marker URL
-    const [rows] = await getPool().execute(
-      'SELECT id, resource, username, content_type FROM wp_slim_stats WHERE resource LIKE ?',
-      [`%${marker}%`]
-    ) as any;
-
-    // Admin should NOT be tracked — no row matching our marker
-    expect(rows.length).toBe(0);
+    // Admin should NOT be tracked — poll to confirm no row matching our marker appears
+    await expect.poll(
+      () => getRecentStatByResource(marker),
+      { timeout: 6_000, intervals: [500] }
+    ).toBeNull();
 
     await adminPage.close();
     await adminCtx.close();

--- a/tests/e2e/exclusion-filters.spec.ts
+++ b/tests/e2e/exclusion-filters.spec.ts
@@ -1,0 +1,263 @@
+/**
+ * E2E: Exclusion Filters — validates ignore_content_types, ignore_bots,
+ * ignore_resources, and ignore_wp_users in the tracking pipeline.
+ *
+ * Covers GitHub issue #233 (CPT exclusion requires cpt: prefix).
+ *
+ * @see jaan-to/outputs/qa/cases/10-exclusion-filters/10-test-cases-exclusion-filters.md
+ */
+import { test, expect } from '@playwright/test';
+import {
+  getPool,
+  closeDb,
+  clearStatsTable,
+  setSlimstatSetting,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+  installHeaderInjector,
+  uninstallHeaderInjector,
+  setHeaderOverrides,
+  enableDisableWpCron,
+  restoreWpConfig,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+import * as path from 'path';
+import * as fs from 'fs';
+import { WP_ROOT } from './helpers/env';
+
+// ─── CPT registration mu-plugin ──────────────────────────────────
+const MU_PLUGINS_DIR = path.join(WP_ROOT, 'wp-content', 'mu-plugins');
+const CPT_MU_PLUGIN = path.join(MU_PLUGINS_DIR, 'e2e-test-product-cpt.php');
+
+const CPT_MU_PLUGIN_CONTENT = `<?php
+/**
+ * E2E Test: Register 'product' CPT for exclusion filter testing.
+ */
+if (!defined('ABSPATH')) exit;
+add_action('init', function() {
+    register_post_type('product', [
+        'public'       => true,
+        'label'        => 'Products',
+        'has_archive'  => true,
+        'rewrite'      => ['slug' => 'product'],
+        'supports'     => ['title', 'editor'],
+        'show_in_rest' => true,
+    ]);
+});
+`;
+
+function installCptMuPlugin(): void {
+  fs.mkdirSync(MU_PLUGINS_DIR, { recursive: true });
+  fs.writeFileSync(CPT_MU_PLUGIN, CPT_MU_PLUGIN_CONTENT, 'utf8');
+}
+
+function uninstallCptMuPlugin(): void {
+  if (fs.existsSync(CPT_MU_PLUGIN)) fs.unlinkSync(CPT_MU_PLUGIN);
+}
+
+// ─── DB helpers ──────────────────────────────────────────────────
+
+async function getRecentStatByResource(resourceLike: string): Promise<any | null> {
+  const [rows] = await getPool().execute(
+    'SELECT id, resource, content_type, browser_type, username FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id DESC LIMIT 1',
+    [`%${resourceLike}%`]
+  ) as any;
+  return rows.length > 0 ? rows[0] : null;
+}
+
+async function getStatCount(): Promise<number> {
+  const [rows] = await getPool().execute('SELECT COUNT(*) as cnt FROM wp_slim_stats') as any;
+  return rows[0].cnt;
+}
+
+async function createProductPost(title: string, slug: string): Promise<number> {
+  const now = new Date().toISOString().slice(0, 19).replace('T', ' ');
+  const [result] = await getPool().execute(
+    `INSERT INTO wp_posts (post_author, post_date, post_date_gmt, post_content, post_title, post_excerpt, post_status, comment_status, ping_status, post_name, post_modified, post_modified_gmt, post_type, to_ping, pinged, post_content_filtered)
+     VALUES (1, ?, ?, 'Test content.', ?, '', 'publish', 'closed', 'closed', ?, ?, ?, 'product', '', '', '')`,
+    [now, now, title, slug, now, now]
+  ) as any;
+  return result.insertId;
+}
+
+// ─── Test suite ──────────────────────────────────────────────────
+
+test.describe('Exclusion Filters (@tracking-exclusions)', () => {
+  test.beforeAll(async () => {
+    enableDisableWpCron();
+    installCptMuPlugin();
+    await snapshotSlimstatOptions();
+    // Ensure server-side tracking is on
+    await setSlimstatSetting('javascript_mode', 'off');
+    await setSlimstatSetting('is_tracking', 'on');
+  });
+
+  test.afterAll(async () => {
+    await restoreSlimstatOptions();
+    uninstallCptMuPlugin();
+    restoreWpConfig();
+    await closeDb();
+  });
+
+  test.beforeEach(async () => {
+    await clearStatsTable();
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Test 1: CPT exclusion WITH cpt: prefix — should exclude
+  // REQ-EXCL-003 — @smoke @positive @priority-critical
+  // ────────────────────────────────────────────────────────────────
+  test('CPT excluded when ignore_content_types contains cpt:product', async ({ browser }) => {
+    await setSlimstatSetting('ignore_content_types', 'cpt:product');
+
+    // Create product post via direct DB insert
+    const slug = `e2e-cpt-excl-${Date.now()}`;
+    const postId = await createProductPost('E2E CPT Exclusion Test', slug);
+    // Use pretty permalink to avoid 301 redirect being tracked as redirect:301
+    const productUrl = `${BASE_URL}/product/${slug}/`;
+
+    // Clear stats after post creation
+    await clearStatsTable();
+
+    // Visit single product post as anonymous user
+    const anonCtx = await browser.newContext();
+    const anonPage = await anonCtx.newPage();
+    await anonPage.goto(productUrl, { waitUntil: 'domcontentloaded' });
+    await anonPage.waitForTimeout(4000);
+
+    // Check that no row was tracked for this specific resource
+    const stat = await getRecentStatByResource(slug);
+    expect(stat).toBeNull();
+
+    await anonPage.close();
+    await anonCtx.close();
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Test 2: CPT exclusion WITHOUT prefix — should NOT exclude
+  // REQ-EXCL-004 — @smoke @negative @priority-critical
+  // Confirms GitHub issue #233 behavior
+  // ────────────────────────────────────────────────────────────────
+  test('CPT NOT excluded when ignore_content_types lacks cpt: prefix (#233)', async ({ browser }) => {
+    // Set exclusion WITHOUT the cpt: prefix — this should fail to match
+    await setSlimstatSetting('ignore_content_types', 'product');
+
+    // Create product post via direct DB insert
+    const slug = `e2e-cpt-noprefix-${Date.now()}`;
+    const postId = await createProductPost('E2E No-Prefix Product', slug);
+    // Use pretty permalink to avoid 301 redirect being tracked as redirect:301
+    const productUrl = `${BASE_URL}/product/${slug}/`;
+
+    // Clear stats after post creation
+    await clearStatsTable();
+
+    // Visit as anonymous
+    const anonCtx = await browser.newContext();
+    const anonPage = await anonCtx.newPage();
+    await anonPage.goto(productUrl, { waitUntil: 'domcontentloaded' });
+    await anonPage.waitForTimeout(4000);
+
+    // Without cpt: prefix, the exclusion should NOT match — pageview tracked
+    const stat = await getRecentStatByResource(slug);
+    expect(stat).not.toBeNull();
+
+    // Verify the tracked row has content_type starting with 'cpt:'
+    expect(stat!.content_type).toMatch(/^cpt:/);
+
+    await anonPage.close();
+    await anonCtx.close();
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Test 3: Bot exclusion — ignore_bots=on excludes Googlebot
+  // REQ-EXCL-001 — @smoke @positive @priority-critical
+  // ────────────────────────────────────────────────────────────────
+  test('Bot excluded when ignore_bots is on with Googlebot UA', async ({ browser }) => {
+    await setSlimstatSetting('ignore_bots', 'on');
+
+    // Install header injector to override UA server-side
+    installHeaderInjector();
+    setHeaderOverrides({ 'User-Agent': 'Googlebot/2.1 (+http://www.google.com/bot.html)' });
+
+    const countBefore = await getStatCount();
+
+    // Visit with Googlebot UA
+    const anonCtx = await browser.newContext({
+      userAgent: 'Googlebot/2.1 (+http://www.google.com/bot.html)',
+    });
+    const anonPage = await anonCtx.newPage();
+    const marker = `e2e-bot-test-${Date.now()}`;
+    await anonPage.goto(`${BASE_URL}/?e2e_marker=${marker}`, { waitUntil: 'domcontentloaded' });
+    await anonPage.waitForTimeout(4000);
+
+    const countAfter = await getStatCount();
+
+    // Bot should be excluded
+    expect(countAfter).toBe(countBefore);
+
+    await anonPage.close();
+    await anonCtx.close();
+    uninstallHeaderInjector();
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Test 4: Permalink exclusion — ignore_resources with /wp-login.php
+  // REQ-EXCL-005 — @smoke @positive @priority-critical
+  // ────────────────────────────────────────────────────────────────
+  test('Permalink excluded when ignore_resources matches /wp-login.php', async ({ browser }) => {
+    await setSlimstatSetting('ignore_resources', '/wp-login.php');
+
+    const countBefore = await getStatCount();
+
+    // Visit wp-login.php as anonymous
+    const anonCtx = await browser.newContext();
+    const anonPage = await anonCtx.newPage();
+    await anonPage.goto(`${BASE_URL}/wp-login.php`, { waitUntil: 'domcontentloaded' });
+    await anonPage.waitForTimeout(4000);
+
+    const countAfter = await getStatCount();
+
+    // wp-login.php should be excluded
+    expect(countAfter).toBe(countBefore);
+
+    await anonPage.close();
+    await anonCtx.close();
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Test 5: User exclusion — ignore_wp_users=on with logged-in admin
+  // REQ-EXCL-006 — @smoke @positive @priority-critical
+  // ────────────────────────────────────────────────────────────────
+  test('Logged-in admin excluded when ignore_wp_users is on', async ({ browser }) => {
+    await setSlimstatSetting('ignore_wp_users', 'on');
+
+    // Login directly in a fresh browser context
+    const adminCtx = await browser.newContext();
+    const adminPage = await adminCtx.newPage();
+    await adminPage.goto(`${BASE_URL}/wp-login.php`);
+    await adminPage.fill('#user_login', 'parhumm');
+    await adminPage.fill('#user_pass', 'testpass123');
+    await adminPage.click('#wp-submit');
+    await adminPage.waitForURL('**/wp-admin/**', { timeout: 30_000 });
+
+    // Clear stats table after login
+    await clearStatsTable();
+
+    // Navigate as logged-in admin to a frontend page with a marker
+    const marker = `e2e-user-excl-${Date.now()}`;
+    await adminPage.goto(`${BASE_URL}/?e2e_marker=${marker}`, { waitUntil: 'domcontentloaded' });
+    await adminPage.waitForTimeout(4000);
+
+    // Check specifically for a tracked row matching our marker URL
+    const [rows] = await getPool().execute(
+      'SELECT id, resource, username, content_type FROM wp_slim_stats WHERE resource LIKE ?',
+      [`%${marker}%`]
+    ) as any;
+
+    // Admin should NOT be tracked — no row matching our marker
+    expect(rows.length).toBe(0);
+
+    await adminPage.close();
+    await adminCtx.close();
+  });
+});

--- a/tests/e2e/helpers/calendar-ext-simulator-mu-plugin.php
+++ b/tests/e2e/helpers/calendar-ext-simulator-mu-plugin.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * MU-Plugin: Calendar Extension Simulator
+ *
+ * Defines jddayofweek() in the SlimStat\Helpers namespace to throw a RuntimeException,
+ * simulating an environment where PHP's ext-calendar extension is not loaded.
+ *
+ * How PHP namespace resolution works here:
+ *   When DataBuckets::initSeqWeek() calls jddayofweek() (without a leading backslash),
+ *   PHP looks for SlimStat\Helpers\jddayofweek() first, before falling back to the
+ *   global ext-calendar function. Our stub intercepts that lookup and throws — identical
+ *   to what a server with no ext-calendar would do.
+ *
+ * After the v5.4.3 fix, initSeqWeek() uses self::DAY_NAMES[] instead of jddayofweek(),
+ * so this stub is never called and the chart loads cleanly.
+ *
+ * Used exclusively by E2E tests for the calendar-extension-fallback spec.
+ * Remove this file (or uninstall via setup.ts) to disable.
+ */
+
+namespace SlimStat\Helpers;
+
+function jddayofweek(int $julianday = 0, int $mode = 0): mixed
+{
+    throw new \RuntimeException(
+        'ext-calendar absent: jddayofweek() was called from SlimStat\\Helpers namespace. ' .
+        'DataBuckets must use the DAY_NAMES constant instead (v5.4.3 regression).'
+    );
+}

--- a/tests/e2e/helpers/custom-db-simulator-mu-plugin.php
+++ b/tests/e2e/helpers/custom-db-simulator-mu-plugin.php
@@ -20,5 +20,17 @@ add_filter('slimstat_custom_wpdb', function ($current_wpdb) {
     $custom         = clone $GLOBALS['wpdb'];
     $custom->prefix = 'slimext_';
 
+    // Reset the protected $result property to prevent "mysqli_result already closed" errors.
+    // clone() creates a shallow copy: $custom->result still references the same mysqli_result
+    // object as $GLOBALS['wpdb']->result. When the original wpdb frees that result on its next
+    // query, $custom->result holds a dangling closed resource → fatal on next use.
+    try {
+        $ref = new ReflectionProperty('wpdb', 'result');
+        $ref->setAccessible(true);
+        $ref->setValue($custom, null);
+    } catch (ReflectionException $e) {
+        // If reflection fails, proceed anyway; the worst case is a query-monitor warning.
+    }
+
     return $custom;
 });

--- a/tests/e2e/helpers/custom-db-simulator-mu-plugin.php
+++ b/tests/e2e/helpers/custom-db-simulator-mu-plugin.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * MU-Plugin: Custom DB Simulator
+ *
+ * Simulates the slimstat_custom_wpdb filter used by the external database addon.
+ * When the WP option "slimstat_test_use_custom_db" is set to "yes", this plugin
+ * hooks into the filter and returns a cloned wpdb instance with a different table
+ * prefix (slimext_), simulating an external database configuration.
+ *
+ * Used exclusively by E2E tests for the DataBuckets custom-db accuracy spec.
+ * Remove this file (or set the option to anything other than "yes") to disable.
+ */
+
+add_filter('slimstat_custom_wpdb', function ($current_wpdb) {
+    if (get_option('slimstat_test_use_custom_db') !== 'yes') {
+        return $current_wpdb;
+    }
+
+    // Use $GLOBALS to avoid PHP 8.2 fatal: cannot use global with same name as parameter
+    $custom         = clone $GLOBALS['wpdb'];
+    $custom->prefix = 'slimext_';
+
+    return $custom;
+});

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -65,6 +65,7 @@ const MU_PLUGIN_MANIFEST: MuPluginEntry[] = [
   { sourceFile: 'mail-sink-mu-plugin.php', deployedFile: 'mail-sink-mu-plugin.php' },
   { sourceFile: 'rewrite-flush-mu-plugin.php', deployedFile: 'rewrite-flush-mu-plugin.php' },
   { sourceFile: 'plugin-lifecycle-mu-plugin.php', deployedFile: 'plugin-lifecycle-mu-plugin.php' },
+  { sourceFile: 'custom-db-simulator-mu-plugin.php', deployedFile: 'custom-db-simulator-mu-plugin.php' },
 ];
 
 // ─── Generic MU-Plugin install/uninstall by name ──────────────────

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -66,6 +66,7 @@ const MU_PLUGIN_MANIFEST: MuPluginEntry[] = [
   { sourceFile: 'rewrite-flush-mu-plugin.php', deployedFile: 'rewrite-flush-mu-plugin.php' },
   { sourceFile: 'plugin-lifecycle-mu-plugin.php', deployedFile: 'plugin-lifecycle-mu-plugin.php' },
   { sourceFile: 'custom-db-simulator-mu-plugin.php', deployedFile: 'custom-db-simulator-mu-plugin.php' },
+  { sourceFile: 'calendar-ext-simulator-mu-plugin.php', deployedFile: 'calendar-ext-simulator-mu-plugin.php' },
 ];
 
 // ─── Generic MU-Plugin install/uninstall by name ──────────────────


### PR DESCRIPTION
## Summary

Fixes chart data not showing for users with hundreds of records in the database, but only a few visible in the chart. Root cause: an off-by-one bounds check in `DataBuckets::addRow()` silently discarded records into a phantom bucket.

Closes #231
Source: Support #14684

---

## Changes

### Bug fix — `src/Helpers/DataBuckets.php:209`

**What was wrong**: `$offset <= $this->points` allowed `$offset == $this->points` (one past the last valid index). Records that hashed to this offset were accumulated into `$datasets[points]` — a bucket with no corresponding label. The chart renderer silently dropped them, so those records were invisible in the UI despite existing in the database.

**Fix**: `$offset >= 0 && $offset < $this->points` — only valid indices [0, points-1] are accepted.

**Note on -1**: The `shiftDatasets()` method uses -1 as a sentinel for partial-period data. The old code unintentionally accepted all negative offsets too; the new lower bound >= 0 correctly excludes them.

### E2E test suite — `tests/e2e/databuckets-custom-db-accuracy.spec.ts` (new)

6 tests, all passing (19.5s):

| # | Test | What it proves |
|---|------|----------------|
| 1 | Direct AJAX — weekly v1 sum equals DB count | Off-by-one fix works end-to-end via the AJAX path |
| 2 | Server-rendered data-data attribute — sum >= DB count | Fix works on the server-side rendered page-load path |
| 3 | Out-of-range records excluded from chart | WHERE dt BETWEEN clause correctly scopes results |
| 4 | Empty range — sum=0, no crash | DataBuckets handles zero results gracefully |
| 5 | slimstat_custom_wpdb filter active — AJAX survives | Custom DB filter does not crash chart; Chart.php always reads from global wpdb |
| 6 | Phantom bucket regression — boundary records land in valid bucket | Records at rangeEnd-1h and rangeEnd-1.75d all appear in chart |

### Test helper — `tests/e2e/helpers/custom-db-simulator-mu-plugin.php` (new)

Simulates the `slimstat_custom_wpdb` filter. Includes a fix for a shallow-clone pitfall: after `clone $GLOBALS["wpdb"]`, the protected `$result` property (a `mysqli_result` resource) is reset via `ReflectionProperty`. Without this, both the clone and the original share the same closed result object, causing a fatal on the next query.

---

## Type of change

- [x] Fix - Fixes an existing bug
- [x] Dev - Development related task (E2E test suite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened data-bucketing bounds to prevent phantom or out-of-range data points and ensure weekly charts remain correct when calendar extensions are unavailable.

* **Documentation**
  * Clarified that custom post types in content-type exclusion filters require the cpt: prefix (e.g., cpt:product) and that content-type strings are case-insensitive.

* **Tests**
  * Added comprehensive end-to-end suites and supporting test helpers for data bucketing, exclusion filters, chart SQL validation, calendar-extension fallback, and custom-DB scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->