### PR TITLE
Fix weekly chart not showing today's data

### DIFF
--- a/src/Helpers/DataBuckets.php
+++ b/src/Helpers/DataBuckets.php
@@ -195,17 +195,10 @@ class DataBuckets
                 $offset = $diff->y * 12 + $diff->m;
             }
         } elseif ('WEEK' === $this->gran) {
-            $startOfWeek = (int) get_option('start_of_week', 1);
-
             // Calculate the start-of-week date for both base and dt
             // This respects WordPress start_of_week setting instead of using ISO weeks
-            $baseDayOfWeek = (int) date('w', $base); // 0=Sun, 6=Sat
-            $baseDiff = ($baseDayOfWeek - $startOfWeek + 7) % 7;
-            $baseWeekStart = strtotime(date('Y-m-d', strtotime("-{$baseDiff} days", $base)));
-
-            $dtDayOfWeek = (int) date('w', $dt);
-            $dtDiff = ($dtDayOfWeek - $startOfWeek + 7) % 7;
-            $dtWeekStart = strtotime(date('Y-m-d', strtotime("-{$dtDiff} days", $dt)));
+            $baseWeekStart = $this->getWeekStartTimestamp($base);
+            $dtWeekStart = $this->getWeekStartTimestamp($dt);
 
             // Calculate weeks between the two week start dates
             $offset = (int) round(($dtWeekStart - $baseWeekStart) / (7 * 86400));
@@ -243,6 +236,18 @@ class DataBuckets
             $timestamp = strtotime($offset, $baseTime);
             return date($params['data_points_label'], $timestamp);
         }, $labels, array_keys($labels));
+    }
+
+    /**
+     * Get the start-of-week timestamp for a given timestamp.
+     * Respects WordPress start_of_week setting.
+     */
+    private function getWeekStartTimestamp(int $timestamp): int
+    {
+        $startOfWeek = (int) get_option('start_of_week', 1);
+        $dayOfWeek = (int) date('w', $timestamp); // 0=Sun, 6=Sat
+        $diff = ($dayOfWeek - $startOfWeek + 7) % 7;
+        return strtotime(date('Y-m-d', strtotime("-{$diff} days", $timestamp)));
     }
 
     private function shiftDatasets(): void
@@ -284,7 +289,7 @@ class DataBuckets
             'prev_labels'   => $this->prev_labels,
             'datasets'      => $this->datasets,
             'datasets_prev' => $this->datasetsPrev,
-            'today'         => 'WEEK' === $this->gran && wp_date('YW', $this->end, wp_timezone()) === wp_date('YW', time(), wp_timezone()) ? str_replace("'", '', $this->labels[count($this->labels) - 1]) : wp_date($this->labelFormat, time(), wp_timezone()),
+            'today'         => 'WEEK' === $this->gran && $this->getWeekStartTimestamp($this->end) === $this->getWeekStartTimestamp(time()) ? str_replace("'", '', $this->labels[count($this->labels) - 1]) : wp_date($this->labelFormat, time(), wp_timezone()),
             'granularity'   => $this->gran,
         ];
     }

--- a/src/Helpers/DataBuckets.php
+++ b/src/Helpers/DataBuckets.php
@@ -195,7 +195,21 @@ class DataBuckets
                 $offset = $diff->y * 12 + $diff->m;
             }
         } elseif ('WEEK' === $this->gran) {
-            $offset = date('W', $dt) - date('W', $base) + (date('Y', $dt) - date('Y', $base)) * 52;
+            $startOfWeek = (int) get_option('start_of_week', 1);
+
+            // Calculate the start-of-week date for both base and dt
+            // This respects WordPress start_of_week setting instead of using ISO weeks
+            $baseDayOfWeek = (int) date('w', $base); // 0=Sun, 6=Sat
+            $baseDiff = ($baseDayOfWeek - $startOfWeek + 7) % 7;
+            $baseWeekStart = strtotime(date('Y-m-d', strtotime("-{$baseDiff} days", $base)));
+
+            $dtDayOfWeek = (int) date('w', $dt);
+            $dtDiff = ($dtDayOfWeek - $startOfWeek + 7) % 7;
+            $dtWeekStart = strtotime(date('Y-m-d', strtotime("-{$dtDiff} days", $dt)));
+
+            // Calculate weeks between the two week start dates
+            $offset = (int) round(($dtWeekStart - $baseWeekStart) / (7 * 86400));
+
             if ($offset < 0) {
                 $offset = -1;
             }

--- a/tests/e2e/chart-monthly-daily-granularity.spec.ts
+++ b/tests/e2e/chart-monthly-daily-granularity.spec.ts
@@ -1,0 +1,512 @@
+/**
+ * E2E: Monthly and Daily chart granularity validation
+ *
+ * Validates that monthly and daily chart bucketing produces correct
+ * totals and bucket assignments across different start_of_week settings.
+ * These granularities should NOT be affected by start_of_week, but
+ * we verify no regressions were introduced by the weekly fix.
+ *
+ * Tests cover:
+ *   - Monthly bucketing: correct month boundaries, sum = DB total
+ *   - Daily bucketing: correct day boundaries, sum = DB total
+ *   - Cross-granularity: daily, weekly, monthly all produce same total
+ *   - sow changes don't affect daily/monthly (only weekly)
+ *   - Previous period data populated for both granularities
+ */
+import { test, expect } from '@playwright/test';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getPool, closeDb, snapshotOption, restoreOption } from './helpers/setup';
+import { WP_ROOT } from './helpers/env';
+
+// ─── WP-CLI chart AJAX simulation ───────────────────────────────────────────
+
+function fetchChartData(startTs: number, endTs: number, granularity: string): any {
+  const tmpFile = path.join('/tmp', `slimstat-gran-${Date.now()}.php`);
+  const phpCode = `<?php
+wp_set_current_user(get_users(['role' => 'administrator', 'number' => 1])[0]->ID);
+
+$_POST['args'] = json_encode([
+    'start' => ${startTs},
+    'end' => ${endTs},
+    'chart_data' => [
+        'data1' => 'COUNT(id)',
+        'data2' => 'COUNT( DISTINCT ip )',
+    ],
+]);
+$_POST['granularity'] = '${granularity}';
+$_REQUEST['granularity'] = '${granularity}';
+$_POST['nonce'] = wp_create_nonce('slimstat_chart_nonce');
+$_REQUEST['_ajax_nonce'] = $_POST['nonce'];
+
+global $wpdb;
+$wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_wp_slimstat_%' OR option_name LIKE '_transient_timeout_wp_slimstat_%'");
+
+ob_start();
+try {
+    \\SlimStat\\Modules\\Chart::ajaxFetchChartData();
+} catch (\\Throwable $e) {
+    ob_end_clean();
+    echo json_encode(['error' => $e->getMessage()]);
+    exit;
+}
+$output = ob_get_clean();
+echo $output;
+`;
+
+  fs.writeFileSync(tmpFile, phpCode);
+
+  function extractJson(raw: string): any {
+    const start = raw.indexOf('{"success"');
+    if (start === -1) return null;
+    try {
+      return JSON.parse(raw.substring(start));
+    } catch {
+      let depth = 0;
+      for (let i = start; i < raw.length; i++) {
+        if (raw[i] === '{') depth++;
+        if (raw[i] === '}') depth--;
+        if (depth === 0) {
+          try { return JSON.parse(raw.substring(start, i + 1)); } catch { return null; }
+        }
+      }
+    }
+    return null;
+  }
+
+  try {
+    const raw = execSync(`wp eval-file "${tmpFile}" --path="${WP_ROOT}" 2>/dev/null`, {
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    const parsed = extractJson(raw);
+    if (parsed) return parsed;
+    throw new Error(`No JSON in output: ${raw.substring(0, 300)}`);
+  } catch (e: any) {
+    if (e.stdout) {
+      const parsed = extractJson(e.stdout);
+      if (parsed) return parsed;
+    }
+    throw new Error(`WP-CLI chart call failed: ${e.message}`);
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch {}
+  }
+}
+
+// ─── DB helpers ───────────────────────────────────────────────────────────────
+
+async function insertRows(timestamp: number, count: number, label: string): Promise<void> {
+  const pool = getPool();
+  for (let i = 0; i < count; i++) {
+    await pool.execute(
+      `INSERT INTO wp_slim_stats (dt, ip, resource, browser, browser_version, platform, language, visit_id, user_agent)
+       VALUES (?, CONCAT('10.0.0.', FLOOR(RAND()*254)+1), ?, 'test', '0', 'test', 'en', 1, 'gran-validation-e2e')`,
+      [timestamp + i * 60, `/gran-${label}-${i}`]
+    );
+  }
+}
+
+async function clearTestData(): Promise<void> {
+  await getPool().execute("TRUNCATE TABLE wp_slim_stats");
+  await getPool().execute(
+    "DELETE FROM wp_options WHERE option_name LIKE '_transient_wp_slimstat_%' OR option_name LIKE '_transient_timeout_wp_slimstat_%'"
+  );
+}
+
+function utcMidnight(dateStr: string): number {
+  return Math.floor(new Date(dateStr + 'T00:00:00Z').getTime() / 1000);
+}
+
+function getV1(json: any): number[] {
+  return json?.data?.data?.datasets?.v1 ?? [];
+}
+
+function getV1Prev(json: any): number[] {
+  return json?.data?.data?.datasets_prev?.v1 ?? [];
+}
+
+function getLabels(json: any): string[] {
+  return json?.data?.data?.labels ?? [];
+}
+
+function sumArr(arr: number[]): number {
+  return arr.reduce((a, b) => a + b, 0);
+}
+
+// ─── DAILY TESTS ──────────────────────────────────────────────────────────────
+
+test.describe('Daily chart granularity', () => {
+  test.setTimeout(90_000);
+
+  test.afterAll(async () => {
+    await clearTestData();
+    await closeDb();
+  });
+
+  test.beforeEach(async () => {
+    await clearTestData();
+  });
+
+  /**
+   * Test D1: Daily buckets — each day gets its own bucket, sum = DB total
+   */
+  test('D1: daily buckets match DB total for Last 28 Days', async () => {
+    const dates = [
+      '2026-02-18', '2026-02-20', '2026-02-25', '2026-03-01',
+      '2026-03-05', '2026-03-09', '2026-03-12', '2026-03-14',
+      '2026-03-15', '2026-03-16', '2026-03-17',
+    ];
+    for (const d of dates) {
+      await insertRows(utcMidnight(d), 5, d.replace(/-/g, ''));
+    }
+    const totalExpected = dates.length * 5; // 55
+
+    const rangeStart = utcMidnight('2026-02-18');
+    const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+    const json = fetchChartData(rangeStart, rangeEnd, 'daily');
+    expect(json?.success).toBe(true);
+
+    const v1 = getV1(json);
+    const labels = getLabels(json);
+    const chartSum = sumArr(v1);
+
+    console.log('=== D1: Daily buckets ===');
+    console.log('Labels count:', labels.length, 'V1 count:', v1.length);
+    console.log('Sum:', chartSum, 'Expected:', totalExpected);
+
+    expect(chartSum, 'Daily sum must match DB').toBe(totalExpected);
+    expect(v1.length, 'Bucket count = label count').toBe(labels.length);
+
+    // Each seeded date should have exactly 5 in its bucket
+    const nonZero = v1.filter(v => v > 0);
+    expect(nonZero.length, '11 days with data').toBe(11);
+    for (const val of nonZero) {
+      expect(val, 'Each day with data should have 5').toBe(5);
+    }
+
+    console.log('D1 PASS: daily sum =', chartSum, ', non-zero buckets =', nonZero.length);
+  });
+
+  /**
+   * Test D2: Daily is unaffected by start_of_week changes
+   */
+  test('D2: daily totals identical across sow=1, sow=0, sow=6', async () => {
+    await insertRows(utcMidnight('2026-02-18'), 10, 'feb18');
+    await insertRows(utcMidnight('2026-03-07'), 20, 'mar07');
+    await insertRows(utcMidnight('2026-03-14'), 15, 'mar14');
+    await insertRows(utcMidnight('2026-03-17'), 25, 'mar17');
+    const totalExpected = 70;
+
+    const rangeStart = utcMidnight('2026-02-18');
+    const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+    await snapshotOption('start_of_week');
+
+    const results: Record<string, number> = {};
+
+    for (const sow of ['1', '0', '6']) {
+      await getPool().execute("UPDATE wp_options SET option_value = ? WHERE option_name = 'start_of_week'", [sow]);
+      const json = fetchChartData(rangeStart, rangeEnd, 'daily');
+      expect(json?.success).toBe(true);
+      results[`sow${sow}`] = sumArr(getV1(json));
+    }
+
+    await restoreOption('start_of_week');
+
+    console.log('=== D2: Daily vs sow ===');
+    console.log('Results:', results);
+
+    expect(results['sow1'], 'sow=1 daily total').toBe(totalExpected);
+    expect(results['sow0'], 'sow=0 daily total').toBe(totalExpected);
+    expect(results['sow6'], 'sow=6 daily total').toBe(totalExpected);
+
+    console.log('D2 PASS: daily unaffected by sow changes, all =', totalExpected);
+  });
+
+  /**
+   * Test D3: Daily previous period is populated
+   */
+  test('D3: daily previous period data is populated', async () => {
+    // Current period
+    await insertRows(utcMidnight('2026-03-10'), 8, 'curr');
+    // Previous period (28 days earlier)
+    await insertRows(utcMidnight('2026-02-10'), 12, 'prev');
+
+    const rangeStart = utcMidnight('2026-02-18');
+    const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+    const json = fetchChartData(rangeStart, rangeEnd, 'daily');
+    expect(json?.success).toBe(true);
+
+    const v1 = getV1(json);
+    const v1Prev = getV1Prev(json);
+
+    console.log('=== D3: Daily prev period ===');
+    console.log('Current sum:', sumArr(v1), 'Prev sum:', sumArr(v1Prev));
+
+    expect(sumArr(v1), 'Current sum').toBe(8);
+    expect(sumArr(v1Prev), 'Previous period must have data').toBe(12);
+
+    console.log('D3 PASS: prev period sum =', sumArr(v1Prev));
+  });
+});
+
+// ─── MONTHLY TESTS ────────────────────────────────────────────────────────────
+
+test.describe('Monthly chart granularity', () => {
+  test.setTimeout(90_000);
+
+  test.afterAll(async () => {
+    await clearTestData();
+    await closeDb();
+  });
+
+  test.beforeEach(async () => {
+    await clearTestData();
+  });
+
+  /**
+   * Test M1: Monthly buckets — data grouped by calendar month
+   *
+   * Range: 6 months (Sep 2025 - Mar 2026) to trigger monthly granularity
+   */
+  test('M1: monthly buckets match DB total for 5-month range', async () => {
+    // Seed data across months (start from Nov to avoid first-bucket edge case)
+    await insertRows(utcMidnight('2025-11-20'), 15, 'nov');
+    await insertRows(utcMidnight('2025-12-25'), 20, 'dec');
+    await insertRows(utcMidnight('2026-01-10'), 25, 'jan');
+    await insertRows(utcMidnight('2026-02-14'), 30, 'feb');
+    await insertRows(utcMidnight('2026-03-07'), 35, 'mar');
+    const totalExpected = 15 + 20 + 25 + 30 + 35; // 125
+
+    // Start range at mid-October to avoid first-bucket timezone edge case
+    const rangeStart = utcMidnight('2025-10-15');
+    const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+    const json = fetchChartData(rangeStart, rangeEnd, 'monthly');
+    expect(json?.success).toBe(true);
+
+    const v1 = getV1(json);
+    const labels = getLabels(json);
+    const chartSum = sumArr(v1);
+
+    console.log('=== M1: Monthly buckets ===');
+    console.log('Labels:', labels);
+    console.log('V1:', v1);
+    console.log('Sum:', chartSum, 'Expected:', totalExpected);
+
+    expect(chartSum, 'Monthly sum must match DB').toBe(totalExpected);
+    expect(v1.length, 'Bucket count = label count').toBe(labels.length);
+
+    // November through March should each have their exact count
+    const novIdx = labels.findIndex(l => l.includes('November'));
+    const decIdx = labels.findIndex(l => l.includes('December'));
+    const janIdx = labels.findIndex(l => l.includes('January'));
+    const febIdx = labels.findIndex(l => l.includes('February'));
+    const marIdx = labels.findIndex(l => l.includes('March'));
+
+    expect(v1[novIdx], 'November').toBe(15);
+    expect(v1[decIdx], 'December').toBe(20);
+    expect(v1[janIdx], 'January').toBe(25);
+    expect(v1[febIdx], 'February').toBe(30);
+    expect(v1[marIdx], 'March').toBe(35);
+
+    console.log('M1 PASS: monthly sum =', chartSum, ', all months correct');
+  });
+
+  /**
+   * Test M2: Monthly is unaffected by start_of_week changes
+   */
+  test('M2: monthly totals identical across sow=1, sow=0, sow=6', async () => {
+    await insertRows(utcMidnight('2025-11-10'), 10, 'nov');
+    await insertRows(utcMidnight('2026-01-15'), 20, 'jan');
+    await insertRows(utcMidnight('2026-03-05'), 30, 'mar');
+    const totalExpected = 60;
+
+    const rangeStart = utcMidnight('2025-10-01');
+    const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+    await snapshotOption('start_of_week');
+
+    const results: Record<string, number> = {};
+
+    for (const sow of ['1', '0', '6']) {
+      await getPool().execute("UPDATE wp_options SET option_value = ? WHERE option_name = 'start_of_week'", [sow]);
+      const json = fetchChartData(rangeStart, rangeEnd, 'monthly');
+      expect(json?.success).toBe(true);
+      results[`sow${sow}`] = sumArr(getV1(json));
+    }
+
+    await restoreOption('start_of_week');
+
+    console.log('=== M2: Monthly vs sow ===');
+    console.log('Results:', results);
+
+    expect(results['sow1'], 'sow=1 monthly total').toBe(totalExpected);
+    expect(results['sow0'], 'sow=0 monthly total').toBe(totalExpected);
+    expect(results['sow6'], 'sow=6 monthly total').toBe(totalExpected);
+
+    console.log('M2 PASS: monthly unaffected by sow changes, all =', totalExpected);
+  });
+
+  /**
+   * Test M3: Monthly previous period is populated
+   */
+  test('M3: monthly previous period data is populated', async () => {
+    // Current period
+    await insertRows(utcMidnight('2026-02-15'), 10, 'curr');
+    // Previous period (6 months earlier = ~Aug 2025)
+    await insertRows(utcMidnight('2025-08-15'), 15, 'prev');
+
+    const rangeStart = utcMidnight('2025-10-01');
+    const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+    const json = fetchChartData(rangeStart, rangeEnd, 'monthly');
+    expect(json?.success).toBe(true);
+
+    const v1 = getV1(json);
+    const v1Prev = getV1Prev(json);
+
+    console.log('=== M3: Monthly prev period ===');
+    console.log('Current sum:', sumArr(v1), 'Prev sum:', sumArr(v1Prev));
+
+    expect(sumArr(v1), 'Current sum').toBe(10);
+    expect(sumArr(v1Prev), 'Previous period must have data').toBe(15);
+
+    console.log('M3 PASS: prev period sum =', sumArr(v1Prev));
+  });
+
+  /**
+   * Test M4: Month boundary — last day of Feb vs first day of Mar
+   */
+  test('M4: Feb 28 and Mar 1 land in different monthly buckets', async () => {
+    await insertRows(utcMidnight('2026-02-28'), 100, 'feb28');
+    await insertRows(utcMidnight('2026-03-01'), 200, 'mar01');
+
+    const rangeStart = utcMidnight('2025-10-01');
+    const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+    const json = fetchChartData(rangeStart, rangeEnd, 'monthly');
+    expect(json?.success).toBe(true);
+
+    const v1 = getV1(json);
+    const labels = getLabels(json);
+
+    console.log('=== M4: Month boundary ===');
+    console.log('Labels:', labels);
+    console.log('V1:', v1);
+
+    // Feb bucket and Mar bucket should be separate
+    const febIdx = labels.findIndex(l => l.includes('February'));
+    const marIdx = labels.findIndex(l => l.includes('March'));
+
+    expect(febIdx, 'February label exists').toBeGreaterThanOrEqual(0);
+    expect(marIdx, 'March label exists').toBeGreaterThanOrEqual(0);
+    expect(v1[febIdx], 'Feb bucket = 100').toBe(100);
+    expect(v1[marIdx], 'Mar bucket = 200').toBe(200);
+
+    console.log('M4 PASS: Feb=100, Mar=200 — boundary correct');
+  });
+});
+
+// ─── CROSS-GRANULARITY ────────────────────────────────────────────────────────
+
+test.describe('Cross-granularity consistency', () => {
+  test.setTimeout(90_000);
+
+  test.afterAll(async () => {
+    await clearTestData();
+    await closeDb();
+  });
+
+  test.beforeEach(async () => {
+    await clearTestData();
+  });
+
+  /**
+   * Test X1: All granularities produce same total with sow=6
+   */
+  test('X1: daily, weekly, monthly all produce same total (sow=6)', async () => {
+    await snapshotOption('start_of_week');
+    await getPool().execute("UPDATE wp_options SET option_value = '6' WHERE option_name = 'start_of_week'");
+
+    try {
+      // Seed from Nov onwards to avoid monthly first-bucket edge case
+      const dates = [
+        '2025-11-20', '2025-12-25',
+        '2026-01-10', '2026-02-14', '2026-02-28',
+        '2026-03-07', '2026-03-13', '2026-03-14', '2026-03-17',
+      ];
+      for (const d of dates) {
+        await insertRows(utcMidnight(d), 7, d.replace(/-/g, ''));
+      }
+      const totalExpected = dates.length * 7; // 63
+
+      const rangeStart = utcMidnight('2025-10-15');
+      const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+      const dailyJson = fetchChartData(rangeStart, rangeEnd, 'daily');
+      const weeklyJson = fetchChartData(rangeStart, rangeEnd, 'weekly');
+      const monthlyJson = fetchChartData(rangeStart, rangeEnd, 'monthly');
+
+      const dailySum = sumArr(getV1(dailyJson));
+      const weeklySum = sumArr(getV1(weeklyJson));
+      const monthlySum = sumArr(getV1(monthlyJson));
+
+      console.log('=== X1: Cross-granularity (sow=6) ===');
+      console.log('Daily:', dailySum, 'Weekly:', weeklySum, 'Monthly:', monthlySum, 'DB:', totalExpected);
+
+      expect(dailySum, 'Daily total').toBe(totalExpected);
+      expect(weeklySum, 'Weekly total').toBe(totalExpected);
+      expect(monthlySum, 'Monthly total').toBe(totalExpected);
+
+      console.log('X1 PASS: all three granularities =', totalExpected);
+    } finally {
+      await restoreOption('start_of_week');
+    }
+  });
+
+  /**
+   * Test X2: All granularities produce same total with sow=0
+   */
+  test('X2: daily, weekly, monthly all produce same total (sow=0)', async () => {
+    await snapshotOption('start_of_week');
+    await getPool().execute("UPDATE wp_options SET option_value = '0' WHERE option_name = 'start_of_week'");
+
+    try {
+      const dates = [
+        '2025-11-20', '2025-12-25',
+        '2026-01-10', '2026-02-14', '2026-02-28',
+        '2026-03-07', '2026-03-13', '2026-03-14', '2026-03-17',
+      ];
+      for (const d of dates) {
+        await insertRows(utcMidnight(d), 7, d.replace(/-/g, ''));
+      }
+      const totalExpected = dates.length * 7; // 63
+
+      const rangeStart = utcMidnight('2025-10-15');
+      const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+      const dailyJson = fetchChartData(rangeStart, rangeEnd, 'daily');
+      const weeklyJson = fetchChartData(rangeStart, rangeEnd, 'weekly');
+      const monthlyJson = fetchChartData(rangeStart, rangeEnd, 'monthly');
+
+      const dailySum = sumArr(getV1(dailyJson));
+      const weeklySum = sumArr(getV1(weeklyJson));
+      const monthlySum = sumArr(getV1(monthlyJson));
+
+      console.log('=== X2: Cross-granularity (sow=0) ===');
+      console.log('Daily:', dailySum, 'Weekly:', weeklySum, 'Monthly:', monthlySum, 'DB:', totalExpected);
+
+      expect(dailySum, 'Daily total').toBe(totalExpected);
+      expect(weeklySum, 'Weekly total').toBe(totalExpected);
+      expect(monthlySum, 'Monthly total').toBe(totalExpected);
+
+      console.log('X2 PASS: all three granularities =', totalExpected);
+    } finally {
+      await restoreOption('start_of_week');
+    }
+  });
+});

--- a/tests/e2e/weekly-bucketing-sow6-mar7-validation.spec.ts
+++ b/tests/e2e/weekly-bucketing-sow6-mar7-validation.spec.ts
@@ -1,0 +1,339 @@
+/**
+ * E2E: Weekly bucketing sow=6 (Saturday) — Mar 7-14 bucket validation
+ *
+ * Validates the exact scenario from screenshots:
+ *   - Page: slimview2, Last 28 Days, Weekly, sow=6
+ *   - "Mar 7 - Mar 14" bucket: 302 (old/wrong) vs 159 (fix/correct)
+ *   - Previous period tooltip: 0 (old/wrong) vs 17 (fix/correct)
+ *
+ * With sow=6 (Saturday), week boundaries are Sat-Fri:
+ *   - "Mar 7" bucket = Sat Mar 7 – Fri Mar 13
+ *   - "Mar 14" bucket = Sat Mar 14 – Tue Mar 17 (partial)
+ *
+ * The old code used ISO date('W') (Monday-start) which shifts all
+ * buckets by 1 position when sow=6, causing Mar 14-17 data to land
+ * in the "Mar 7" bucket and inflating its count.
+ */
+import { test, expect } from '@playwright/test';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getPool, closeDb, snapshotOption, restoreOption } from './helpers/setup';
+import { WP_ROOT } from './helpers/env';
+
+// ─── WP-CLI chart AJAX simulation ───────────────────────────────────────────
+
+function fetchChartData(startTs: number, endTs: number, granularity: string): any {
+  const tmpFile = path.join('/tmp', `slimstat-sow6-${Date.now()}.php`);
+  const phpCode = `<?php
+wp_set_current_user(get_users(['role' => 'administrator', 'number' => 1])[0]->ID);
+
+$_POST['args'] = json_encode([
+    'start' => ${startTs},
+    'end' => ${endTs},
+    'chart_data' => [
+        'data1' => 'COUNT(id)',
+        'data2' => 'COUNT( DISTINCT ip )',
+    ],
+]);
+$_POST['granularity'] = '${granularity}';
+$_REQUEST['granularity'] = '${granularity}';
+$_POST['nonce'] = wp_create_nonce('slimstat_chart_nonce');
+$_REQUEST['_ajax_nonce'] = $_POST['nonce'];
+
+global $wpdb;
+$wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_wp_slimstat_%' OR option_name LIKE '_transient_timeout_wp_slimstat_%'");
+
+ob_start();
+try {
+    \\SlimStat\\Modules\\Chart::ajaxFetchChartData();
+} catch (\\Throwable $e) {
+    ob_end_clean();
+    echo json_encode(['error' => $e->getMessage()]);
+    exit;
+}
+$output = ob_get_clean();
+echo $output;
+`;
+
+  fs.writeFileSync(tmpFile, phpCode);
+
+  function extractJson(raw: string): any {
+    const start = raw.indexOf('{"success"');
+    if (start === -1) return null;
+    try {
+      return JSON.parse(raw.substring(start));
+    } catch {
+      let depth = 0;
+      for (let i = start; i < raw.length; i++) {
+        if (raw[i] === '{') depth++;
+        if (raw[i] === '}') depth--;
+        if (depth === 0) {
+          try { return JSON.parse(raw.substring(start, i + 1)); } catch { return null; }
+        }
+      }
+    }
+    return null;
+  }
+
+  try {
+    const raw = execSync(`wp eval-file "${tmpFile}" --path="${WP_ROOT}" 2>/dev/null`, {
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    const parsed = extractJson(raw);
+    if (parsed) return parsed;
+    throw new Error(`No JSON in output: ${raw.substring(0, 300)}`);
+  } catch (e: any) {
+    if (e.stdout) {
+      const parsed = extractJson(e.stdout);
+      if (parsed) return parsed;
+    }
+    throw new Error(`WP-CLI chart call failed: ${e.message}`);
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch {}
+  }
+}
+
+// ─── DB helpers ───────────────────────────────────────────────────────────────
+
+async function insertRows(timestamp: number, count: number, label: string): Promise<void> {
+  const pool = getPool();
+  for (let i = 0; i < count; i++) {
+    await pool.execute(
+      `INSERT INTO wp_slim_stats (dt, ip, resource, browser, browser_version, platform, language, visit_id, user_agent)
+       VALUES (?, CONCAT('10.0.0.', FLOOR(RAND()*254)+1), ?, 'test', '0', 'test', 'en', 1, 'sow6-validation-e2e')`,
+      [timestamp + i * 60, `/sow6-validation-${label}-${i}`]
+    );
+  }
+}
+
+async function clearTestData(): Promise<void> {
+  await getPool().execute("TRUNCATE TABLE wp_slim_stats");
+  await getPool().execute(
+    "DELETE FROM wp_options WHERE option_name LIKE '_transient_wp_slimstat_%' OR option_name LIKE '_transient_timeout_wp_slimstat_%'"
+  );
+}
+
+function utcMidnight(dateStr: string): number {
+  return Math.floor(new Date(dateStr + 'T00:00:00Z').getTime() / 1000);
+}
+
+function getV1(json: any): number[] {
+  return json?.data?.data?.datasets?.v1 ?? [];
+}
+
+function getV1Prev(json: any): number[] {
+  return json?.data?.data?.datasets_prev?.v1 ?? [];
+}
+
+function getLabels(json: any): string[] {
+  return json?.data?.data?.labels ?? [];
+}
+
+function getPrevLabels(json: any): string[] {
+  return json?.data?.data?.prev_labels ?? [];
+}
+
+function sumArr(arr: number[]): number {
+  return arr.reduce((a, b) => a + b, 0);
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+test.describe('Weekly bucketing sow=6: Mar 7-14 bucket validation', () => {
+  test.setTimeout(90_000);
+
+  test.beforeAll(async () => {
+    await snapshotOption('start_of_week');
+    await getPool().execute("UPDATE wp_options SET option_value = '6' WHERE option_name = 'start_of_week'");
+  });
+
+  test.afterAll(async () => {
+    await restoreOption('start_of_week');
+    await clearTestData();
+    await closeDb();
+  });
+
+  test.beforeEach(async () => {
+    await clearTestData();
+  });
+
+  /**
+   * Test 1: Mar 7 bucket must contain ONLY Sat Mar 7 – Fri Mar 13 data
+   *
+   * Seeds specific counts per day and verifies exact bucket contents.
+   * With sow=6, labels should be: [Feb 18, Feb 21, Feb 28, Mar 7, Mar 14]
+   */
+  test('Mar 7 bucket contains only Sat Mar 7 – Fri Mar 13 data', async () => {
+    // Seed data: specific counts per day in the critical range
+    // Mar 7 (Sat) = 10, Mar 9 (Mon) = 20, Mar 13 (Fri) = 15  → total in Mar 7 bucket = 45
+    // Mar 14 (Sat) = 30, Mar 16 (Mon) = 25, Mar 17 (Tue) = 35 → total in Mar 14 bucket = 90
+    await insertRows(utcMidnight('2026-02-18'), 5, 'feb18');   // bucket 0 (partial)
+    await insertRows(utcMidnight('2026-02-25'), 8, 'feb25');   // bucket 1
+    await insertRows(utcMidnight('2026-03-03'), 12, 'mar03');  // bucket 2
+    await insertRows(utcMidnight('2026-03-07'), 10, 'mar07');  // bucket 3 (Sat - week start)
+    await insertRows(utcMidnight('2026-03-09'), 20, 'mar09');  // bucket 3 (Mon)
+    await insertRows(utcMidnight('2026-03-13'), 15, 'mar13');  // bucket 3 (Fri - last day of week)
+    await insertRows(utcMidnight('2026-03-14'), 30, 'mar14');  // bucket 4 (Sat - new week)
+    await insertRows(utcMidnight('2026-03-16'), 25, 'mar16');  // bucket 4 (Mon)
+    await insertRows(utcMidnight('2026-03-17'), 35, 'mar17');  // bucket 4 (Tue)
+
+    const totalExpected = 5 + 8 + 12 + 10 + 20 + 15 + 30 + 25 + 35; // = 160
+
+    const rangeStart = utcMidnight('2026-02-18');
+    const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+    const json = fetchChartData(rangeStart, rangeEnd, 'weekly');
+    expect(json?.success, `Chart error: ${JSON.stringify(json)}`).toBe(true);
+
+    const v1 = getV1(json);
+    const labels = getLabels(json);
+
+    console.log('=== Test 1: Mar 7 bucket isolation ===');
+    console.log('Labels:', labels);
+    console.log('V1:', v1);
+    console.log('Sum:', sumArr(v1), 'Expected:', totalExpected);
+
+    // Total must match
+    expect(sumArr(v1), 'Total sum must match DB').toBe(totalExpected);
+
+    // Expected buckets with sow=6:
+    // [0] Feb 18 (Wed-Fri, partial): 5
+    // [1] Feb 21 (Sat-Fri): 8
+    // [2] Feb 28 (Sat-Fri): 12
+    // [3] Mar 7 (Sat-Fri): 10+20+15 = 45
+    // [4] Mar 14 (Sat-Tue): 30+25+35 = 90
+
+    expect(v1.length, 'Should have 5 weekly buckets').toBe(5);
+
+    // CRITICAL: Mar 7 bucket must be exactly 45 (not inflated by Mar 14-17 data)
+    expect(v1[3], 'Mar 7 bucket: must be 45 (Mar 7=10 + Mar 9=20 + Mar 13=15)').toBe(45);
+
+    // CRITICAL: Mar 14 bucket must be exactly 90 (not 0 or deflated)
+    expect(v1[4], 'Mar 14 bucket: must be 90 (Mar 14=30 + Mar 16=25 + Mar 17=35)').toBe(90);
+
+    // Other buckets
+    expect(v1[0], 'Feb 18 bucket').toBe(5);
+    expect(v1[1], 'Feb 21 bucket').toBe(8);
+    expect(v1[2], 'Feb 28 bucket').toBe(12);
+
+    console.log('PASS: Mar 7 bucket = 45, Mar 14 bucket = 90 (correctly separated)');
+  });
+
+  /**
+   * Test 2: Previous period data is correctly mapped (not zero)
+   *
+   * Seeds data in both current and previous periods.
+   * With "Last 28 Days" (Feb 18 - Mar 17), previous period = Jan 21 - Feb 17.
+   */
+  test('previous period for Mar 7-14 range is populated (not zero)', async () => {
+    // Current period: seed in Mar 7-13 range
+    await insertRows(utcMidnight('2026-03-07'), 10, 'curr-mar07');
+    await insertRows(utcMidnight('2026-03-10'), 15, 'curr-mar10');
+
+    // Previous period: seed in the equivalent range (~28 days earlier)
+    // Feb 7-13 maps to the same bucket position as Mar 7-13
+    await insertRows(utcMidnight('2026-02-07'), 8, 'prev-feb07');
+    await insertRows(utcMidnight('2026-02-10'), 12, 'prev-feb10');
+
+    const rangeStart = utcMidnight('2026-02-18');
+    const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+    const json = fetchChartData(rangeStart, rangeEnd, 'weekly');
+    expect(json?.success).toBe(true);
+
+    const v1 = getV1(json);
+    const v1Prev = getV1Prev(json);
+    const labels = getLabels(json);
+    const prevLabels = getPrevLabels(json);
+
+    console.log('=== Test 2: Previous period validation ===');
+    console.log('Labels:', labels);
+    console.log('Prev labels:', prevLabels);
+    console.log('V1 current:', v1, 'sum:', sumArr(v1));
+    console.log('V1 previous:', v1Prev, 'sum:', sumArr(v1Prev));
+
+    // Current period: Mar 7+10 data should be in bucket 3 (Mar 7 week)
+    const currentSum = sumArr(v1);
+    expect(currentSum, 'Current period sum').toBe(25);
+
+    // Previous period must not be all zeros
+    const prevSum = sumArr(v1Prev);
+    expect(prevSum, 'Previous period must have data (not zero)').toBeGreaterThan(0);
+    expect(prevSum, 'Previous period sum').toBe(20);
+
+    console.log('PASS: Previous period correctly populated, sum =', prevSum);
+  });
+
+  /**
+   * Test 3: Cross-granularity — daily and weekly totals must match
+   */
+  test('daily vs weekly totals match with sow=6', async () => {
+    // Seed across full range
+    const dates = [
+      '2026-02-18', '2026-02-22', '2026-02-28', '2026-03-03',
+      '2026-03-07', '2026-03-09', '2026-03-13', '2026-03-14',
+      '2026-03-16', '2026-03-17',
+    ];
+    for (const d of dates) {
+      await insertRows(utcMidnight(d), 5, d.replace(/-/g, ''));
+    }
+    const totalExpected = dates.length * 5; // 50
+
+    const rangeStart = utcMidnight('2026-02-18');
+    const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+    const dailyJson = fetchChartData(rangeStart, rangeEnd, 'daily');
+    const weeklyJson = fetchChartData(rangeStart, rangeEnd, 'weekly');
+
+    const dailySum = sumArr(getV1(dailyJson));
+    const weeklySum = sumArr(getV1(weeklyJson));
+
+    console.log('=== Test 3: Cross-granularity (sow=6) ===');
+    console.log('Daily sum:', dailySum, 'Weekly sum:', weeklySum, 'DB:', totalExpected);
+
+    expect(dailySum, 'Daily total').toBe(totalExpected);
+    expect(weeklySum, 'Weekly total').toBe(totalExpected);
+    expect(dailySum, 'Daily == Weekly').toBe(weeklySum);
+
+    console.log('PASS: daily =', dailySum, '== weekly =', weeklySum);
+  });
+
+  /**
+   * Test 4: Boundary precision — Mar 13 (Fri) and Mar 14 (Sat) in different buckets
+   *
+   * Mar 13 is the LAST day of the "Mar 7" week (Fri).
+   * Mar 14 is the FIRST day of the "Mar 14" week (Sat).
+   * They must never be in the same bucket.
+   */
+  test('Mar 13 (Fri) in Mar 7 bucket, Mar 14 (Sat) in Mar 14 bucket — boundary split', async () => {
+    // Only seed on the boundary days
+    await insertRows(utcMidnight('2026-03-13'), 100, 'fri-mar13');
+    await insertRows(utcMidnight('2026-03-14'), 200, 'sat-mar14');
+
+    const rangeStart = utcMidnight('2026-02-18');
+    const rangeEnd = utcMidnight('2026-03-17') + 86399;
+
+    const json = fetchChartData(rangeStart, rangeEnd, 'weekly');
+    expect(json?.success).toBe(true);
+
+    const v1 = getV1(json);
+    const labels = getLabels(json);
+
+    console.log('=== Test 4: Boundary split ===');
+    console.log('Labels:', labels);
+    console.log('V1:', v1);
+
+    // Mar 7 bucket (index 3): must contain ONLY Mar 13 = 100
+    expect(v1[3], 'Mar 7 bucket must be exactly 100 (Mar 13 only)').toBe(100);
+
+    // Mar 14 bucket (index 4): must contain ONLY Mar 14 = 200
+    expect(v1[4], 'Mar 14 bucket must be exactly 200 (Mar 14 only)').toBe(200);
+
+    // They must not be mixed
+    expect(v1[3] + v1[4], 'Combined must be 300').toBe(300);
+
+    console.log('PASS: Boundary split correct — Mar 13=100 in bucket 3, Mar 14=200 in bucket 4');
+  });
+});

--- a/tests/e2e/weekly-start-of-week-bucketing.spec.ts
+++ b/tests/e2e/weekly-start-of-week-bucketing.spec.ts
@@ -1,0 +1,358 @@
+/**
+ * E2E: Weekly chart start_of_week bucketing — PR #235 regression
+ *
+ * PR #235 fixes DataBuckets::addRow() weekly offset calculation to respect
+ * WordPress start_of_week setting instead of ISO week numbers (date('W')).
+ *
+ * Bug: ISO weeks always start Monday. When start_of_week=0 (Sunday),
+ * data was bucketed into the wrong week offset, causing current week
+ * to show zero.
+ *
+ * Tests verify correct bucketing across start_of_week values (0, 1, 6)
+ * and cross-granularity consistency.
+ */
+import { test, expect } from '@playwright/test';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getPool, closeDb, snapshotOption, restoreOption } from './helpers/setup';
+import { WP_ROOT } from './helpers/env';
+
+// ─── WP-CLI chart AJAX simulation (reused from chart-today-zero-regression) ──
+
+function fetchChartData(startTs: number, endTs: number, granularity: string): any {
+  const tmpFile = path.join('/tmp', `slimstat-chart-sow-${Date.now()}.php`);
+  const phpCode = `<?php
+wp_set_current_user(get_users(['role' => 'administrator', 'number' => 1])[0]->ID);
+
+$_POST['args'] = json_encode([
+    'start' => ${startTs},
+    'end' => ${endTs},
+    'chart_data' => [
+        'data1' => 'COUNT(id)',
+        'data2' => 'COUNT( DISTINCT ip )',
+    ],
+]);
+$_POST['granularity'] = '${granularity}';
+$_REQUEST['granularity'] = '${granularity}';
+$_POST['nonce'] = wp_create_nonce('slimstat_chart_nonce');
+$_REQUEST['_ajax_nonce'] = $_POST['nonce'];
+
+global $wpdb;
+$wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_wp_slimstat_%' OR option_name LIKE '_transient_timeout_wp_slimstat_%'");
+
+ob_start();
+try {
+    \\SlimStat\\Modules\\Chart::ajaxFetchChartData();
+} catch (\\Throwable $e) {
+    ob_end_clean();
+    echo json_encode(['error' => $e->getMessage()]);
+    exit;
+}
+$output = ob_get_clean();
+echo $output;
+`;
+
+  fs.writeFileSync(tmpFile, phpCode);
+
+  function extractJson(raw: string): any {
+    const start = raw.indexOf('{"success"');
+    if (start === -1) return null;
+    try {
+      return JSON.parse(raw.substring(start));
+    } catch {
+      let depth = 0;
+      for (let i = start; i < raw.length; i++) {
+        if (raw[i] === '{') depth++;
+        if (raw[i] === '}') depth--;
+        if (depth === 0) {
+          try { return JSON.parse(raw.substring(start, i + 1)); } catch { return null; }
+        }
+      }
+    }
+    return null;
+  }
+
+  try {
+    const raw = execSync(`wp eval-file "${tmpFile}" --path="${WP_ROOT}" 2>/dev/null`, {
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    const parsed = extractJson(raw);
+    if (parsed) return parsed;
+    throw new Error(`No JSON in output: ${raw.substring(0, 300)}`);
+  } catch (e: any) {
+    if (e.stdout) {
+      const parsed = extractJson(e.stdout);
+      if (parsed) return parsed;
+    }
+    throw new Error(`WP-CLI chart call failed: ${e.message}`);
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch {}
+  }
+}
+
+// ─── WP option helpers ───────────────────────────────────────────────────────
+
+function setStartOfWeek(value: number): void {
+  execSync(
+    `wp option update start_of_week ${value} --path="${WP_ROOT}" 2>/dev/null`,
+    { encoding: 'utf8', timeout: 10_000 }
+  );
+}
+
+function getStartOfWeek(): number {
+  const raw = execSync(
+    `wp option get start_of_week --path="${WP_ROOT}" 2>/dev/null`,
+    { encoding: 'utf8', timeout: 10_000 }
+  );
+  return parseInt(raw.trim(), 10);
+}
+
+// ─── DB helpers ──────────────────────────────────────────────────────────────
+
+async function insertRows(timestamp: number, count: number, label: string): Promise<void> {
+  const pool = getPool();
+  for (let i = 0; i < count; i++) {
+    await pool.execute(
+      `INSERT INTO wp_slim_stats (dt, ip, resource, browser, browser_version, platform, language, visit_id, user_agent)
+       VALUES (?, '127.0.0.1', ?, 'test', '0', 'test', 'en', 1, 'weekly-sow-e2e')`,
+      [timestamp + i, `/weekly-sow-${label}-${i}`]
+    );
+  }
+}
+
+async function countTestRows(): Promise<number> {
+  const [rows] = (await getPool().execute(
+    "SELECT COUNT(*) as cnt FROM wp_slim_stats WHERE user_agent = 'weekly-sow-e2e'"
+  )) as any;
+  return parseInt(rows[0].cnt, 10);
+}
+
+async function clearTestData(): Promise<void> {
+  await getPool().execute("TRUNCATE TABLE wp_slim_stats");
+  await getPool().execute(
+    "DELETE FROM wp_options WHERE option_name LIKE '_transient_wp_slimstat_%' OR option_name LIKE '_transient_timeout_wp_slimstat_%'"
+  );
+}
+
+// ─── Data extractors ─────────────────────────────────────────────────────────
+
+function sumV1(json: any): number {
+  const d = json?.data?.data?.datasets?.v1;
+  if (Array.isArray(d)) return d.reduce((a: number, b: number) => a + b, 0);
+  return 0;
+}
+
+function getV1(json: any): number[] {
+  return json?.data?.data?.datasets?.v1 ?? [];
+}
+
+function getLabels(json: any): string[] {
+  return json?.data?.data?.labels ?? [];
+}
+
+// ─── Timestamp helpers ───────────────────────────────────────────────────────
+
+/**
+ * Find the most recent day-of-week relative to a timestamp.
+ * dayOfWeek: 0=Sunday, 1=Monday, ..., 6=Saturday
+ */
+function mostRecentDayOfWeek(dayOfWeek: number, refTs: number): number {
+  const refDate = new Date(refTs * 1000);
+  const currentDay = refDate.getUTCDay(); // 0=Sun
+  const diff = (currentDay - dayOfWeek + 7) % 7;
+  // If diff is 0, it's today — use it
+  const targetDate = new Date(refDate);
+  targetDate.setUTCDate(targetDate.getUTCDate() - diff);
+  targetDate.setUTCHours(12, 0, 0, 0); // noon to avoid DST edge cases
+  return Math.floor(targetDate.getTime() / 1000);
+}
+
+// ─── Test suite ──────────────────────────────────────────────────────────────
+
+test.describe('Weekly chart start_of_week bucketing (PR #235)', () => {
+  test.setTimeout(60_000);
+
+  const now = Math.floor(Date.now() / 1000);
+  const day = 86400;
+  const rangeStart = now - 28 * day;
+  const rangeEnd = now;
+  let originalStartOfWeek: number;
+
+  test.beforeAll(async () => {
+    originalStartOfWeek = getStartOfWeek();
+    await snapshotOption('start_of_week');
+  });
+
+  test.afterAll(async () => {
+    setStartOfWeek(originalStartOfWeek);
+    await restoreOption('start_of_week');
+    await clearTestData();
+    await closeDb();
+  });
+
+  test.beforeEach(async () => {
+    await clearTestData();
+  });
+
+  // ─── Test 1: start_of_week=0 (Sunday) — the bug case ─────────────────────
+
+  test('weekly chart with start_of_week=0 (Sunday): today visible in current week', async () => {
+    setStartOfWeek(0);
+
+    const todayTs = now - 60;
+    const lastWeekTs = now - 7 * day;
+
+    await insertRows(todayTs, 5, 'sow0-today');
+    await insertRows(lastWeekTs, 8, 'sow0-lastweek');
+
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(13);
+
+    const json = fetchChartData(rangeStart, rangeEnd, 'weekly');
+    expect(json?.success, `Chart error: ${JSON.stringify(json)}`).toBe(true);
+
+    const chartSum = sumV1(json);
+    const v1 = getV1(json);
+
+    // All records must be accounted for
+    expect(chartSum).toBe(dbCount);
+
+    // Last bucket (current week) must contain today's records
+    const lastBucket = v1[v1.length - 1];
+    expect(lastBucket, 'Current week bucket must contain today\'s 5 records').toBeGreaterThanOrEqual(5);
+
+    console.log(`Test 1 PASS — sow=0: DB=${dbCount}, sum=${chartSum}, lastBucket=${lastBucket}`);
+  });
+
+  // ─── Test 2: start_of_week=1 (Monday) — default, no regression ───────────
+
+  test('weekly chart with start_of_week=1 (Monday): today visible (no regression)', async () => {
+    setStartOfWeek(1);
+
+    const todayTs = now - 60;
+    const lastWeekTs = now - 7 * day;
+
+    await insertRows(todayTs, 4, 'sow1-today');
+    await insertRows(lastWeekTs, 6, 'sow1-lastweek');
+
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(10);
+
+    const json = fetchChartData(rangeStart, rangeEnd, 'weekly');
+    expect(json?.success).toBe(true);
+
+    const chartSum = sumV1(json);
+    const v1 = getV1(json);
+
+    expect(chartSum).toBe(dbCount);
+
+    const lastBucket = v1[v1.length - 1];
+    expect(lastBucket, 'Current week bucket must contain today\'s 4 records').toBeGreaterThanOrEqual(4);
+
+    console.log(`Test 2 PASS — sow=1: DB=${dbCount}, sum=${chartSum}, lastBucket=${lastBucket}`);
+  });
+
+  // ─── Test 3: start_of_week=6 (Saturday) — edge case ──────────────────────
+
+  test('weekly chart with start_of_week=6 (Saturday): today visible', async () => {
+    setStartOfWeek(6);
+
+    const todayTs = now - 60;
+    const twoWeeksAgoTs = now - 14 * day;
+
+    await insertRows(todayTs, 3, 'sow6-today');
+    await insertRows(twoWeeksAgoTs, 5, 'sow6-2wago');
+
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(8);
+
+    const json = fetchChartData(rangeStart, rangeEnd, 'weekly');
+    expect(json?.success).toBe(true);
+
+    const chartSum = sumV1(json);
+    const v1 = getV1(json);
+
+    expect(chartSum).toBe(dbCount);
+
+    const lastBucket = v1[v1.length - 1];
+    expect(lastBucket, 'Current week bucket must contain today\'s 3 records').toBeGreaterThanOrEqual(3);
+
+    console.log(`Test 3 PASS — sow=6: DB=${dbCount}, sum=${chartSum}, lastBucket=${lastBucket}`);
+  });
+
+  // ─── Test 4: Cross-granularity consistency with start_of_week=0 ───────────
+
+  test('daily vs weekly totals match when start_of_week=0', async () => {
+    setStartOfWeek(0);
+
+    const todayTs = now - 60;
+    const lastWeekTs = now - 7 * day;
+    const twoWeeksAgoTs = now - 14 * day;
+
+    await insertRows(todayTs, 3, 'xgran-today');
+    await insertRows(lastWeekTs, 5, 'xgran-lastweek');
+    await insertRows(twoWeeksAgoTs, 4, 'xgran-2wago');
+
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(12);
+
+    const dailyJson = fetchChartData(rangeStart, rangeEnd, 'daily');
+    const weeklyJson = fetchChartData(rangeStart, rangeEnd, 'weekly');
+
+    expect(dailyJson?.success).toBe(true);
+    expect(weeklyJson?.success).toBe(true);
+
+    const dailySum = sumV1(dailyJson);
+    const weeklySum = sumV1(weeklyJson);
+
+    expect(dailySum).toBe(dbCount);
+    expect(weeklySum).toBe(dbCount);
+    expect(dailySum).toBe(weeklySum);
+
+    console.log(`Test 4 PASS — xgran sow=0: DB=${dbCount}, daily=${dailySum}, weekly=${weeklySum}`);
+  });
+
+  // ─── Test 5: Sunday record buckets correctly for sow=0 vs sow=1 ──────────
+
+  test('Sunday records land in correct week bucket for sow=0 vs sow=1', async () => {
+    // Find the most recent Sunday timestamp
+    const sundayTs = mostRecentDayOfWeek(0, now); // 0 = Sunday
+    // And the Saturday before it
+    const saturdayTs = sundayTs - day;
+
+    // Insert records on Saturday and Sunday
+    await insertRows(saturdayTs, 4, 'boundary-sat');
+    await insertRows(sundayTs, 3, 'boundary-sun');
+
+    const dbCount = await countTestRows();
+    expect(dbCount).toBe(7);
+
+    // With sow=0 (Sunday): Sunday starts a NEW week
+    setStartOfWeek(0);
+    const jsonSow0 = fetchChartData(rangeStart, rangeEnd, 'weekly');
+    expect(jsonSow0?.success).toBe(true);
+    const v1Sow0 = getV1(jsonSow0);
+    const sumSow0 = sumV1(jsonSow0);
+    expect(sumSow0).toBe(dbCount);
+
+    // With sow=1 (Monday): Sunday is the LAST day of the week
+    setStartOfWeek(1);
+    const jsonSow1 = fetchChartData(rangeStart, rangeEnd, 'weekly');
+    expect(jsonSow1?.success).toBe(true);
+    const v1Sow1 = getV1(jsonSow1);
+    const sumSow1 = sumV1(jsonSow1);
+    expect(sumSow1).toBe(dbCount);
+
+    // Both must account for all records
+    expect(sumSow0).toBe(sumSow1);
+
+    // The bucket distribution should differ: with sow=0, Sunday starts a new week
+    // so Saturday (4) and Sunday (3) are in different weeks.
+    // With sow=1, Saturday and Sunday are in the same week (both after Monday).
+    // We can't assert exact bucket indices without knowing the day-of-week of 'now',
+    // but we can verify the total is correct and no records are lost.
+    console.log(`Test 5 PASS — boundary: DB=${dbCount}, sow0=${JSON.stringify(v1Sow0)}, sow1=${JSON.stringify(v1Sow1)}`);
+  });
+});


### PR DESCRIPTION
The weekly offset calculation was using ISO week numbers (date('W')) which always start on Monday, regardless of WordPress start_of_week setting. This caused data to be placed in the wrong bucket when start_of_week was set to Sunday (0).

Now calculates the start-of-week date for both base and data point timestamps using the WordPress start_of_week setting, ensuring correct bucket placement.

### Describe your changes
...

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Weekly grouping now respects the site's configured week-start and correctly computes week boundaries and the "today" bucket so weekly charts and totals align with site settings.

* **Tests**
  * Added comprehensive end-to-end tests for daily, weekly, and monthly bucketing covering multiple week-start settings (including Saturday), boundary cases, previous-period population, cross-granularity consistency, and data seeding/cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->