### PR TITLE
fix(security): add output escaping in reports default case (#244)

### DIFF
--- a/admin/view/wp-slimstat-reports.php
+++ b/admin/view/wp-slimstat-reports.php
@@ -1390,11 +1390,12 @@ class wp_slimstat_reports
                         $element_value = $resource_title;
                         break;
                     default:
+                        $element_value = esc_html($element_value);
                 }
 
                 if (is_admin()) {
                     $column_value  = is_array($results[$i]) && isset($results[$i][$_args['columns']]) ? $results[$i][$_args['columns']] : '';
-                    $element_value = "<a class='slimstat-filter-link' href='" . self::fs_url($_args['columns'] . ' ' . $_args['filter_op'] . ' ' . htmlentities(strval($column_value), ENT_QUOTES, 'UTF-8')) . sprintf("'>%s</a>", $element_value);
+                    $element_value = "<a class='slimstat-filter-link' href='" . esc_attr(self::fs_url($_args['columns'] . ' ' . $_args['filter_op'] . ' ' . $column_value)) . sprintf("'>%s</a>", $element_value);
                 }
 
                 if (!empty($_args['type']) && 'recent' == $_args['type']) {

--- a/admin/view/wp-slimstat-reports.php
+++ b/admin/view/wp-slimstat-reports.php
@@ -1395,7 +1395,7 @@ class wp_slimstat_reports
 
                 if (is_admin()) {
                     $column_value  = is_array($results[$i]) && isset($results[$i][$_args['columns']]) ? $results[$i][$_args['columns']] : '';
-                    $element_value = "<a class='slimstat-filter-link' href='" . esc_attr(self::fs_url($_args['columns'] . ' ' . $_args['filter_op'] . ' ' . $column_value)) . sprintf("'>%s</a>", $element_value);
+                    $element_value = "<a class='slimstat-filter-link' href='" . self::fs_url($_args['columns'] . ' ' . $_args['filter_op'] . ' ' . $column_value) . sprintf("'>%s</a>", $element_value);
                 }
 
                 if (!empty($_args['type']) && 'recent' == $_args['type']) {

--- a/admin/view/wp-slimstat-reports.php
+++ b/admin/view/wp-slimstat-reports.php
@@ -1394,8 +1394,9 @@ class wp_slimstat_reports
                 }
 
                 if (is_admin()) {
-                    $column_value  = is_array($results[$i]) && isset($results[$i][$_args['columns']]) ? $results[$i][$_args['columns']] : '';
-                    $element_value = "<a class='slimstat-filter-link' href='" . self::fs_url($_args['columns'] . ' ' . $_args['filter_op'] . ' ' . $column_value) . sprintf("'>%s</a>", $element_value);
+                    $column_value         = is_array($results[$i]) && isset($results[$i][$_args['columns']]) ? (string) $results[$i][$_args['columns']] : '';
+                    $encoded_column_value = rawurlencode($column_value);
+                    $element_value        = "<a class='slimstat-filter-link' href='" . self::fs_url($_args['columns'] . ' ' . $_args['filter_op'] . ' ' . $encoded_column_value) . sprintf("'>%s</a>", $element_value);
                 }
 
                 if (!empty($_args['type']) && 'recent' == $_args['type']) {

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     "test:lazy-migration": "php tests/lazy-migration-test.php",
     "test:rest-controller": "php tests/tracking-rest-controller-test.php",
     "test:reports-escaping": "php tests/reports-output-escaping-test.php",
+    "test:fingerprint-sanitize": "php tests/fingerprint-sanitization-test.php",
     "test:all": [
       "@test:license-tags",
       "@test:geoip-resolver",
@@ -50,7 +51,8 @@
       "@test:legacy-sync",
       "@test:lazy-migration",
       "@test:rest-controller",
-      "@test:reports-escaping"
+      "@test:reports-escaping",
+      "@test:fingerprint-sanitize"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,13 +42,15 @@
     "test:legacy-sync": "php tests/legacy-sync-mapping-test.php",
     "test:lazy-migration": "php tests/lazy-migration-test.php",
     "test:rest-controller": "php tests/tracking-rest-controller-test.php",
+    "test:reports-escaping": "php tests/reports-output-escaping-test.php",
     "test:all": [
       "@test:license-tags",
       "@test:geoip-resolver",
       "@test:geoservice",
       "@test:legacy-sync",
       "@test:lazy-migration",
-      "@test:rest-controller"
+      "@test:rest-controller",
+      "@test:reports-escaping"
     ]
   }
 }

--- a/src/Controllers/Rest/TrackingRestController.php
+++ b/src/Controllers/Rest/TrackingRestController.php
@@ -29,6 +29,21 @@ class TrackingRestController implements RestControllerInterface
         return is_numeric($value) ? (int) $value : 0;
     }
 
+    /**
+     * Sanitize fingerprint parameter: alphanumeric + dash + underscore only, max 256 chars.
+     *
+     * @param mixed $value Raw fingerprint value.
+     * @return string Sanitized fingerprint.
+     */
+    public static function sanitize_fingerprint_param($value): string
+    {
+        $value = preg_replace('/[^a-zA-Z0-9\-_]/', '', (string) $value);
+        if (strlen($value) > 256) {
+            $value = substr($value, 0, 256);
+        }
+        return sanitize_text_field($value);
+    }
+
     public function register_routes(): void
     {
         register_rest_route('slimstat/v1', '/hit', [
@@ -97,7 +112,7 @@ class TrackingRestController implements RestControllerInterface
                 'fh' => [
                     'required'          => false,
                     'type'              => 'string',
-                    'sanitize_callback' => 'sanitize_text_field',
+                    'sanitize_callback' => [self::class, 'sanitize_fingerprint_param'],
                 ],
                 'tz' => [
                     'required'          => false,

--- a/src/Tracker/Tracker.php
+++ b/src/Tracker/Tracker.php
@@ -355,7 +355,11 @@ class Tracker
         }
 
         if (!empty($_data_js['fh']) && 'on' != \wp_slimstat::$settings['anonymize_ip']) {
-            $_stat['fingerprint'] = sanitize_text_field($_data_js['fh']);
+            $fingerprint = preg_replace('/[^a-zA-Z0-9\-_]/', '', $_data_js['fh']);
+            if (strlen($fingerprint) > 256) {
+                $fingerprint = substr($fingerprint, 0, 256);
+            }
+            $_stat['fingerprint'] = sanitize_text_field($fingerprint);
         }
 
         if (!empty($_data_js['tz'])) {

--- a/src/Tracker/Utils.php
+++ b/src/Tracker/Utils.php
@@ -375,7 +375,11 @@ class Utils
 				$piiAllowed = Consent::piiAllowed();
 
 				if ($piiAllowed || $isAnonymousTracking) {
-					$stat['fingerprint'] = sanitize_text_field($dataJs['fh']);
+					$fingerprint = preg_replace('/[^a-zA-Z0-9\-_]/', '', $dataJs['fh']);
+					if (strlen($fingerprint) > 256) {
+						$fingerprint = substr($fingerprint, 0, 256);
+					}
+					$stat['fingerprint'] = sanitize_text_field($fingerprint);
 				}
 			} catch (\Throwable $e) {
 				// Fingerprint not stored when consent check fails (GDPR-safe default)

--- a/tests/e2e/cve-2026-1238-xss-hardening.spec.ts
+++ b/tests/e2e/cve-2026-1238-xss-hardening.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * E2E roundtrip test for CVE-2026-1238 defense-in-depth hardening.
+ *
+ * Tests the full chain: POST XSS payload to tracking endpoint → verify
+ * payload is sanitized in DB → verify admin renders safely.
+ *
+ * Covers: #244 — Input sanitization (strict regex) + Output escaping
+ */
+import { test, expect, Page } from '@playwright/test';
+import * as mysql from 'mysql2/promise';
+import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
+
+let pool: mysql.Pool;
+
+function getPool(): mysql.Pool {
+  if (!pool) pool = mysql.createPool(MYSQL_CONFIG);
+  return pool;
+}
+
+async function ensureLoggedIn(page: Page): Promise<void> {
+  if (page.url().includes('wp-login.php')) {
+    await page.fill('#user_login', 'parhumm');
+    await page.fill('#user_pass', 'testpass123');
+    await page.click('#wp-submit');
+    await page.waitForURL('**/wp-admin/**', { timeout: 30_000 });
+  }
+}
+
+async function clearStatsTable(): Promise<void> {
+  await getPool().execute('TRUNCATE TABLE wp_slim_stats');
+}
+
+async function getLatestFingerprint(resource?: string): Promise<string | null> {
+  const query = resource
+    ? 'SELECT fingerprint FROM wp_slim_stats WHERE resource = ? ORDER BY id DESC LIMIT 1'
+    : 'SELECT fingerprint FROM wp_slim_stats WHERE fingerprint IS NOT NULL ORDER BY id DESC LIMIT 1';
+  const params = resource ? [resource] : [];
+  const [rows] = (await getPool().execute(query, params)) as any;
+  return rows.length > 0 ? rows[0].fingerprint : null;
+}
+
+test.describe('CVE-2026-1238 XSS Hardening — Full Roundtrip', () => {
+  test.setTimeout(90_000);
+
+  test.beforeEach(async () => {
+    await clearStatsTable();
+  });
+
+  test.afterAll(async () => {
+    if (pool) await pool.end();
+  });
+
+  // ─── Test 1: Valid hex fingerprint stored unchanged ─────────────────
+
+  test('valid hex fingerprint is stored unchanged via REST endpoint', async ({ page }) => {
+    const validFingerprint = 'a1b2c3d4e5f6a7b8';
+
+    // POST to tracking endpoint with valid fingerprint
+    const response = await page.request.post(`${BASE_URL}/wp-json/slimstat/v1/hit`, {
+      data: {
+        fh: validFingerprint,
+        id: '1',
+      },
+    });
+
+    // Endpoint should not error
+    expect(response.status()).toBeLessThan(500);
+
+    // Wait for async processing
+    await page.waitForTimeout(2_000);
+
+    const stored = await getLatestFingerprint();
+    // Fingerprint may be null if anonymize_ip is on or consent is required
+    if (stored !== null) {
+      expect(stored, 'Valid fingerprint should be stored unchanged').toBe(validFingerprint);
+    }
+  });
+
+  // ─── Test 2: XSS payload stripped by input sanitization ─────────────
+
+  test('script tag payload is stripped before DB storage', async ({ page }) => {
+    const xssPayload = '<script>alert("xss")</script>';
+
+    const response = await page.request.post(`${BASE_URL}/wp-json/slimstat/v1/hit`, {
+      data: {
+        fh: xssPayload,
+        id: '1',
+      },
+    });
+
+    expect(response.status()).toBeLessThan(500);
+    await page.waitForTimeout(2_000);
+
+    const stored = await getLatestFingerprint();
+    // The regex strips all non-alphanumeric chars except - and _
+    if (stored !== null) {
+      expect(stored, 'Stored value must not contain angle brackets').not.toContain('<');
+      expect(stored, 'Stored value must not contain script tag').not.toContain('script>');
+    }
+    // Note: fingerprint may be null if consent/anonymize settings prevent storage
+  });
+
+  // ─── Test 3: IMG onerror payload stripped ───────────────────────────
+
+  test('img onerror payload is stripped before DB storage', async ({ page }) => {
+    const xssPayload = '"><img src=x onerror=alert(1)>';
+
+    const response = await page.request.post(`${BASE_URL}/wp-json/slimstat/v1/hit`, {
+      data: {
+        fh: xssPayload,
+        id: '1',
+      },
+    });
+
+    expect(response.status()).toBeLessThan(500);
+    await page.waitForTimeout(2_000);
+
+    const stored = await getLatestFingerprint();
+    if (stored !== null) {
+      expect(stored, 'Stored value must not contain angle brackets').not.toContain('<');
+      expect(stored, 'Stored value must not contain equals sign').not.toContain('=');
+    }
+  });
+
+  // ─── Test 4: Full roundtrip — XSS injected via REST, admin safe ────
+
+  test('full roundtrip: XSS sent via REST, admin renders safely', async ({ page }) => {
+    // Send XSS payload via REST
+    await page.request.post(`${BASE_URL}/wp-json/slimstat/v1/hit`, {
+      data: {
+        fh: '<script>alert("roundtrip")</script>',
+        id: '1',
+      },
+    });
+
+    await page.waitForTimeout(2_000);
+
+    // Track dialogs
+    let dialogTriggered = false;
+    page.on('dialog', async (dialog) => {
+      dialogTriggered = true;
+      await dialog.dismiss();
+    });
+
+    // Navigate to admin reports
+    const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await ensureLoggedIn(page);
+    await page.waitForTimeout(6_000);
+
+    expect(response?.status(), 'Admin page should load').toBeLessThan(500);
+    expect(dialogTriggered, 'XSS must not execute in admin').toBe(false);
+  });
+
+  // ─── Test 5: Fingerprint with dash and underscore preserved ─────────
+
+  test('fingerprint with dash and underscore preserved after sanitization', async ({ page }) => {
+    const fingerprint = 'fp-test_123-abc';
+
+    await page.request.post(`${BASE_URL}/wp-json/slimstat/v1/hit`, {
+      data: {
+        fh: fingerprint,
+        id: '1',
+      },
+    });
+
+    await page.waitForTimeout(2_000);
+
+    const stored = await getLatestFingerprint();
+    // Fingerprint may be null if anonymize_ip is on or consent is required
+    if (stored !== null) {
+      expect(stored, 'Fingerprint with dash/underscore should be stored unchanged').toBe(fingerprint);
+    }
+  });
+});

--- a/tests/e2e/reports-fingerprint-xss.spec.ts
+++ b/tests/e2e/reports-fingerprint-xss.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * E2E tests: Reports fingerprint XSS escaping — verifies that malicious
+ * fingerprint values stored in the database are rendered safely in admin
+ * report pages (no script execution, proper HTML escaping).
+ *
+ * Covers: GitHub #244 — Defense-in-depth output escaping for reports default case
+ * CVE: CVE-2026-1238 (historical, patched in 5.4.0, defense-in-depth hardened here)
+ *
+ * Strategy: seed malicious fingerprint data directly into wp_slim_stats,
+ * then navigate to admin report pages and verify content is safely escaped.
+ */
+import { test, expect, Page } from '@playwright/test';
+import * as mysql from 'mysql2/promise';
+import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
+
+let pool: mysql.Pool;
+
+function getPool(): mysql.Pool {
+  if (!pool) pool = mysql.createPool(MYSQL_CONFIG);
+  return pool;
+}
+
+async function ensureLoggedIn(page: Page): Promise<void> {
+  if (page.url().includes('wp-login.php')) {
+    await page.fill('#user_login', 'parhumm');
+    await page.fill('#user_pass', 'testpass123');
+    await page.click('#wp-submit');
+    await page.waitForURL('**/wp-admin/**', { timeout: 30_000 });
+  }
+}
+
+async function clearStatsTable(): Promise<void> {
+  await getPool().execute('TRUNCATE TABLE wp_slim_stats');
+}
+
+/**
+ * Seed a pageview with a known fingerprint value directly in the DB.
+ * Bypasses input sanitization to simulate a defense-in-depth test scenario.
+ */
+async function seedFingerprintPageview(fingerprint: string): Promise<number> {
+  const now = Math.floor(Date.now() / 1000);
+  const [result] = (await getPool().execute(
+    `INSERT INTO wp_slim_stats
+       (resource, fingerprint, dt, ip, visit_id, browser, platform, content_type)
+     VALUES (?, ?, ?, '127.0.0.1', 1, 'Chrome', 'Windows', 'post')`,
+    [`/xss-test-${Date.now()}/`, fingerprint, now],
+  )) as any;
+  return result.insertId;
+}
+
+// XSS payloads to test (inserted directly into DB, bypassing sanitization)
+// mustNotContain patterns are specific enough to avoid matching legitimate page elements
+const XSS_PAYLOADS = [
+  {
+    name: 'script tag',
+    value: '<script>alert("xss")</script>',
+    mustNotContain: 'alert("xss")</script>',
+  },
+  {
+    name: 'img onerror',
+    value: '"><img src=x onerror=alert(1)>',
+    mustNotContain: 'onerror=alert(1)',
+  },
+  {
+    name: 'svg onload',
+    value: '"><svg/onload=alert(1)>',
+    mustNotContain: 'onload=alert(1)',
+  },
+  {
+    name: 'onclick injection',
+    value: "' onclick='alert(1)'",
+    mustNotContain: "onclick='alert(1)'",
+  },
+];
+
+test.describe('Reports Fingerprint XSS Escaping (#244)', () => {
+  test.setTimeout(90_000);
+
+  test.beforeEach(async () => {
+    await clearStatsTable();
+  });
+
+  test.afterAll(async () => {
+    if (pool) await pool.end();
+  });
+
+  // ─── Test 1: Admin reports page loads without errors with XSS fingerprints ─
+
+  test('admin reports page loads safely with XSS fingerprints in DB', async ({ page }) => {
+    // Seed all XSS payloads into the DB
+    for (const payload of XSS_PAYLOADS) {
+      await seedFingerprintPageview(payload.value);
+    }
+
+    // Collect console errors to detect any JS execution from XSS
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    // Track dialog events (alert/confirm/prompt) — XSS would trigger these
+    let dialogTriggered = false;
+    page.on('dialog', async (dialog) => {
+      dialogTriggered = true;
+      await dialog.dismiss();
+    });
+
+    // Navigate to Access Log (slimview1) — shows fingerprint in Right Now widget
+    const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await ensureLoggedIn(page);
+
+    expect(response?.status(), 'Page should load without server error').toBeLessThan(500);
+
+    // Wait for async-loaded report content
+    await page.waitForTimeout(6_000);
+
+    expect(dialogTriggered, 'No alert/confirm/prompt dialog should be triggered by XSS').toBe(false);
+  });
+
+  // ─── Test 2: Verify XSS payloads don't execute in report pages ──────────
+  // Note: innerHTML decodes HTML entities (&#039; → '), making text-based HTML
+  // checks unreliable. The definitive test is that no JS dialog fires.
+
+  for (const payload of XSS_PAYLOADS) {
+    test(`fingerprint "${payload.name}" does not execute in reports`, async ({ page }) => {
+      await seedFingerprintPageview(payload.value);
+
+      let dialogTriggered = false;
+      let dialogMessage = '';
+      page.on('dialog', async (dialog) => {
+        dialogTriggered = true;
+        dialogMessage = dialog.message();
+        await dialog.dismiss();
+      });
+
+      // Test on Access Log (slimview1) — shows fingerprint in Right Now widget
+      const response1 = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await ensureLoggedIn(page);
+      await page.waitForTimeout(6_000);
+
+      expect(response1?.status(), 'slimview1 should not crash').toBeLessThan(500);
+      expect(dialogTriggered, `XSS "${payload.name}" must not fire on slimview1: ${dialogMessage}`).toBe(false);
+
+      // Test on Audience tab (slimview3) — shows fingerprint in top reports
+      const response3 = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await page.waitForTimeout(6_000);
+
+      expect(response3?.status(), 'slimview3 should not crash').toBeLessThan(500);
+      expect(dialogTriggered, `XSS "${payload.name}" must not fire on slimview3: ${dialogMessage}`).toBe(false);
+    });
+  }
+
+  // ─── Test 3: Top Fingerprints report (slimview3) also safe ─────────────
+
+  test('top fingerprints report escapes XSS payloads', async ({ page }) => {
+    // Seed multiple rows with same XSS fingerprint to appear in "top" reports
+    for (let i = 0; i < 5; i++) {
+      await seedFingerprintPageview('<script>alert("top")</script>');
+    }
+
+    let dialogTriggered = false;
+    page.on('dialog', async (dialog) => {
+      dialogTriggered = true;
+      await dialog.dismiss();
+    });
+
+    // slimview3 = Audience tab (shows top browsers, platforms, fingerprints)
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await ensureLoggedIn(page);
+    await page.waitForTimeout(6_000);
+
+    // Check postbox widgets (scoped to report content, not the full page)
+    const widgets = page.locator('.postbox .inside');
+    const widgetCount = await widgets.count();
+    for (let i = 0; i < widgetCount; i++) {
+      const widgetHtml = await widgets.nth(i).innerHTML();
+      expect(widgetHtml, `Widget ${i} must not contain raw script tag`).not.toContain('alert("top")</script>');
+    }
+    expect(dialogTriggered, 'No JS dialog from top reports').toBe(false);
+  });
+
+  // ─── Test 4: No fatal errors with edge-case fingerprint values ─────────
+
+  test('edge-case fingerprint values do not crash admin', async ({ page }) => {
+    const edgeCases = [
+      '', // empty
+      'a'.repeat(256), // max length
+      '日本語フィンガープリント', // unicode
+      '&lt;already&gt;escaped&lt;/already&gt;', // pre-escaped
+      "Robert'); DROP TABLE wp_slim_stats;--", // SQL injection (should be safe in display)
+    ];
+
+    for (const value of edgeCases) {
+      if (value) await seedFingerprintPageview(value);
+    }
+
+    const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await ensureLoggedIn(page);
+
+    expect(response?.status(), 'Edge cases should not crash admin').toBeLessThan(500);
+  });
+});

--- a/tests/e2e/reports-fingerprint-xss.spec.ts
+++ b/tests/e2e/reports-fingerprint-xss.spec.ts
@@ -21,7 +21,7 @@
  * raw_results_to_html() HTML output with entity-level assertions against the actual
  * renderer code. This E2E test validates the full browser execution context.
  */
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import * as mysql from 'mysql2/promise';
 import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
 
@@ -46,6 +46,22 @@ async function seedFingerprintPageview(fingerprint: string): Promise<number> {
     [`/xss-fp-${Date.now()}-${Math.random().toString(36).slice(2)}/`, fingerprint, now, vid],
   )) as any;
   return result.insertId;
+}
+
+function fingerprintPreview(fingerprint: string): string {
+  return fingerprint.slice(0, 8);
+}
+
+async function expectFingerprintRendered(page: Page, fingerprint: string) {
+  const fpLink = page
+    .locator("a[href*='fingerprint']")
+    .filter({ hasText: fingerprintPreview(fingerprint) })
+    .first();
+
+  await expect(fpLink, `Seeded fingerprint should render for ${fingerprintPreview(fingerprint)}`).toBeVisible({ timeout: 15_000 });
+  await expect(fpLink, 'Rendered fingerprint should preserve the full seeded value in title').toHaveAttribute('title', fingerprint);
+
+  return fpLink;
 }
 
 test.describe('Reports Fingerprint XSS Escaping (#243, #244)', () => {
@@ -73,17 +89,16 @@ test.describe('Reports Fingerprint XSS Escaping (#243, #244)', () => {
 
     const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`);
     expect(response?.status(), 'Page must load without server error').toBeLessThan(500);
-    const fpLink = page.locator("a[href*='fingerprint']").first();
-    await expect(fpLink, 'Seeded fingerprint link should render on slimview1').toBeVisible({ timeout: 15_000 });
+    const fpLink = await expectFingerprintRendered(page, seededFingerprint);
     expect(dialogTriggered, 'Script tag XSS must not execute').toBe(false);
     await expect(fpLink, 'Fingerprint link text should match the seeded first 8 chars').toHaveText('<script>');
-    await expect(fpLink, 'Fingerprint title should preserve the full seeded value').toHaveAttribute('title', seededFingerprint);
   });
 
   // ─── Test 2: IMG onerror — no XSS execution ───────────────────────────
 
   test('img onerror fingerprint does not execute on slimview1', async ({ page }) => {
-    await seedFingerprintPageview('"><img src=x onerror=alert(1)>');
+    const seededFingerprint = '"><img src=x onerror=alert(1)>';
+    await seedFingerprintPageview(seededFingerprint);
 
     let dialogTriggered = false;
     page.on('dialog', async (dialog) => {
@@ -93,8 +108,9 @@ test.describe('Reports Fingerprint XSS Escaping (#243, #244)', () => {
 
     const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`);
     expect(response?.status()).toBeLessThan(500);
-    await page.waitForTimeout(8_000);
+    const fpLink = await expectFingerprintRendered(page, seededFingerprint);
     expect(dialogTriggered, 'IMG onerror must not execute').toBe(false);
+    await expect(fpLink, 'Fingerprint link text should match the seeded first 8 chars').toHaveText(fingerprintPreview(seededFingerprint));
   });
 
   // ─── Test 3: Valid fingerprint renders correctly ───────────────────────
@@ -105,19 +121,23 @@ test.describe('Reports Fingerprint XSS Escaping (#243, #244)', () => {
 
     const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`);
     expect(response?.status()).toBeLessThan(500);
-    const fpLink = page.locator("a[href*='fingerprint']").first();
-    await expect(fpLink, 'Seeded fingerprint link should render on slimview1').toBeVisible({ timeout: 15_000 });
+    const fpLink = await expectFingerprintRendered(page, validFp);
     await expect(fpLink, 'Should display first 8 chars').toHaveText('a1b2c3d4');
-    await expect(fpLink, 'Title should contain full fingerprint').toHaveAttribute('title', validFp);
   });
 
   // ─── Test 4: Multiple XSS payloads — no execution on the rendered report ──────
 
   test('multiple XSS payloads do not execute on slimview1', async ({ page }) => {
-    await seedFingerprintPageview('<script>alert("xss")</script>');
-    await seedFingerprintPageview('"><img src=x onerror=alert(1)>');
-    await seedFingerprintPageview('"><svg/onload=alert(1)>');
-    await seedFingerprintPageview("' onclick='alert(1)'");
+    const seededFingerprints = [
+      '<script>alert("xss")</script>',
+      '"><img src=x onerror=alert(1)>',
+      '"><svg/onload=alert(1)>',
+      "' onclick='alert(1)'",
+    ];
+
+    for (const fingerprint of seededFingerprints) {
+      await seedFingerprintPageview(fingerprint);
+    }
 
     let dialogTriggered = false;
     let dialogMsg = '';
@@ -130,7 +150,9 @@ test.describe('Reports Fingerprint XSS Escaping (#243, #244)', () => {
     // Test slimview1 (Access Log / right-now.php)
     const r1 = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`);
     expect(r1?.status()).toBeLessThan(500);
-    await expect(page.locator("a[href*='fingerprint']").first()).toBeVisible({ timeout: 15_000 });
+    for (const fingerprint of seededFingerprints) {
+      await expectFingerprintRendered(page, fingerprint);
+    }
     expect(dialogTriggered, `XSS on slimview1: ${dialogMsg}`).toBe(false);
   });
 

--- a/tests/e2e/reports-fingerprint-xss.spec.ts
+++ b/tests/e2e/reports-fingerprint-xss.spec.ts
@@ -15,7 +15,7 @@
  * Assertions:
  *   - Primary: No JS dialog fires (proves XSS did not execute)
  *   - Primary: Page loads without 5xx error
- *   - Secondary: Fingerprint link element exists with correct text (when visible)
+ *   - Secondary: On slimview1, the seeded fingerprint link exists with the expected text/title
  *
  * The integration unit test (reports-output-escaping-test.php) validates the real
  * raw_results_to_html() HTML output with entity-level assertions against the actual
@@ -62,7 +62,8 @@ test.describe('Reports Fingerprint XSS Escaping (#243, #244)', () => {
   // ─── Test 1: Script tag fingerprint — no XSS execution ────────────────
 
   test('script tag fingerprint does not execute on slimview1', async ({ page }) => {
-    await seedFingerprintPageview('<script>alert("xss")</script>');
+    const seededFingerprint = '<script>alert("xss")</script>';
+    await seedFingerprintPageview(seededFingerprint);
 
     let dialogTriggered = false;
     page.on('dialog', async (dialog) => {
@@ -72,17 +73,11 @@ test.describe('Reports Fingerprint XSS Escaping (#243, #244)', () => {
 
     const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`);
     expect(response?.status(), 'Page must load without server error').toBeLessThan(500);
-    await page.waitForTimeout(8_000);
+    const fpLink = page.locator("a[href*='fingerprint']").first();
+    await expect(fpLink, 'Seeded fingerprint link should render on slimview1').toBeVisible({ timeout: 15_000 });
     expect(dialogTriggered, 'Script tag XSS must not execute').toBe(false);
-
-    // If the Access Log widget rendered the fingerprint, verify the link exists
-    const fpLink = page.locator("a[href*='fingerprint']");
-    if ((await fpLink.count()) > 0) {
-      // The link text should be the first 8 chars (right-now.php:196 esc_html(substr(fp,0,8)))
-      // textContent decodes entities so '<script>' appears as '<script>' — safe in DOM, just decoded
-      const text = await fpLink.first().textContent();
-      expect(text?.length, 'Fingerprint text should be max 8 chars').toBeLessThanOrEqual(8);
-    }
+    await expect(fpLink, 'Fingerprint link text should match the seeded first 8 chars').toHaveText('<script>');
+    await expect(fpLink, 'Fingerprint title should preserve the full seeded value').toHaveAttribute('title', seededFingerprint);
   });
 
   // ─── Test 2: IMG onerror — no XSS execution ───────────────────────────
@@ -110,22 +105,15 @@ test.describe('Reports Fingerprint XSS Escaping (#243, #244)', () => {
 
     const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`);
     expect(response?.status()).toBeLessThan(500);
-    await page.waitForTimeout(8_000);
-
-    const fpLink = page.locator("a[href*='fingerprint']");
-    if ((await fpLink.count()) > 0) {
-      // right-now.php:196: esc_html(substr(fingerprint, 0, 8)) → 'a1b2c3d4'
-      const linkText = await fpLink.first().textContent();
-      expect(linkText, 'Should display first 8 chars').toBe('a1b2c3d4');
-
-      const title = await fpLink.first().getAttribute('title');
-      expect(title, 'Title should contain full fingerprint').toBe(validFp);
-    }
+    const fpLink = page.locator("a[href*='fingerprint']").first();
+    await expect(fpLink, 'Seeded fingerprint link should render on slimview1').toBeVisible({ timeout: 15_000 });
+    await expect(fpLink, 'Should display first 8 chars').toHaveText('a1b2c3d4');
+    await expect(fpLink, 'Title should contain full fingerprint').toHaveAttribute('title', validFp);
   });
 
-  // ─── Test 4: Multiple XSS payloads — no execution on any view ─────────
+  // ─── Test 4: Multiple XSS payloads — no execution on the rendered report ──────
 
-  test('multiple XSS payloads do not execute on slimview1 or slimview3', async ({ page }) => {
+  test('multiple XSS payloads do not execute on slimview1', async ({ page }) => {
     await seedFingerprintPageview('<script>alert("xss")</script>');
     await seedFingerprintPageview('"><img src=x onerror=alert(1)>');
     await seedFingerprintPageview('"><svg/onload=alert(1)>');
@@ -142,14 +130,8 @@ test.describe('Reports Fingerprint XSS Escaping (#243, #244)', () => {
     // Test slimview1 (Access Log / right-now.php)
     const r1 = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`);
     expect(r1?.status()).toBeLessThan(500);
-    await page.waitForTimeout(8_000);
+    await expect(page.locator("a[href*='fingerprint']").first()).toBeVisible({ timeout: 15_000 });
     expect(dialogTriggered, `XSS on slimview1: ${dialogMsg}`).toBe(false);
-
-    // Test slimview3 (Audience)
-    const r3 = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`);
-    expect(r3?.status()).toBeLessThan(500);
-    await page.waitForTimeout(8_000);
-    expect(dialogTriggered, `XSS on slimview3: ${dialogMsg}`).toBe(false);
   });
 
   // ─── Test 5: Edge-case values don't crash admin ────────────────────────

--- a/tests/e2e/reports-fingerprint-xss.spec.ts
+++ b/tests/e2e/reports-fingerprint-xss.spec.ts
@@ -1,15 +1,27 @@
 /**
  * E2E tests: Reports fingerprint XSS escaping — verifies that malicious
- * fingerprint values stored in the database are rendered safely in admin
- * report pages (no script execution, proper HTML escaping).
+ * fingerprint values stored in the database do not execute as JavaScript
+ * when rendered in admin report pages.
  *
- * Covers: GitHub #244 — Defense-in-depth output escaping for reports default case
+ * Covers: GitHub #243, #244 — Defense-in-depth output escaping
  * CVE: CVE-2026-1238 (historical, patched in 5.4.0, defense-in-depth hardened here)
  *
- * Strategy: seed malicious fingerprint data directly into wp_slim_stats,
- * then navigate to admin report pages and verify content is safely escaped.
+ * Strategy: seed malicious fingerprint data directly into wp_slim_stats
+ * (bypassing input sanitization), then navigate to admin report pages.
+ *
+ * The fingerprint renders in right-now.php:196 inside #slim_p7_02 (Access Log)
+ * as: <code><a class='slimstat-filter-link' href='...fingerprint...'>FIRST_8</a></code>
+ *
+ * Assertions:
+ *   - Primary: No JS dialog fires (proves XSS did not execute)
+ *   - Primary: Page loads without 5xx error
+ *   - Secondary: Fingerprint link element exists with correct text (when visible)
+ *
+ * The integration unit test (reports-output-escaping-test.php) validates the real
+ * raw_results_to_html() HTML output with entity-level assertions against the actual
+ * renderer code. This E2E test validates the full browser execution context.
  */
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import * as mysql from 'mysql2/promise';
 import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
 
@@ -20,61 +32,24 @@ function getPool(): mysql.Pool {
   return pool;
 }
 
-async function ensureLoggedIn(page: Page): Promise<void> {
-  if (page.url().includes('wp-login.php')) {
-    await page.fill('#user_login', 'parhumm');
-    await page.fill('#user_pass', 'testpass123');
-    await page.click('#wp-submit');
-    await page.waitForURL('**/wp-admin/**', { timeout: 30_000 });
-  }
-}
-
 async function clearStatsTable(): Promise<void> {
   await getPool().execute('TRUNCATE TABLE wp_slim_stats');
 }
 
-/**
- * Seed a pageview with a known fingerprint value directly in the DB.
- * Bypasses input sanitization to simulate a defense-in-depth test scenario.
- */
 async function seedFingerprintPageview(fingerprint: string): Promise<number> {
   const now = Math.floor(Date.now() / 1000);
+  const vid = Math.floor(Math.random() * 100000);
   const [result] = (await getPool().execute(
     `INSERT INTO wp_slim_stats
        (resource, fingerprint, dt, ip, visit_id, browser, platform, content_type)
-     VALUES (?, ?, ?, '127.0.0.1', 1, 'Chrome', 'Windows', 'post')`,
-    [`/xss-test-${Date.now()}/`, fingerprint, now],
+     VALUES (?, ?, ?, '127.0.0.1', ?, 'Chrome', 'Windows', 'post')`,
+    [`/xss-fp-${Date.now()}-${Math.random().toString(36).slice(2)}/`, fingerprint, now, vid],
   )) as any;
   return result.insertId;
 }
 
-// XSS payloads to test (inserted directly into DB, bypassing sanitization)
-// mustNotContain patterns are specific enough to avoid matching legitimate page elements
-const XSS_PAYLOADS = [
-  {
-    name: 'script tag',
-    value: '<script>alert("xss")</script>',
-    mustNotContain: 'alert("xss")</script>',
-  },
-  {
-    name: 'img onerror',
-    value: '"><img src=x onerror=alert(1)>',
-    mustNotContain: 'onerror=alert(1)',
-  },
-  {
-    name: 'svg onload',
-    value: '"><svg/onload=alert(1)>',
-    mustNotContain: 'onload=alert(1)',
-  },
-  {
-    name: 'onclick injection',
-    value: "' onclick='alert(1)'",
-    mustNotContain: "onclick='alert(1)'",
-  },
-];
-
-test.describe('Reports Fingerprint XSS Escaping (#244)', () => {
-  test.setTimeout(90_000);
+test.describe('Reports Fingerprint XSS Escaping (#243, #244)', () => {
+  test.setTimeout(60_000);
 
   test.beforeEach(async () => {
     await clearStatsTable();
@@ -84,85 +59,10 @@ test.describe('Reports Fingerprint XSS Escaping (#244)', () => {
     if (pool) await pool.end();
   });
 
-  // ─── Test 1: Admin reports page loads without errors with XSS fingerprints ─
+  // ─── Test 1: Script tag fingerprint — no XSS execution ────────────────
 
-  test('admin reports page loads safely with XSS fingerprints in DB', async ({ page }) => {
-    // Seed all XSS payloads into the DB
-    for (const payload of XSS_PAYLOADS) {
-      await seedFingerprintPageview(payload.value);
-    }
-
-    // Collect console errors to detect any JS execution from XSS
-    const consoleErrors: string[] = [];
-    page.on('console', (msg) => {
-      if (msg.type() === 'error') consoleErrors.push(msg.text());
-    });
-
-    // Track dialog events (alert/confirm/prompt) — XSS would trigger these
-    let dialogTriggered = false;
-    page.on('dialog', async (dialog) => {
-      dialogTriggered = true;
-      await dialog.dismiss();
-    });
-
-    // Navigate to Access Log (slimview1) — shows fingerprint in Right Now widget
-    const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`, {
-      waitUntil: 'domcontentloaded',
-    });
-    await ensureLoggedIn(page);
-
-    expect(response?.status(), 'Page should load without server error').toBeLessThan(500);
-
-    // Wait for async-loaded report content
-    await page.waitForTimeout(6_000);
-
-    expect(dialogTriggered, 'No alert/confirm/prompt dialog should be triggered by XSS').toBe(false);
-  });
-
-  // ─── Test 2: Verify XSS payloads don't execute in report pages ──────────
-  // Note: innerHTML decodes HTML entities (&#039; → '), making text-based HTML
-  // checks unreliable. The definitive test is that no JS dialog fires.
-
-  for (const payload of XSS_PAYLOADS) {
-    test(`fingerprint "${payload.name}" does not execute in reports`, async ({ page }) => {
-      await seedFingerprintPageview(payload.value);
-
-      let dialogTriggered = false;
-      let dialogMessage = '';
-      page.on('dialog', async (dialog) => {
-        dialogTriggered = true;
-        dialogMessage = dialog.message();
-        await dialog.dismiss();
-      });
-
-      // Test on Access Log (slimview1) — shows fingerprint in Right Now widget
-      const response1 = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`, {
-        waitUntil: 'domcontentloaded',
-      });
-      await ensureLoggedIn(page);
-      await page.waitForTimeout(6_000);
-
-      expect(response1?.status(), 'slimview1 should not crash').toBeLessThan(500);
-      expect(dialogTriggered, `XSS "${payload.name}" must not fire on slimview1: ${dialogMessage}`).toBe(false);
-
-      // Test on Audience tab (slimview3) — shows fingerprint in top reports
-      const response3 = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`, {
-        waitUntil: 'domcontentloaded',
-      });
-      await page.waitForTimeout(6_000);
-
-      expect(response3?.status(), 'slimview3 should not crash').toBeLessThan(500);
-      expect(dialogTriggered, `XSS "${payload.name}" must not fire on slimview3: ${dialogMessage}`).toBe(false);
-    });
-  }
-
-  // ─── Test 3: Top Fingerprints report (slimview3) also safe ─────────────
-
-  test('top fingerprints report escapes XSS payloads', async ({ page }) => {
-    // Seed multiple rows with same XSS fingerprint to appear in "top" reports
-    for (let i = 0; i < 5; i++) {
-      await seedFingerprintPageview('<script>alert("top")</script>');
-    }
+  test('script tag fingerprint does not execute on slimview1', async ({ page }) => {
+    await seedFingerprintPageview('<script>alert("xss")</script>');
 
     let dialogTriggered = false;
     page.on('dialog', async (dialog) => {
@@ -170,43 +70,97 @@ test.describe('Reports Fingerprint XSS Escaping (#244)', () => {
       await dialog.dismiss();
     });
 
-    // slimview3 = Audience tab (shows top browsers, platforms, fingerprints)
-    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`, {
-      waitUntil: 'domcontentloaded',
-    });
-    await ensureLoggedIn(page);
-    await page.waitForTimeout(6_000);
+    const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`);
+    expect(response?.status(), 'Page must load without server error').toBeLessThan(500);
+    await page.waitForTimeout(8_000);
+    expect(dialogTriggered, 'Script tag XSS must not execute').toBe(false);
 
-    // Check postbox widgets (scoped to report content, not the full page)
-    const widgets = page.locator('.postbox .inside');
-    const widgetCount = await widgets.count();
-    for (let i = 0; i < widgetCount; i++) {
-      const widgetHtml = await widgets.nth(i).innerHTML();
-      expect(widgetHtml, `Widget ${i} must not contain raw script tag`).not.toContain('alert("top")</script>');
+    // If the Access Log widget rendered the fingerprint, verify the link exists
+    const fpLink = page.locator("a[href*='fingerprint']");
+    if ((await fpLink.count()) > 0) {
+      // The link text should be the first 8 chars (right-now.php:196 esc_html(substr(fp,0,8)))
+      // textContent decodes entities so '<script>' appears as '<script>' — safe in DOM, just decoded
+      const text = await fpLink.first().textContent();
+      expect(text?.length, 'Fingerprint text should be max 8 chars').toBeLessThanOrEqual(8);
     }
-    expect(dialogTriggered, 'No JS dialog from top reports').toBe(false);
   });
 
-  // ─── Test 4: No fatal errors with edge-case fingerprint values ─────────
+  // ─── Test 2: IMG onerror — no XSS execution ───────────────────────────
+
+  test('img onerror fingerprint does not execute on slimview1', async ({ page }) => {
+    await seedFingerprintPageview('"><img src=x onerror=alert(1)>');
+
+    let dialogTriggered = false;
+    page.on('dialog', async (dialog) => {
+      dialogTriggered = true;
+      await dialog.dismiss();
+    });
+
+    const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`);
+    expect(response?.status()).toBeLessThan(500);
+    await page.waitForTimeout(8_000);
+    expect(dialogTriggered, 'IMG onerror must not execute').toBe(false);
+  });
+
+  // ─── Test 3: Valid fingerprint renders correctly ───────────────────────
+
+  test('valid hex fingerprint displays first 8 chars when link is visible', async ({ page }) => {
+    const validFp = 'a1b2c3d4e5f6a7b8c9d0';
+    await seedFingerprintPageview(validFp);
+
+    const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`);
+    expect(response?.status()).toBeLessThan(500);
+    await page.waitForTimeout(8_000);
+
+    const fpLink = page.locator("a[href*='fingerprint']");
+    if ((await fpLink.count()) > 0) {
+      // right-now.php:196: esc_html(substr(fingerprint, 0, 8)) → 'a1b2c3d4'
+      const linkText = await fpLink.first().textContent();
+      expect(linkText, 'Should display first 8 chars').toBe('a1b2c3d4');
+
+      const title = await fpLink.first().getAttribute('title');
+      expect(title, 'Title should contain full fingerprint').toBe(validFp);
+    }
+  });
+
+  // ─── Test 4: Multiple XSS payloads — no execution on any view ─────────
+
+  test('multiple XSS payloads do not execute on slimview1 or slimview3', async ({ page }) => {
+    await seedFingerprintPageview('<script>alert("xss")</script>');
+    await seedFingerprintPageview('"><img src=x onerror=alert(1)>');
+    await seedFingerprintPageview('"><svg/onload=alert(1)>');
+    await seedFingerprintPageview("' onclick='alert(1)'");
+
+    let dialogTriggered = false;
+    let dialogMsg = '';
+    page.on('dialog', async (dialog) => {
+      dialogTriggered = true;
+      dialogMsg = dialog.message();
+      await dialog.dismiss();
+    });
+
+    // Test slimview1 (Access Log / right-now.php)
+    const r1 = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`);
+    expect(r1?.status()).toBeLessThan(500);
+    await page.waitForTimeout(8_000);
+    expect(dialogTriggered, `XSS on slimview1: ${dialogMsg}`).toBe(false);
+
+    // Test slimview3 (Audience)
+    const r3 = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`);
+    expect(r3?.status()).toBeLessThan(500);
+    await page.waitForTimeout(8_000);
+    expect(dialogTriggered, `XSS on slimview3: ${dialogMsg}`).toBe(false);
+  });
+
+  // ─── Test 5: Edge-case values don't crash admin ────────────────────────
 
   test('edge-case fingerprint values do not crash admin', async ({ page }) => {
-    const edgeCases = [
-      '', // empty
-      'a'.repeat(256), // max length
-      '日本語フィンガープリント', // unicode
-      '&lt;already&gt;escaped&lt;/already&gt;', // pre-escaped
-      "Robert'); DROP TABLE wp_slim_stats;--", // SQL injection (should be safe in display)
-    ];
+    await seedFingerprintPageview('a'.repeat(256));
+    await seedFingerprintPageview('日本語フィンガープリント');
+    await seedFingerprintPageview('&lt;already&gt;escaped&lt;/already&gt;');
+    await seedFingerprintPageview("Robert'); DROP TABLE wp_slim_stats;--");
 
-    for (const value of edgeCases) {
-      if (value) await seedFingerprintPageview(value);
-    }
-
-    const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`, {
-      waitUntil: 'domcontentloaded',
-    });
-    await ensureLoggedIn(page);
-
-    expect(response?.status(), 'Edge cases should not crash admin').toBeLessThan(500);
+    const response = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`);
+    expect(response?.status(), 'Edge cases must not crash admin').toBeLessThan(500);
   });
 });

--- a/tests/fingerprint-sanitization-test.php
+++ b/tests/fingerprint-sanitization-test.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Tests for fingerprint input sanitization (strict alphanumeric regex).
+ *
+ * Covers: #244 — CVE-2026-1238 defense-in-depth input hardening
+ * Sources:
+ *   - src/Controllers/Rest/TrackingRestController.php::sanitize_fingerprint_param()
+ *   - src/Tracker/Tracker.php (line ~357)
+ *   - src/Tracker/Utils.php (line ~377)
+ *   - src/Tracker/Ajax.php (line ~324, reference implementation)
+ *
+ * Run: php tests/fingerprint-sanitization-test.php
+ */
+
+declare(strict_types=1);
+
+$assertions = 0;
+
+function assert_same($expected, $actual, string $message): void
+{
+    global $assertions;
+    $assertions++;
+
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message} (expected " . var_export($expected, true) . ', got ' . var_export($actual, true) . ")\n");
+        exit(1);
+    }
+}
+
+function assert_true($actual, string $message): void
+{
+    global $assertions;
+    $assertions++;
+
+    if ($actual !== true) {
+        fwrite(STDERR, "FAIL: {$message} (expected true, got " . var_export($actual, true) . ")\n");
+        exit(1);
+    }
+}
+
+// ─── WordPress stub ────────────────────────────────────────────────
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($str)
+    {
+        $str = (string) $str;
+        $str = strip_tags($str);
+        $str = trim($str);
+        $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
+        return $str;
+    }
+}
+
+// ─── Replicate the sanitization logic under test ───────────────────
+// This is the exact logic used in TrackingRestController::sanitize_fingerprint_param(),
+// Tracker.php, and Utils.php.
+
+function sanitize_fingerprint(string $value): string
+{
+    $value = preg_replace('/[^a-zA-Z0-9\-_]/', '', $value);
+    if (strlen($value) > 256) {
+        $value = substr($value, 0, 256);
+    }
+    return sanitize_text_field($value);
+}
+
+// ─── Test Cases ────────────────────────────────────────────────────
+
+// Test 1: Valid FingerprintJS v4 hash (32-char hex) passes through unchanged
+$result = sanitize_fingerprint('a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6');
+assert_same('a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6', $result, 'Valid 32-char hex fingerprint should pass through');
+
+// Test 2: Valid fingerprint with dashes and underscores
+$result = sanitize_fingerprint('fp-abc123_def456');
+assert_same('fp-abc123_def456', $result, 'Dashes and underscores should be preserved');
+
+// Test 3: Script tag completely stripped
+$result = sanitize_fingerprint('<script>alert(1)</script>');
+assert_same('scriptalert1script', $result, 'Script tag chars should be stripped, only alphanumeric remains');
+
+// Test 4: IMG onerror payload stripped
+$result = sanitize_fingerprint('"><img src=x onerror=alert(1)>');
+assert_same('imgsrcxonerroralert1', $result, 'IMG onerror payload should be stripped to alphanumeric');
+
+// Test 5: Single quotes stripped
+$result = sanitize_fingerprint("' onclick='alert(1)'");
+assert_same('onclickalert1', $result, 'Single quotes should be stripped');
+
+// Test 6: Double quotes stripped
+$result = sanitize_fingerprint('" onmouseover="alert(1)"');
+assert_same('onmouseoveralert1', $result, 'Double quotes should be stripped');
+
+// Test 7: Empty string
+$result = sanitize_fingerprint('');
+assert_same('', $result, 'Empty string should remain empty');
+
+// Test 8: Special characters only (result: empty after regex)
+$result = sanitize_fingerprint('!@#$%^&*()+=[]{}|;:,.<>?/');
+assert_same('', $result, 'All special chars should be stripped');
+
+// Test 9: Length truncation at 256
+$long_value = str_repeat('a', 300);
+$result = sanitize_fingerprint($long_value);
+assert_same(256, strlen($result), 'Result should be truncated to 256 chars');
+assert_same(str_repeat('a', 256), $result, 'Truncated value should be first 256 chars');
+
+// Test 10: Exactly 256 chars passes through
+$exact_value = str_repeat('b', 256);
+$result = sanitize_fingerprint($exact_value);
+assert_same($exact_value, $result, '256-char value should pass through unchanged');
+
+// Test 11: Unicode stripped (only ASCII alphanumeric allowed)
+$result = sanitize_fingerprint('fp-日本語-test');
+assert_same('fp--test', $result, 'Unicode chars should be stripped');
+
+// Test 12: SQL injection payload stripped
+$result = sanitize_fingerprint("Robert'); DROP TABLE wp_slim_stats;--");
+assert_same('RobertDROPTABLEwp_slim_stats--', $result, 'SQL injection special chars stripped');
+
+// Test 13: Null byte stripped
+$result = sanitize_fingerprint("test\x00payload");
+assert_same('testpayload', $result, 'Null byte should be stripped');
+
+// Test 14: SVG onload payload stripped
+$result = sanitize_fingerprint('"><svg/onload=alert(1)>');
+assert_same('svgonloadalert1', $result, 'SVG onload payload should be stripped');
+
+// Test 15: Base64-encoded payload (alphanumeric chars preserved, + and = stripped)
+$result = sanitize_fingerprint('PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==');
+assert_same('PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg', $result, 'Base64 alpha chars preserved, padding stripped');
+
+// Test 16: Mixed valid fingerprint with trailing XSS
+$result = sanitize_fingerprint('abc123<script>alert(1)</script>');
+assert_same('abc123scriptalert1script', $result, 'Valid prefix preserved, tag chars stripped');
+
+echo "All {$assertions} assertions passed in fingerprint-sanitization-test.php\n";

--- a/tests/reports-output-escaping-test.php
+++ b/tests/reports-output-escaping-test.php
@@ -16,12 +16,17 @@
 
 declare(strict_types=1);
 
-$wordpress_root = dirname(__DIR__, 4);
-$wp_load_path   = $wordpress_root . '/wp-load.php';
+$default_wp_load_path = dirname(__DIR__, 4) . '/wp-load.php';
+$wp_load_override     = getenv('TESTS_WP_LOAD_PATH');
+$wp_load_path         = (false !== $wp_load_override && '' !== trim($wp_load_override)) ? trim($wp_load_override) : $default_wp_load_path;
+
+if (is_dir($wp_load_path)) {
+    $wp_load_path = rtrim($wp_load_path, '/\\') . '/wp-load.php';
+}
 
 if (!file_exists($wp_load_path)) {
-    fwrite(STDERR, "SKIP: wp-load.php not found at {$wp_load_path}\n");
-    exit(0);
+    fwrite(STDERR, "ERROR: wp-load.php not found at {$wp_load_path}. Set TESTS_WP_LOAD_PATH to an absolute wp-load.php path or WordPress root.\n");
+    exit(1);
 }
 
 if (!defined('SHORTINIT')) {

--- a/tests/reports-output-escaping-test.php
+++ b/tests/reports-output-escaping-test.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * Tests for output escaping in wp_slimstat_reports::raw_results_to_html()
+ *
+ * Covers: #244 — Defense-in-depth output escaping for reports default case
+ * Source: admin/view/wp-slimstat-reports.php (default case + filter link wrapper)
+ *
+ * Run: php tests/reports-output-escaping-test.php
+ */
+
+declare(strict_types=1);
+
+$assertions = 0;
+
+function assert_same($expected, $actual, string $message): void
+{
+    global $assertions;
+    $assertions++;
+
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message} (expected " . var_export($expected, true) . ', got ' . var_export($actual, true) . ")\n");
+        exit(1);
+    }
+}
+
+function assert_true($actual, string $message): void
+{
+    global $assertions;
+    $assertions++;
+
+    if ($actual !== true) {
+        fwrite(STDERR, "FAIL: {$message} (expected true, got " . var_export($actual, true) . ")\n");
+        exit(1);
+    }
+}
+
+function assert_contains(string $needle, string $haystack, string $message): void
+{
+    global $assertions;
+    $assertions++;
+
+    if (strpos($haystack, $needle) === false) {
+        fwrite(STDERR, "FAIL: {$message} (expected to contain '{$needle}' in '{$haystack}')\n");
+        exit(1);
+    }
+}
+
+function assert_not_contains(string $needle, string $haystack, string $message): void
+{
+    global $assertions;
+    $assertions++;
+
+    if (strpos($haystack, $needle) !== false) {
+        fwrite(STDERR, "FAIL: {$message} (expected NOT to contain '{$needle}' in '{$haystack}')\n");
+        exit(1);
+    }
+}
+
+// ─── WordPress escaping stubs (real behavior) ──────────────────────
+
+if (!function_exists('esc_html')) {
+    function esc_html($text)
+    {
+        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8', true);
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr($text)
+    {
+        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8', true);
+    }
+}
+
+// ─── Simulate the default case escaping logic ──────────────────────
+// This mirrors what admin/view/wp-slimstat-reports.php does:
+//   1. $element_value = $results[$i][$_args['columns']];  (line 1175)
+//   2. default: $element_value = esc_html($element_value); (line 1393, the fix)
+//   3. Filter link: href uses esc_attr(), text uses $element_value (line 1397)
+
+/**
+ * Simulates the fixed default-case output path.
+ *
+ * @param string $raw_db_value  The value as stored in the database
+ * @return array{element: string, href_value: string}  The escaped element text and href attribute value
+ */
+function simulate_default_case_output(string $raw_db_value): array
+{
+    // Step 1: raw DB value assigned to $element_value (line 1175)
+    $element_value = $raw_db_value;
+
+    // Step 2: default case applies esc_html (line 1393 — THE FIX)
+    $element_value = esc_html($element_value);
+
+    // Step 3: filter link wrapper (line 1397)
+    $column_value = $raw_db_value;
+    $fs_url = 'fingerprint equals ' . $column_value; // simplified fs_url
+    $href_value = esc_attr($fs_url);
+    $output = "<a class='slimstat-filter-link' href='" . $href_value . "'>" . $element_value . "</a>";
+
+    return [
+        'element' => $element_value,
+        'href_value' => $href_value,
+        'output' => $output,
+    ];
+}
+
+// ─── Test Cases ────────────────────────────────────────────────────
+
+// Test 1: Clean alphanumeric fingerprint passes through unchanged
+$result = simulate_default_case_output('abc123def456');
+assert_same('abc123def456', $result['element'], 'Clean alphanumeric should pass through unchanged');
+
+// Test 2: Script tag gets HTML-escaped
+$result = simulate_default_case_output('<script>alert(1)</script>');
+assert_same('&lt;script&gt;alert(1)&lt;/script&gt;', $result['element'], 'Script tag must be escaped');
+assert_not_contains('<script>', $result['output'], 'Output must not contain raw script tags');
+
+// Test 3: Attribute injection gets escaped — quotes are neutralized so attribute can't break out
+$result = simulate_default_case_output('" onmouseover="alert(1)"');
+assert_contains('&quot;', $result['href_value'], 'Double quotes must be escaped in href value');
+assert_not_contains('" onmouseover=', $result['href_value'], 'Raw attribute injection must not appear in href');
+assert_contains('&quot;', $result['element'], 'Double quotes must be escaped in element text');
+
+// Test 4: IMG tag with onerror gets escaped
+$result = simulate_default_case_output('<img src=x onerror=alert(1)>');
+assert_same('&lt;img src=x onerror=alert(1)&gt;', $result['element'], 'IMG tag must be escaped');
+assert_not_contains('<img', $result['output'], 'Output must not contain raw img tags');
+
+// Test 5: Empty string remains empty
+$result = simulate_default_case_output('');
+assert_same('', $result['element'], 'Empty string should remain empty');
+
+// Test 6: Long string (256 chars) is escaped without truncation
+$long_value = str_repeat('a', 250) . '<b>XSS</b>';
+$result = simulate_default_case_output($long_value);
+assert_not_contains('<b>', $result['element'], 'Long string with tags must be escaped');
+assert_contains('&lt;b&gt;', $result['element'], 'Tags in long string must be HTML-encoded');
+assert_true(strlen($result['element']) > 256, 'Escaped string should be longer than input due to entity encoding');
+
+// Test 7: Unicode/multibyte is preserved and escaped
+$result = simulate_default_case_output('fingerprint-日本語-<b>test</b>');
+assert_contains('日本語', $result['element'], 'Unicode should be preserved');
+assert_contains('&lt;b&gt;', $result['element'], 'Tags in unicode string must be escaped');
+
+// Test 8: Already-escaped string gets double-escaped (correct — prevents decoder attacks)
+$result = simulate_default_case_output('&lt;script&gt;alert(1)&lt;/script&gt;');
+assert_contains('&amp;lt;', $result['element'], 'Already-escaped entities should be double-escaped');
+assert_not_contains('<script>', $result['output'], 'Double-escaped string must not produce raw tags');
+
+// Test 9: Single quotes in fingerprint are escaped
+$result = simulate_default_case_output("' onclick='alert(1)'");
+assert_contains('&#039;', $result['element'], 'Single quotes must be escaped in element');
+assert_contains('&#039;', $result['href_value'], 'Single quotes must be escaped in href');
+
+// Test 10: Mixed XSS vector
+$result = simulate_default_case_output('"><svg/onload=alert(1)>');
+assert_not_contains('<svg', $result['output'], 'SVG onload vector must be neutralized');
+assert_contains('&lt;svg', $result['element'], 'SVG tag must be HTML-escaped');
+
+// Test 11: Null bytes stripped (PHP string behavior)
+$result = simulate_default_case_output("test\x00<script>alert(1)</script>");
+assert_not_contains('<script>', $result['output'], 'Null byte + script must be escaped');
+
+// Test 12: href context — single quotes in value are escaped so href can't break out
+$result = simulate_default_case_output("val' onclick='alert(1)");
+assert_contains("&#039;", $result['href_value'], 'Single quotes in href must be entity-encoded');
+assert_not_contains("' onclick='", $result['output'], 'Raw single-quote breakout must not appear in output');
+
+echo "All {$assertions} assertions passed in reports-output-escaping-test.php\n";

--- a/tests/reports-output-escaping-test.php
+++ b/tests/reports-output-escaping-test.php
@@ -6,14 +6,41 @@
  * Covers: #243, #244 — Defense-in-depth output escaping for reports default case
  * Source: admin/view/wp-slimstat-reports.php (default case + filter link wrapper)
  *
- * This test boots a minimal stub environment, loads the real wp_slimstat_reports class,
- * calls raw_results_to_html() with test data containing XSS payloads, captures the
- * rendered HTML via ob_start()/ob_get_clean(), and asserts the output is safely escaped.
+ * This test boots a minimal WordPress core environment so the real esc_url() is available,
+ * loads the real wp_slimstat_reports class, calls raw_results_to_html() with test data
+ * containing XSS payloads, captures the rendered HTML via ob_start()/ob_get_clean(), and
+ * asserts the output is safely escaped.
  *
  * Run: php tests/reports-output-escaping-test.php
  */
 
 declare(strict_types=1);
+
+$wordpress_root = dirname(__DIR__, 4);
+$wp_load_path   = $wordpress_root . '/wp-load.php';
+
+if (!file_exists($wp_load_path)) {
+    fwrite(STDERR, "SKIP: wp-load.php not found at {$wp_load_path}\n");
+    exit(0);
+}
+
+if (!defined('SHORTINIT')) {
+    define('SHORTINIT', true);
+}
+
+if (!defined('WP_ADMIN')) {
+    define('WP_ADMIN', true);
+}
+
+require_once $wp_load_path;
+require_once ABSPATH . WPINC . '/http.php';
+require_once ABSPATH . WPINC . '/kses.php';
+// SHORTINIT does not load the block parser stack needed by the default pre_kses hook.
+remove_all_filters('pre_kses');
+
+if (!defined('DOING_AJAX')) {
+    define('DOING_AJAX', false);
+}
 
 $assertions = 0;
 
@@ -21,6 +48,7 @@ function assert_same($expected, $actual, string $message): void
 {
     global $assertions;
     $assertions++;
+
     if ($expected !== $actual) {
         fwrite(STDERR, "FAIL: {$message} (expected " . var_export($expected, true) . ', got ' . var_export($actual, true) . ")\n");
         exit(1);
@@ -31,6 +59,7 @@ function assert_true($actual, string $message): void
 {
     global $assertions;
     $assertions++;
+
     if ($actual !== true) {
         fwrite(STDERR, "FAIL: {$message} (expected true, got " . var_export($actual, true) . ")\n");
         exit(1);
@@ -41,6 +70,7 @@ function assert_contains(string $needle, string $haystack, string $message): voi
 {
     global $assertions;
     $assertions++;
+
     if (strpos($haystack, $needle) === false) {
         fwrite(STDERR, "FAIL: {$message}\n  Expected to contain: '{$needle}'\n  In: " . substr($haystack, 0, 500) . "\n");
         exit(1);
@@ -51,6 +81,7 @@ function assert_not_contains(string $needle, string $haystack, string $message):
 {
     global $assertions;
     $assertions++;
+
     if (strpos($haystack, $needle) !== false) {
         fwrite(STDERR, "FAIL: {$message}\n  Expected NOT to contain: '{$needle}'\n  In: " . substr($haystack, 0, 500) . "\n");
         exit(1);
@@ -58,68 +89,12 @@ function assert_not_contains(string $needle, string $haystack, string $message):
 }
 
 // ─── Minimal WordPress + SlimStat stubs ─────────────────────────────
-// Only stubs that raw_results_to_html() actually calls are defined here.
-
-if (!defined('DOING_AJAX')) {
-    define('DOING_AJAX', false);
-}
-
-if (!function_exists('esc_html')) {
-    function esc_html($text)
-    {
-        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8', true);
-    }
-}
-
-if (!function_exists('esc_attr')) {
-    function esc_attr($text)
-    {
-        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8', true);
-    }
-}
-
-if (!function_exists('esc_url')) {
-    function esc_url($url)
-    {
-        // Simplified: just ensure it's a string — real WP filters schemes etc.
-        return (string) $url;
-    }
-}
-
-if (!function_exists('wp_kses_post')) {
-    function wp_kses_post($data)
-    {
-        return $data;
-    }
-}
+// Only the functions/classes that the report renderer reaches in this test are stubbed.
 
 if (!function_exists('__')) {
     function __($text, $domain = 'default')
     {
         return $text;
-    }
-}
-
-if (!function_exists('is_admin')) {
-    function is_admin()
-    {
-        return true; // Simulate admin context — this is what triggers the filter link at line 1396
-    }
-}
-
-if (!function_exists('get_option')) {
-    function get_option($key, $default = false)
-    {
-        if ($key === 'permalink_structure') {
-            return '/%postname%/';
-        }
-        if ($key === 'date_format') {
-            return 'Y-m-d';
-        }
-        if ($key === 'time_format') {
-            return 'H:i';
-        }
-        return $default;
     }
 }
 
@@ -130,27 +105,6 @@ if (!function_exists('admin_url')) {
     }
 }
 
-if (!function_exists('sanitize_url')) {
-    function sanitize_url($url)
-    {
-        return filter_var($url, FILTER_SANITIZE_URL) ?: '';
-    }
-}
-
-if (!function_exists('wp_unslash')) {
-    function wp_unslash($value)
-    {
-        return is_string($value) ? stripslashes($value) : $value;
-    }
-}
-
-if (!function_exists('number_format_i18n')) {
-    function number_format_i18n($number, $decimals = 0)
-    {
-        return number_format((float) $number, $decimals);
-    }
-}
-
 if (!function_exists('is_rtl')) {
     function is_rtl()
     {
@@ -158,51 +112,43 @@ if (!function_exists('is_rtl')) {
     }
 }
 
-if (!function_exists('date_i18n')) {
-    function date_i18n($format, $timestamp = false, $gmt = false)
-    {
-        return date($format, $timestamp ?: time());
-    }
-}
-
-// ─── wp_slimstat stub ───────────────────────────────────────────────
-
 if (!class_exists('wp_slimstat')) {
     class wp_slimstat
     {
         public static $settings = [
-            'async_load'     => 'off', // Must be 'off' so raw_results_to_html doesn't early-return
-            'rows_to_show'   => 20,
-            'show_hits'      => 'off',
-            'show_display_name' => 'off',
+            'async_load'                     => 'off',
+            'rows_to_show'                   => 20,
+            'show_hits'                      => 'off',
+            'show_display_name'              => 'off',
             'show_complete_user_agent_tooltip' => 'off',
-            'limit_results'  => 0,
+            'limit_results'                  => 0,
         ];
     }
 }
 
-// ─── wp_slimstat_db stub ────────────────────────────────────────────
-
 if (!class_exists('wp_slimstat_db')) {
     class wp_slimstat_db
     {
-        public static $debug_message = '';
-        public static $pageviews     = 100;
+        public static $debug_message      = '';
+        public static $pageviews          = 100;
         public static $filters_normalized = ['utime' => [], 'columns' => [], 'misc' => ['start_from' => 0]];
 
         /**
-         * parse_filters is called by fs_url() to build URL parameters.
-         * Return a minimal structure matching what the real function returns.
+         * Mirror the real parser's split-then-decode behavior so delimiter bugs surface here.
          */
         public static function parse_filters($filters_string)
         {
             $result = ['columns' => [], 'date' => [], 'misc' => []];
 
-            // Parse "column operator value" triples
             if (!empty($filters_string)) {
-                $parts = explode(' ', $filters_string, 3);
-                if (count($parts) === 3) {
-                    $result['columns'][$parts[0]] = [$parts[1], $parts[2]];
+                foreach (explode('&&&', $filters_string) as $match) {
+                    if (!preg_match('/([^\s]+)\s([^\s]+)\s(.+)?/', urldecode($match), $parts)) {
+                        continue;
+                    }
+
+                    if (isset($parts[1], $parts[2])) {
+                        $result['columns'][$parts[1]] = [$parts[2], $parts[3] ?? ''];
+                    }
                 }
             }
 
@@ -211,16 +157,12 @@ if (!class_exists('wp_slimstat_db')) {
     }
 }
 
-// ─── wp_slimstat_admin stub ─────────────────────────────────────────
-
 if (!class_exists('wp_slimstat_admin')) {
     class wp_slimstat_admin
     {
         public static $current_screen = 'slimview1';
     }
 }
-
-// ─── wp_slimstat_i18n stub ──────────────────────────────────────────
 
 if (!class_exists('wp_slimstat_i18n')) {
     class wp_slimstat_i18n
@@ -232,15 +174,8 @@ if (!class_exists('wp_slimstat_i18n')) {
     }
 }
 
-// ─── Test data provider ─────────────────────────────────────────────
-
-/**
- * Returns a callback array that raw_results_to_html() expects as $_args['raw'].
- * The callback returns $test_data when called.
- */
 function make_data_callback(array $test_data): array
 {
-    // Store test data in a global so our callback can access it
     $GLOBALS['__test_report_data'] = $test_data;
     return ['TestDataProvider', 'getData'];
 }
@@ -253,16 +188,8 @@ class TestDataProvider
     }
 }
 
-// ─── Load the real wp_slimstat_reports class ────────────────────────
-
 require_once __DIR__ . '/../admin/view/wp-slimstat-reports.php';
 
-// ─── Helper: render a single column value through raw_results_to_html() ──
-
-/**
- * Render a single-row report with the given column and value.
- * Returns the captured HTML output.
- */
 function render_column(string $column, string $value): string
 {
     $test_data = [
@@ -277,71 +204,81 @@ function render_column(string $column, string $value): string
         'where'     => '',
         'filter_op' => 'equals',
     ]);
+
     return ob_get_clean();
 }
 
-// ═══════════════════════════════════════════════════════════════════
-// TESTS: Exercise the REAL raw_results_to_html() with XSS payloads
-// ═══════════════════════════════════════════════════════════════════
+function extract_href(string $html): string
+{
+    if (preg_match("/href='([^']+)'/", $html, $matches)) {
+        return $matches[1];
+    }
 
-// Test 1: Clean fingerprint value passes through the default case
+    return '';
+}
+
+// Test 1: Clean fingerprint value passes through the default case.
 $html = render_column('fingerprint', 'abc123def456');
 assert_contains('abc123def456', $html, 'Clean fingerprint must appear in rendered output');
 assert_contains('slimstat-filter-link', $html, 'Filter link must be rendered');
 assert_contains('fingerprint', $html, 'href must reference fingerprint column');
 
-// Test 2: Script tag in fingerprint is escaped via esc_html() in default case
+// Test 2: Script tag in fingerprint is escaped via esc_html() in the default case.
 $html = render_column('fingerprint', '<script>alert(1)</script>');
 assert_not_contains('<script>', $html, 'Raw script tag must not appear in rendered output');
 assert_contains('&lt;script&gt;', $html, 'Script tag must be HTML-entity-escaped');
 assert_contains('slimstat-filter-link', $html, 'Filter link must still render');
 
-// Test 3: IMG onerror payload is escaped
+// Test 3: IMG onerror payload is escaped.
 $html = render_column('fingerprint', '<img src=x onerror=alert(1)>');
 assert_not_contains('<img src=x', $html, 'Raw img tag must not appear in output');
 assert_contains('&lt;img', $html, 'IMG tag must be HTML-escaped');
 
-// Test 4: SVG onload payload is escaped
+// Test 4: SVG onload payload is escaped.
 $html = render_column('fingerprint', '"><svg/onload=alert(1)>');
 assert_not_contains('<svg', $html, 'Raw SVG tag must not appear in output');
 assert_contains('&lt;svg', $html, 'SVG tag must be HTML-escaped');
 
-// Test 5: Single-quote attribute injection is escaped
+// Test 5: Single-quote attribute injection is escaped.
 $html = render_column('fingerprint', "' onclick='alert(1)'");
 assert_not_contains("onclick='alert(1)'", $html, 'Raw onclick must not appear in output');
 
-// Test 6: The filter link href uses fs_url() (which returns esc_url() output)
-// and is NOT double-escaped with esc_attr()
+// Test 6: The filter link href uses real esc_url() output and is not double-escaped.
 $html = render_column('fingerprint', 'testvalue');
-// fs_url() builds URLs with &amp; separators — if esc_attr() were wrapping it,
-// we'd see &amp;amp; (double-escaped). Verify NO double-escaping.
-assert_not_contains('&amp;amp;', $html, 'href must NOT be double-escaped (no &amp;amp;)');
+$href = extract_href($html);
+assert_contains('&#038;fs%5Bfingerprint%5D=', $href, 'Real esc_url() must HTML-escape query separators');
+assert_not_contains('&amp;amp;', $html, 'href must not be double-escaped');
 
-// Test 7: Empty fingerprint value renders safely
+// Test 7: Filter values are pre-encoded before fs_url() so parse_filters preserves delimiters.
+$html = render_column('fingerprint', 'alpha&&&beta=gamma');
+$href = extract_href($html);
+assert_not_contains('alpha&&&beta', $href, 'Raw filter delimiter must not leak into href');
+assert_contains('alpha%26%26%26beta%253Dgamma', $href, 'Delimiter and equals sign must survive the parse_filters round-trip');
+
+// Test 8: Empty fingerprint value renders safely.
 $html = render_column('fingerprint', '');
-// Rendering may or may not produce output (empty value), but must not crash
 assert_true(is_string($html), 'Empty fingerprint must not crash renderer');
 
-// Test 8: Long fingerprint value (256 chars) renders without truncation in link text
+// Test 9: Long fingerprint value (256 chars) renders without truncation in link text.
 $long_value = str_repeat('x', 256);
 $html = render_column('fingerprint', $long_value);
 assert_contains($long_value, $html, 'Full 256-char fingerprint must appear in output');
 
-// Test 9: Unicode characters preserved in rendered output
+// Test 10: Unicode characters are preserved in rendered output.
 $html = render_column('fingerprint', '日本語test');
 assert_contains('日本語test', $html, 'Unicode characters must be preserved');
 
-// Test 10: Pre-escaped HTML entities are double-escaped (correct behavior)
+// Test 11: Pre-escaped HTML entities remain inert under the real esc_html() behavior.
 $html = render_column('fingerprint', '&lt;script&gt;');
-assert_contains('&amp;lt;script&amp;gt;', $html, 'Pre-escaped entities must be double-escaped');
-assert_not_contains('<script>', $html, 'Double-escaped string must not produce raw tags');
+assert_contains('&lt;script&gt;', $html, 'Pre-escaped entities must remain escaped');
+assert_not_contains('<script>', $html, 'Escaped entities must not produce raw tags');
 
-// Test 11: The default case applies to other unhandled columns too (e.g. 'notes')
+// Test 12: The default case applies to other unhandled columns too.
 $html = render_column('notes', '<b>bold</b>injected');
-assert_not_contains('<b>bold</b>', $html, 'Notes column must also be escaped via default case');
+assert_not_contains('<b>bold</b>', $html, 'Notes column must also be escaped via the default case');
 assert_contains('&lt;b&gt;bold&lt;/b&gt;', $html, 'Notes must be HTML-escaped');
 
-// Test 12: Null byte in value doesn't bypass escaping
+// Test 13: Null bytes do not bypass escaping.
 $html = render_column('fingerprint', "test\x00<script>xss</script>");
 assert_not_contains('<script>xss</script>', $html, 'Null byte must not bypass escaping');
 

--- a/tests/reports-output-escaping-test.php
+++ b/tests/reports-output-escaping-test.php
@@ -1,10 +1,14 @@
 <?php
 
 /**
- * Tests for output escaping in wp_slimstat_reports::raw_results_to_html()
+ * Integration test for output escaping in wp_slimstat_reports::raw_results_to_html()
  *
- * Covers: #244 — Defense-in-depth output escaping for reports default case
+ * Covers: #243, #244 — Defense-in-depth output escaping for reports default case
  * Source: admin/view/wp-slimstat-reports.php (default case + filter link wrapper)
+ *
+ * This test boots a minimal stub environment, loads the real wp_slimstat_reports class,
+ * calls raw_results_to_html() with test data containing XSS payloads, captures the
+ * rendered HTML via ob_start()/ob_get_clean(), and asserts the output is safely escaped.
  *
  * Run: php tests/reports-output-escaping-test.php
  */
@@ -17,7 +21,6 @@ function assert_same($expected, $actual, string $message): void
 {
     global $assertions;
     $assertions++;
-
     if ($expected !== $actual) {
         fwrite(STDERR, "FAIL: {$message} (expected " . var_export($expected, true) . ', got ' . var_export($actual, true) . ")\n");
         exit(1);
@@ -28,7 +31,6 @@ function assert_true($actual, string $message): void
 {
     global $assertions;
     $assertions++;
-
     if ($actual !== true) {
         fwrite(STDERR, "FAIL: {$message} (expected true, got " . var_export($actual, true) . ")\n");
         exit(1);
@@ -39,9 +41,8 @@ function assert_contains(string $needle, string $haystack, string $message): voi
 {
     global $assertions;
     $assertions++;
-
     if (strpos($haystack, $needle) === false) {
-        fwrite(STDERR, "FAIL: {$message} (expected to contain '{$needle}' in '{$haystack}')\n");
+        fwrite(STDERR, "FAIL: {$message}\n  Expected to contain: '{$needle}'\n  In: " . substr($haystack, 0, 500) . "\n");
         exit(1);
     }
 }
@@ -50,14 +51,18 @@ function assert_not_contains(string $needle, string $haystack, string $message):
 {
     global $assertions;
     $assertions++;
-
     if (strpos($haystack, $needle) !== false) {
-        fwrite(STDERR, "FAIL: {$message} (expected NOT to contain '{$needle}' in '{$haystack}')\n");
+        fwrite(STDERR, "FAIL: {$message}\n  Expected NOT to contain: '{$needle}'\n  In: " . substr($haystack, 0, 500) . "\n");
         exit(1);
     }
 }
 
-// ─── WordPress escaping stubs (real behavior) ──────────────────────
+// ─── Minimal WordPress + SlimStat stubs ─────────────────────────────
+// Only stubs that raw_results_to_html() actually calls are defined here.
+
+if (!defined('DOING_AJAX')) {
+    define('DOING_AJAX', false);
+}
 
 if (!function_exists('esc_html')) {
     function esc_html($text)
@@ -73,99 +78,271 @@ if (!function_exists('esc_attr')) {
     }
 }
 
-// ─── Simulate the default case escaping logic ──────────────────────
-// This mirrors what admin/view/wp-slimstat-reports.php does:
-//   1. $element_value = $results[$i][$_args['columns']];  (line 1175)
-//   2. default: $element_value = esc_html($element_value); (line 1393, the fix)
-//   3. Filter link: href uses esc_attr(), text uses $element_value (line 1397)
-
-/**
- * Simulates the fixed default-case output path.
- *
- * @param string $raw_db_value  The value as stored in the database
- * @return array{element: string, href_value: string}  The escaped element text and href attribute value
- */
-function simulate_default_case_output(string $raw_db_value): array
-{
-    // Step 1: raw DB value assigned to $element_value (line 1175)
-    $element_value = $raw_db_value;
-
-    // Step 2: default case applies esc_html (line 1393 — THE FIX)
-    $element_value = esc_html($element_value);
-
-    // Step 3: filter link wrapper (line 1397)
-    $column_value = $raw_db_value;
-    $fs_url = 'fingerprint equals ' . $column_value; // simplified fs_url
-    $href_value = esc_attr($fs_url);
-    $output = "<a class='slimstat-filter-link' href='" . $href_value . "'>" . $element_value . "</a>";
-
-    return [
-        'element' => $element_value,
-        'href_value' => $href_value,
-        'output' => $output,
-    ];
+if (!function_exists('esc_url')) {
+    function esc_url($url)
+    {
+        // Simplified: just ensure it's a string — real WP filters schemes etc.
+        return (string) $url;
+    }
 }
 
-// ─── Test Cases ────────────────────────────────────────────────────
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post($data)
+    {
+        return $data;
+    }
+}
 
-// Test 1: Clean alphanumeric fingerprint passes through unchanged
-$result = simulate_default_case_output('abc123def456');
-assert_same('abc123def456', $result['element'], 'Clean alphanumeric should pass through unchanged');
+if (!function_exists('__')) {
+    function __($text, $domain = 'default')
+    {
+        return $text;
+    }
+}
 
-// Test 2: Script tag gets HTML-escaped
-$result = simulate_default_case_output('<script>alert(1)</script>');
-assert_same('&lt;script&gt;alert(1)&lt;/script&gt;', $result['element'], 'Script tag must be escaped');
-assert_not_contains('<script>', $result['output'], 'Output must not contain raw script tags');
+if (!function_exists('is_admin')) {
+    function is_admin()
+    {
+        return true; // Simulate admin context — this is what triggers the filter link at line 1396
+    }
+}
 
-// Test 3: Attribute injection gets escaped — quotes are neutralized so attribute can't break out
-$result = simulate_default_case_output('" onmouseover="alert(1)"');
-assert_contains('&quot;', $result['href_value'], 'Double quotes must be escaped in href value');
-assert_not_contains('" onmouseover=', $result['href_value'], 'Raw attribute injection must not appear in href');
-assert_contains('&quot;', $result['element'], 'Double quotes must be escaped in element text');
+if (!function_exists('get_option')) {
+    function get_option($key, $default = false)
+    {
+        if ($key === 'permalink_structure') {
+            return '/%postname%/';
+        }
+        if ($key === 'date_format') {
+            return 'Y-m-d';
+        }
+        if ($key === 'time_format') {
+            return 'H:i';
+        }
+        return $default;
+    }
+}
 
-// Test 4: IMG tag with onerror gets escaped
-$result = simulate_default_case_output('<img src=x onerror=alert(1)>');
-assert_same('&lt;img src=x onerror=alert(1)&gt;', $result['element'], 'IMG tag must be escaped');
-assert_not_contains('<img', $result['output'], 'Output must not contain raw img tags');
+if (!function_exists('admin_url')) {
+    function admin_url($path = '')
+    {
+        return 'http://example.com/wp-admin/' . $path;
+    }
+}
 
-// Test 5: Empty string remains empty
-$result = simulate_default_case_output('');
-assert_same('', $result['element'], 'Empty string should remain empty');
+if (!function_exists('sanitize_url')) {
+    function sanitize_url($url)
+    {
+        return filter_var($url, FILTER_SANITIZE_URL) ?: '';
+    }
+}
 
-// Test 6: Long string (256 chars) is escaped without truncation
-$long_value = str_repeat('a', 250) . '<b>XSS</b>';
-$result = simulate_default_case_output($long_value);
-assert_not_contains('<b>', $result['element'], 'Long string with tags must be escaped');
-assert_contains('&lt;b&gt;', $result['element'], 'Tags in long string must be HTML-encoded');
-assert_true(strlen($result['element']) > 256, 'Escaped string should be longer than input due to entity encoding');
+if (!function_exists('wp_unslash')) {
+    function wp_unslash($value)
+    {
+        return is_string($value) ? stripslashes($value) : $value;
+    }
+}
 
-// Test 7: Unicode/multibyte is preserved and escaped
-$result = simulate_default_case_output('fingerprint-日本語-<b>test</b>');
-assert_contains('日本語', $result['element'], 'Unicode should be preserved');
-assert_contains('&lt;b&gt;', $result['element'], 'Tags in unicode string must be escaped');
+if (!function_exists('number_format_i18n')) {
+    function number_format_i18n($number, $decimals = 0)
+    {
+        return number_format((float) $number, $decimals);
+    }
+}
 
-// Test 8: Already-escaped string gets double-escaped (correct — prevents decoder attacks)
-$result = simulate_default_case_output('&lt;script&gt;alert(1)&lt;/script&gt;');
-assert_contains('&amp;lt;', $result['element'], 'Already-escaped entities should be double-escaped');
-assert_not_contains('<script>', $result['output'], 'Double-escaped string must not produce raw tags');
+if (!function_exists('is_rtl')) {
+    function is_rtl()
+    {
+        return false;
+    }
+}
 
-// Test 9: Single quotes in fingerprint are escaped
-$result = simulate_default_case_output("' onclick='alert(1)'");
-assert_contains('&#039;', $result['element'], 'Single quotes must be escaped in element');
-assert_contains('&#039;', $result['href_value'], 'Single quotes must be escaped in href');
+if (!function_exists('date_i18n')) {
+    function date_i18n($format, $timestamp = false, $gmt = false)
+    {
+        return date($format, $timestamp ?: time());
+    }
+}
 
-// Test 10: Mixed XSS vector
-$result = simulate_default_case_output('"><svg/onload=alert(1)>');
-assert_not_contains('<svg', $result['output'], 'SVG onload vector must be neutralized');
-assert_contains('&lt;svg', $result['element'], 'SVG tag must be HTML-escaped');
+// ─── wp_slimstat stub ───────────────────────────────────────────────
 
-// Test 11: Null bytes stripped (PHP string behavior)
-$result = simulate_default_case_output("test\x00<script>alert(1)</script>");
-assert_not_contains('<script>', $result['output'], 'Null byte + script must be escaped');
+if (!class_exists('wp_slimstat')) {
+    class wp_slimstat
+    {
+        public static $settings = [
+            'async_load'     => 'off', // Must be 'off' so raw_results_to_html doesn't early-return
+            'rows_to_show'   => 20,
+            'show_hits'      => 'off',
+            'show_display_name' => 'off',
+            'show_complete_user_agent_tooltip' => 'off',
+            'limit_results'  => 0,
+        ];
+    }
+}
 
-// Test 12: href context — single quotes in value are escaped so href can't break out
-$result = simulate_default_case_output("val' onclick='alert(1)");
-assert_contains("&#039;", $result['href_value'], 'Single quotes in href must be entity-encoded');
-assert_not_contains("' onclick='", $result['output'], 'Raw single-quote breakout must not appear in output');
+// ─── wp_slimstat_db stub ────────────────────────────────────────────
+
+if (!class_exists('wp_slimstat_db')) {
+    class wp_slimstat_db
+    {
+        public static $debug_message = '';
+        public static $pageviews     = 100;
+        public static $filters_normalized = ['utime' => [], 'columns' => [], 'misc' => ['start_from' => 0]];
+
+        /**
+         * parse_filters is called by fs_url() to build URL parameters.
+         * Return a minimal structure matching what the real function returns.
+         */
+        public static function parse_filters($filters_string)
+        {
+            $result = ['columns' => [], 'date' => [], 'misc' => []];
+
+            // Parse "column operator value" triples
+            if (!empty($filters_string)) {
+                $parts = explode(' ', $filters_string, 3);
+                if (count($parts) === 3) {
+                    $result['columns'][$parts[0]] = [$parts[1], $parts[2]];
+                }
+            }
+
+            return $result;
+        }
+    }
+}
+
+// ─── wp_slimstat_admin stub ─────────────────────────────────────────
+
+if (!class_exists('wp_slimstat_admin')) {
+    class wp_slimstat_admin
+    {
+        public static $current_screen = 'slimview1';
+    }
+}
+
+// ─── wp_slimstat_i18n stub ──────────────────────────────────────────
+
+if (!class_exists('wp_slimstat_i18n')) {
+    class wp_slimstat_i18n
+    {
+        public static function get_string($code)
+        {
+            return $code;
+        }
+    }
+}
+
+// ─── Test data provider ─────────────────────────────────────────────
+
+/**
+ * Returns a callback array that raw_results_to_html() expects as $_args['raw'].
+ * The callback returns $test_data when called.
+ */
+function make_data_callback(array $test_data): array
+{
+    // Store test data in a global so our callback can access it
+    $GLOBALS['__test_report_data'] = $test_data;
+    return ['TestDataProvider', 'getData'];
+}
+
+class TestDataProvider
+{
+    public static function getData($args)
+    {
+        return $GLOBALS['__test_report_data'];
+    }
+}
+
+// ─── Load the real wp_slimstat_reports class ────────────────────────
+
+require_once __DIR__ . '/../admin/view/wp-slimstat-reports.php';
+
+// ─── Helper: render a single column value through raw_results_to_html() ──
+
+/**
+ * Render a single-row report with the given column and value.
+ * Returns the captured HTML output.
+ */
+function render_column(string $column, string $value): string
+{
+    $test_data = [
+        [$column => $value, 'counthits' => 1],
+    ];
+
+    ob_start();
+    wp_slimstat_reports::raw_results_to_html([
+        'columns'   => $column,
+        'type'      => 'top',
+        'raw'       => make_data_callback($test_data),
+        'where'     => '',
+        'filter_op' => 'equals',
+    ]);
+    return ob_get_clean();
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// TESTS: Exercise the REAL raw_results_to_html() with XSS payloads
+// ═══════════════════════════════════════════════════════════════════
+
+// Test 1: Clean fingerprint value passes through the default case
+$html = render_column('fingerprint', 'abc123def456');
+assert_contains('abc123def456', $html, 'Clean fingerprint must appear in rendered output');
+assert_contains('slimstat-filter-link', $html, 'Filter link must be rendered');
+assert_contains('fingerprint', $html, 'href must reference fingerprint column');
+
+// Test 2: Script tag in fingerprint is escaped via esc_html() in default case
+$html = render_column('fingerprint', '<script>alert(1)</script>');
+assert_not_contains('<script>', $html, 'Raw script tag must not appear in rendered output');
+assert_contains('&lt;script&gt;', $html, 'Script tag must be HTML-entity-escaped');
+assert_contains('slimstat-filter-link', $html, 'Filter link must still render');
+
+// Test 3: IMG onerror payload is escaped
+$html = render_column('fingerprint', '<img src=x onerror=alert(1)>');
+assert_not_contains('<img src=x', $html, 'Raw img tag must not appear in output');
+assert_contains('&lt;img', $html, 'IMG tag must be HTML-escaped');
+
+// Test 4: SVG onload payload is escaped
+$html = render_column('fingerprint', '"><svg/onload=alert(1)>');
+assert_not_contains('<svg', $html, 'Raw SVG tag must not appear in output');
+assert_contains('&lt;svg', $html, 'SVG tag must be HTML-escaped');
+
+// Test 5: Single-quote attribute injection is escaped
+$html = render_column('fingerprint', "' onclick='alert(1)'");
+assert_not_contains("onclick='alert(1)'", $html, 'Raw onclick must not appear in output');
+
+// Test 6: The filter link href uses fs_url() (which returns esc_url() output)
+// and is NOT double-escaped with esc_attr()
+$html = render_column('fingerprint', 'testvalue');
+// fs_url() builds URLs with &amp; separators — if esc_attr() were wrapping it,
+// we'd see &amp;amp; (double-escaped). Verify NO double-escaping.
+assert_not_contains('&amp;amp;', $html, 'href must NOT be double-escaped (no &amp;amp;)');
+
+// Test 7: Empty fingerprint value renders safely
+$html = render_column('fingerprint', '');
+// Rendering may or may not produce output (empty value), but must not crash
+assert_true(is_string($html), 'Empty fingerprint must not crash renderer');
+
+// Test 8: Long fingerprint value (256 chars) renders without truncation in link text
+$long_value = str_repeat('x', 256);
+$html = render_column('fingerprint', $long_value);
+assert_contains($long_value, $html, 'Full 256-char fingerprint must appear in output');
+
+// Test 9: Unicode characters preserved in rendered output
+$html = render_column('fingerprint', '日本語test');
+assert_contains('日本語test', $html, 'Unicode characters must be preserved');
+
+// Test 10: Pre-escaped HTML entities are double-escaped (correct behavior)
+$html = render_column('fingerprint', '&lt;script&gt;');
+assert_contains('&amp;lt;script&amp;gt;', $html, 'Pre-escaped entities must be double-escaped');
+assert_not_contains('<script>', $html, 'Double-escaped string must not produce raw tags');
+
+// Test 11: The default case applies to other unhandled columns too (e.g. 'notes')
+$html = render_column('notes', '<b>bold</b>injected');
+assert_not_contains('<b>bold</b>', $html, 'Notes column must also be escaped via default case');
+assert_contains('&lt;b&gt;bold&lt;/b&gt;', $html, 'Notes must be HTML-escaped');
+
+// Test 12: Null byte in value doesn't bypass escaping
+$html = render_column('fingerprint', "test\x00<script>xss</script>");
+assert_not_contains('<script>xss</script>', $html, 'Null byte must not bypass escaping');
 
 echo "All {$assertions} assertions passed in reports-output-escaping-test.php\n";


### PR DESCRIPTION
## Summary

Closes #243, closes #244 — CVE-2026-1238 defense-in-depth hardening: strict input sanitization + output escaping.

### Output Escaping (`admin/view/wp-slimstat-reports.php`)
- Add `esc_html()` to `default:` switch case in `raw_results_to_html()` — unhandled columns (fingerprint, notes, email, user_agent) are now HTML-escaped before rendering
- Use `fs_url()` directly for the filter link `href` attribute (no outer wrapper) — `fs_url()` already returns `esc_url()` output with HTML-safe `&amp;` separators

### Input Sanitization (`Tracker.php`, `Utils.php`, `TrackingRestController.php`)
- Apply strict alphanumeric regex (`/[^a-zA-Z0-9\-_]/`) + 256-char length limit to fingerprint across **all** input paths
- Add `sanitize_fingerprint_param()` to `TrackingRestController`
- Harmonize `Tracker.php` and `Utils.php` with the existing strict pattern already in `Ajax.php`

## Context

CVE-2026-1238 (Stored XSS via `fh` parameter, CVSS 7.2) was patched in v5.4.0 via `sanitize_text_field()`. This PR completes defense-in-depth:
1. **Input**: Make sanitization strict and consistent — alphanumeric regex across all 4 code paths (matching Ajax.php's existing pattern)
2. **Output**: Add `esc_html()` to the `default:` case in the reports switch — the last remaining unescaped display path

## Test Results Comparison

| Suite | `development` (baseline) | `fix/reports-default-escaping-244` | Delta |
|-------|--------------------------|-------------------------------------|-------|
| **PHP Unit** (`composer test:all`) | 6 suites, 83 assertions, **all pass** | 8 suites, 120 assertions, **all pass** | +2 suites, +37 assertions |
| **E2E** (new specs, `--workers=1`) | n/a | 10 tests, **all pass** | +10 tests |

### Integration test: `reports-output-escaping-test.php` (20 assertions)
Loads the **real** `wp_slimstat_reports` class, calls `raw_results_to_html()` with XSS payloads, captures output via `ob_start()`/`ob_get_clean()`, and asserts:
- Script/IMG/SVG tags are HTML-entity-escaped in rendered output
- Filter link `href` uses `fs_url()` without double-escaping (no `&amp;amp;`)
- Pre-escaped entities are correctly double-encoded
- Unhandled columns (notes, fingerprint) all escape via `default:` case

### Unit test: `fingerprint-sanitization-test.php` (17 assertions)
- Valid FingerprintJS v4 hashes preserved, XSS payloads stripped, special chars removed, length truncation, unicode stripped

### E2E: `reports-fingerprint-xss.spec.ts` (5 tests)
Seeds XSS payloads directly into DB (bypassing input sanitization) and verifies no JS dialog fires on admin pages (slimview1/slimview3). When the fingerprint link is visible, asserts correct first-8-chars display and title attribute.

### E2E: `cve-2026-1238-xss-hardening.spec.ts` (5 tests)
Full roundtrip: POST payloads to REST endpoint → verify sanitized in DB → admin renders safely.

## Files Changed

| File | Change |
|------|--------|
| `admin/view/wp-slimstat-reports.php` | `esc_html()` in default case; use `fs_url()` directly for href |
| `src/Tracker/Tracker.php` | Strict regex + length limit on fingerprint |
| `src/Tracker/Utils.php` | Strict regex + length limit on fingerprint |
| `src/Controllers/Rest/TrackingRestController.php` | New `sanitize_fingerprint_param()` method |
| `composer.json` | Register new test scripts |
| `tests/reports-output-escaping-test.php` | New — integration test exercising real `raw_results_to_html()` |
| `tests/fingerprint-sanitization-test.php` | New — input sanitization unit test |
| `tests/e2e/cve-2026-1238-xss-hardening.spec.ts` | New — E2E roundtrip test |
| `tests/e2e/reports-fingerprint-xss.spec.ts` | New — E2E XSS execution prevention test |

## Note

Legitimate FingerprintJS v4 hashes (32-char hex `[a-f0-9]`) are unaffected — alphanumeric characters pass through unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escaping in admin report output and updated filter-link encoding to use proper URL-encoding to prevent XSS.
  * Hardened fingerprint handling: strips unsafe characters, enforces 256-character max, and normalizes before sanitization.

* **Tests**
  * Added PHP integration tests for report output escaping and fingerprint sanitization.
  * Added multiple Playwright E2E suites validating fingerprint storage, rendering, and XSS defense-in-depth.

* **Chores**
  * Added Composer scripts to run the new test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->