### PR TITLE
fix(#236): store attachment content_type as cpt:attachment

### DIFF
--- a/admin/config/index.php
+++ b/admin/config/index.php
@@ -591,7 +591,7 @@ $settings = [
             'ignore_content_types' => [
                 'title'       => __('Content Types', 'wp-slimstat'),
                 'type'        => 'textarea',
-                'description' => __('Enter a list of Slimstat content types that should not be tracked: <code>post, page, attachment, tag, 404, taxonomy, author, archive, search, feed, login</code>, etc. For custom post types, use the <code>cpt:</code> prefix (e.g., <code>cpt:product</code>, <code>cpt:portfolio</code>). See note at the bottom of this page for more information on how to use wildcards. Strings are case-insensitive.', 'wp-slimstat'),
+                'description' => __('Enter a list of Slimstat content types that should not be tracked: <code>post, page, cpt:attachment, tag, 404, taxonomy, author, archive, search, feed, login</code>, etc. For custom post types, use the <code>cpt:</code> prefix (e.g., <code>cpt:product</code>, <code>cpt:portfolio</code>, <code>cpt:attachment</code>). See note at the bottom of this page for more information on how to use wildcards. Strings are case-insensitive.', 'wp-slimstat'),
             ],
             'wildcards_description' => ['Wildcards',
                 'type'   => 'custom',

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "test:geoservice": "php tests/geoservice-provider-resolution-test.php",
     "test:legacy-sync": "php tests/legacy-sync-mapping-test.php",
     "test:lazy-migration": "php tests/lazy-migration-test.php",
+    "test:content-type-attachment": "php tests/content-type-attachment-test.php",
     "test:rest-controller": "php tests/tracking-rest-controller-test.php",
     "test:all": [
       "@test:license-tags",
@@ -48,6 +49,7 @@
       "@test:geoservice",
       "@test:legacy-sync",
       "@test:lazy-migration",
+      "@test:content-type-attachment",
       "@test:rest-controller"
     ]
   }

--- a/src/Tracker/Processor.php
+++ b/src/Tracker/Processor.php
@@ -155,7 +155,23 @@ class Processor
 
         if (!isset($stat['content_type'])) {
             $content_info = Utils::getContentInfo();
-            if (!empty(\wp_slimstat::$settings['ignore_content_types']) && Utils::isBlacklisted($content_info['content_type'], \wp_slimstat::$settings['ignore_content_types'])) {
+            // Normalize legacy ignore_content_types=attachment to match the
+            // cpt:attachment format introduced in the #236 fix.
+            $ignore_content_types = \wp_slimstat::$settings['ignore_content_types'] ?? '';
+            if ('' !== $ignore_content_types) {
+                $ignore_content_types = implode(',', array_unique(array_merge(
+                    \wp_slimstat::string_to_array($ignore_content_types),
+                    array_map(
+                        function ($v) { return 'cpt:' . $v; },
+                        array_filter(
+                            \wp_slimstat::string_to_array($ignore_content_types),
+                            function ($v) { return 'attachment' === $v; }
+                        )
+                    )
+                )));
+            }
+
+            if (!empty($ignore_content_types) && Utils::isBlacklisted($content_info['content_type'], $ignore_content_types)) {
                 Query::setProcessingTimestamp(null);
                 return false;
             }

--- a/src/Tracker/Tracker.php
+++ b/src/Tracker/Tracker.php
@@ -273,7 +273,7 @@ class Tracker
             $content_info['content_type'] = 'page';
             $content_info['content_id']   = $GLOBALS['post']->ID;
         } elseif (is_attachment()) {
-            $content_info['content_type'] = 'attachment';
+            $content_info['content_type'] = 'cpt:attachment';
         } elseif (is_singular()) {
             $content_info['content_type'] = 'singular';
         } elseif (is_post_type_archive()) {

--- a/src/Tracker/Utils.php
+++ b/src/Tracker/Utils.php
@@ -56,18 +56,6 @@ class Utils
 			$needles = [$needles];
 		}
 
-		// Preserve legacy ignore_content_types=attachment configs after
-		// attachment pages were normalized to the cpt:attachment format.
-		$expanded_needles = [];
-		foreach ($needles as $needle) {
-			$expanded_needles[] = $needle;
-			if (is_string($needle) && 0 === strpos($needle, 'cpt:attachment')) {
-				$expanded_needles[] = substr($needle, 4);
-			}
-		}
-
-		$needles = array_values(array_unique($expanded_needles));
-
 		foreach (\wp_slimstat::string_to_array($haystackString) as $item) {
 			$pattern = str_replace(['\\*', '\\!'], ['(.*)', '.'], preg_quote($item, '@'));
 

--- a/src/Tracker/Utils.php
+++ b/src/Tracker/Utils.php
@@ -284,7 +284,7 @@ class Utils
 			$content_info['content_type'] = 'page';
 			$content_info['content_id']   = $GLOBALS['post']->ID;
 		} elseif (is_attachment()) {
-			$content_info['content_type'] = 'attachment';
+			$content_info['content_type'] = 'cpt:attachment';
 		} elseif (is_singular()) {
 			$content_info['content_type'] = 'singular';
 		} elseif (is_post_type_archive()) {

--- a/src/Tracker/Utils.php
+++ b/src/Tracker/Utils.php
@@ -52,11 +52,24 @@ class Utils
 
 	public static function isBlacklisted($needles = [], $haystackString = '')
 	{
+		if (!is_array($needles)) {
+			$needles = [$needles];
+		}
+
+		// Preserve legacy ignore_content_types=attachment configs after
+		// attachment pages were normalized to the cpt:attachment format.
+		$expanded_needles = [];
+		foreach ($needles as $needle) {
+			$expanded_needles[] = $needle;
+			if (is_string($needle) && 0 === strpos($needle, 'cpt:attachment')) {
+				$expanded_needles[] = substr($needle, 4);
+			}
+		}
+
+		$needles = array_values(array_unique($expanded_needles));
+
 		foreach (\wp_slimstat::string_to_array($haystackString) as $item) {
 			$pattern = str_replace(['\\*', '\\!'], ['(.*)', '.'], preg_quote($item, '@'));
-			if (!is_array($needles)) {
-				$needles = [$needles];
-			}
 
 			foreach ($needles as $needle) {
 				if (preg_match(sprintf('@^%s$@i', $pattern), $needle)) {

--- a/tests/content-type-attachment-test.php
+++ b/tests/content-type-attachment-test.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+$assertions = 0;
+
+function assert_same($expected, $actual, string $message): void
+{
+    global $assertions;
+    $assertions++;
+
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message} (expected " . var_export($expected, true) . ', got ' . var_export($actual, true) . ")\n");
+        exit(1);
+    }
+}
+
+function assert_true($actual, string $message): void
+{
+    global $assertions;
+    $assertions++;
+
+    if ($actual !== true) {
+        fwrite(STDERR, "FAIL: {$message} (expected true, got " . var_export($actual, true) . ")\n");
+        exit(1);
+    }
+}
+
+function assert_false($actual, string $message): void
+{
+    global $assertions;
+    $assertions++;
+
+    if ($actual !== false) {
+        fwrite(STDERR, "FAIL: {$message} (expected false, got " . var_export($actual, true) . ")\n");
+        exit(1);
+    }
+}
+
+if (!class_exists('wp_slimstat')) {
+    class wp_slimstat
+    {
+        public static function string_to_array($_option = '')
+        {
+            if (empty($_option) || !is_string($_option)) {
+                return [];
+            }
+
+            return array_filter(array_map('trim', explode(',', $_option)));
+        }
+    }
+}
+
+$GLOBALS['slimstat_attachment_test_state'] = [];
+$GLOBALS['post'] = (object) ['ID' => 123, 'post_author' => 7];
+$GLOBALS['pagenow'] = '';
+
+function slimstat_attachment_test_reset(array $overrides = []): void
+{
+    $GLOBALS['slimstat_attachment_test_state'] = array_merge([
+        'is_404' => false,
+        'is_single' => false,
+        'is_page' => false,
+        'is_attachment' => false,
+        'is_singular' => false,
+        'is_post_type_archive' => false,
+        'is_tag' => false,
+        'is_tax' => false,
+        'is_category' => false,
+        'is_date' => false,
+        'is_author' => false,
+        'is_archive' => false,
+        'is_search' => false,
+        'is_feed' => false,
+        'is_home' => false,
+        'is_front_page' => false,
+        'is_admin' => false,
+        'is_paged' => false,
+        'post_type' => 'attachment',
+    ], $overrides);
+
+    $GLOBALS['post'] = (object) ['ID' => 123, 'post_author' => 7];
+    $GLOBALS['pagenow'] = '';
+}
+
+function slimstat_attachment_test_state(string $key)
+{
+    return $GLOBALS['slimstat_attachment_test_state'][$key] ?? false;
+}
+
+if (!function_exists('get_post_type')) {
+    function get_post_type()
+    {
+        return slimstat_attachment_test_state('post_type');
+    }
+}
+
+if (!function_exists('get_object_taxonomies')) {
+    function get_object_taxonomies($post)
+    {
+        return [];
+    }
+}
+
+if (!function_exists('get_the_terms')) {
+    function get_the_terms($postId, $taxonomy)
+    {
+        return [];
+    }
+}
+
+if (!function_exists('get_the_tags')) {
+    function get_the_tags()
+    {
+        return [];
+    }
+}
+
+if (!function_exists('get_the_category')) {
+    function get_the_category()
+    {
+        return [];
+    }
+}
+
+if (!function_exists('get_the_author_meta')) {
+    function get_the_author_meta($field, $userId)
+    {
+        return 'attachment-author';
+    }
+}
+
+if (!function_exists('is_404')) {
+    function is_404()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_single')) {
+    function is_single()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_page')) {
+    function is_page()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_attachment')) {
+    function is_attachment()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_singular')) {
+    function is_singular()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_post_type_archive')) {
+    function is_post_type_archive()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_tag')) {
+    function is_tag()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_tax')) {
+    function is_tax()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_category')) {
+    function is_category()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_date')) {
+    function is_date()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_author')) {
+    function is_author()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_archive')) {
+    function is_archive()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_search')) {
+    function is_search()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_feed')) {
+    function is_feed()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_home')) {
+    function is_home()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_front_page')) {
+    function is_front_page()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_admin')) {
+    function is_admin()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+if (!function_exists('is_paged')) {
+    function is_paged()
+    {
+        return slimstat_attachment_test_state(__FUNCTION__);
+    }
+}
+
+require_once __DIR__ . '/../src/Tracker/Utils.php';
+require_once __DIR__ . '/../src/Tracker/Tracker.php';
+
+use SlimStat\Tracker\Tracker;
+use SlimStat\Tracker\Utils;
+
+slimstat_attachment_test_reset([
+    'is_attachment' => true,
+    'is_singular' => true,
+]);
+
+$contentInfo = Utils::getContentInfo();
+assert_same('cpt:attachment', $contentInfo['content_type'], 'Utils::getContentInfo should prefix attachment content types');
+
+$legacyContentInfo = Tracker::_get_content_info();
+assert_same('cpt:attachment', $legacyContentInfo['content_type'], 'Tracker::_get_content_info should prefix attachment content types');
+
+assert_true(Utils::isBlacklisted('cpt:attachment', 'cpt:attachment'), 'Exact attachment CPT exclusions should match');
+assert_false(Utils::isBlacklisted('attachment', 'cpt:attachment'), 'Legacy attachment values should not match prefixed exclusions');
+assert_true(Utils::isBlacklisted('cpt:attachment', 'cpt:*'), 'Wildcard CPT exclusions should match attachments');
+
+echo "All {$assertions} assertions passed in content-type-attachment-test.php\n";

--- a/tests/content-type-attachment-test.php
+++ b/tests/content-type-attachment-test.php
@@ -274,7 +274,7 @@ $legacyContentInfo = Tracker::_get_content_info();
 assert_same('cpt:attachment', $legacyContentInfo['content_type'], 'Tracker::_get_content_info should prefix attachment content types');
 
 assert_true(Utils::isBlacklisted('cpt:attachment', 'cpt:attachment'), 'Exact attachment CPT exclusions should match');
-assert_false(Utils::isBlacklisted('attachment', 'cpt:attachment'), 'Legacy attachment values should not match prefixed exclusions');
+assert_true(Utils::isBlacklisted('cpt:attachment', 'attachment'), 'Legacy attachment exclusions should still match prefixed attachment content types');
 assert_true(Utils::isBlacklisted('cpt:attachment', 'cpt:*'), 'Wildcard CPT exclusions should match attachments');
 
 echo "All {$assertions} assertions passed in content-type-attachment-test.php\n";

--- a/tests/content-type-attachment-test.php
+++ b/tests/content-type-attachment-test.php
@@ -273,8 +273,27 @@ assert_same('cpt:attachment', $contentInfo['content_type'], 'Utils::getContentIn
 $legacyContentInfo = Tracker::_get_content_info();
 assert_same('cpt:attachment', $legacyContentInfo['content_type'], 'Tracker::_get_content_info should prefix attachment content types');
 
+// isBlacklisted is now a generic matcher — no attachment-specific expansion.
 assert_true(Utils::isBlacklisted('cpt:attachment', 'cpt:attachment'), 'Exact attachment CPT exclusions should match');
-assert_true(Utils::isBlacklisted('cpt:attachment', 'attachment'), 'Legacy attachment exclusions should still match prefixed attachment content types');
+assert_false(Utils::isBlacklisted('cpt:attachment', 'attachment'), 'Generic isBlacklisted should NOT expand legacy attachment — compat lives in Processor');
 assert_true(Utils::isBlacklisted('cpt:attachment', 'cpt:*'), 'Wildcard CPT exclusions should match attachments');
+
+// Legacy backward-compat: Processor normalizes "attachment" → "cpt:attachment"
+// in the ignore_content_types setting before calling isBlacklisted.
+if (!class_exists('wp_slimstat', false)) {
+    // wp_slimstat stub already exists from above
+}
+$legacy_setting = 'attachment';
+$normalized = implode(',', array_unique(array_merge(
+    \wp_slimstat::string_to_array($legacy_setting),
+    array_map(
+        function ($v) { return 'cpt:' . $v; },
+        array_filter(
+            \wp_slimstat::string_to_array($legacy_setting),
+            function ($v) { return 'attachment' === $v; }
+        )
+    )
+)));
+assert_true(Utils::isBlacklisted('cpt:attachment', $normalized), 'Processor-normalized legacy "attachment" setting should match cpt:attachment');
 
 echo "All {$assertions} assertions passed in content-type-attachment-test.php\n";

--- a/tests/e2e/exclusion-filters.spec.ts
+++ b/tests/e2e/exclusion-filters.spec.ts
@@ -288,8 +288,10 @@ test.describe('Exclusion Filters (@tracking-exclusions)', () => {
     await setSlimstatSetting('ignore_content_types', 'cpt:attachment');
 
     const slug = `e2e-attachment-excl-${Date.now()}`;
-    const attachmentId = await createAttachmentPost('E2E Attachment Exclusion Test', slug);
-    const attachmentUrl = `${BASE_URL}/?attachment_id=${attachmentId}`;
+    await createAttachmentPost('E2E Attachment Exclusion Test', slug);
+    // Visit the pretty permalink directly — /?attachment_id=X triggers a 301
+    // redirect whose content_type is 'redirect:301', not 'cpt:attachment'.
+    const attachmentUrl = `${BASE_URL}/${slug}/`;
 
     await clearStatsTable();
 
@@ -297,10 +299,11 @@ test.describe('Exclusion Filters (@tracking-exclusions)', () => {
     const anonPage = await anonCtx.newPage();
     await anonPage.goto(attachmentUrl, { waitUntil: 'domcontentloaded' });
 
+    // Poll for the slug-specific row — should remain null (excluded).
     await expect.poll(
-      () => getStatCount(),
+      () => getRecentStatByResource(slug),
       { timeout: 6_000, intervals: [500] }
-    ).toBe(0);
+    ).toBeNull();
 
     await anonPage.close();
     await anonCtx.close();

--- a/tests/e2e/exclusion-filters.spec.ts
+++ b/tests/e2e/exclusion-filters.spec.ts
@@ -2,7 +2,8 @@
  * E2E: Exclusion Filters — validates ignore_content_types, ignore_bots,
  * ignore_resources, and ignore_wp_users in the tracking pipeline.
  *
- * Covers GitHub issue #233 (CPT exclusion requires cpt: prefix).
+ * Covers GitHub issues #233 and #236 (CPT exclusion requires cpt: prefix,
+ * including attachment pages).
  *
  * @see jaan-to/outputs/qa/cases/10-exclusion-filters/10-test-cases-exclusion-filters.md
  */
@@ -78,6 +79,16 @@ async function createProductPost(title: string, slug: string): Promise<number> {
     `INSERT INTO wp_posts (post_author, post_date, post_date_gmt, post_content, post_title, post_excerpt, post_status, comment_status, ping_status, post_name, post_modified, post_modified_gmt, post_type, to_ping, pinged, post_content_filtered)
      VALUES (1, ?, ?, 'Test content.', ?, '', 'publish', 'closed', 'closed', ?, ?, ?, 'product', '', '', '')`,
     [now, now, title, slug, now, now]
+  ) as any;
+  return result.insertId;
+}
+
+async function createAttachmentPost(title: string, slug: string): Promise<number> {
+  const now = new Date().toISOString().slice(0, 19).replace('T', ' ');
+  const [result] = await getPool().execute(
+    `INSERT INTO wp_posts (post_author, post_date, post_date_gmt, post_content, post_title, post_excerpt, post_status, comment_status, ping_status, post_name, to_ping, pinged, post_modified, post_modified_gmt, post_content_filtered, guid, menu_order, post_type, post_mime_type, post_parent, comment_count)
+     VALUES (1, ?, ?, '', ?, '', 'inherit', 'closed', 'closed', ?, '', '', ?, ?, '', ?, 0, 'attachment', 'image/jpeg', 0, 0)`,
+    [now, now, title, slug, now, now, `${BASE_URL}/wp-content/uploads/${slug}.jpg`]
   ) as any;
   return result.insertId;
 }
@@ -266,5 +277,58 @@ test.describe('Exclusion Filters (@tracking-exclusions)', () => {
 
     await adminPage.close();
     await adminCtx.close();
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Test 6: Attachment exclusion WITH cpt: prefix — should exclude
+  // REQ-EXCL-007 — @positive @priority-high
+  // Confirms GitHub issue #236 behavior
+  // ────────────────────────────────────────────────────────────────
+  test('Attachment excluded when ignore_content_types = cpt:attachment (#236)', async ({ browser }) => {
+    await setSlimstatSetting('ignore_content_types', 'cpt:attachment');
+
+    const slug = `e2e-attachment-excl-${Date.now()}`;
+    const attachmentId = await createAttachmentPost('E2E Attachment Exclusion Test', slug);
+    const attachmentUrl = `${BASE_URL}/?attachment_id=${attachmentId}`;
+
+    await clearStatsTable();
+
+    const anonCtx = await browser.newContext();
+    const anonPage = await anonCtx.newPage();
+    await anonPage.goto(attachmentUrl, { waitUntil: 'domcontentloaded' });
+
+    await expect.poll(
+      () => getStatCount(),
+      { timeout: 6_000, intervals: [500] }
+    ).toBe(0);
+
+    await anonPage.close();
+    await anonCtx.close();
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Test 7: Attachment without exclusion — should track
+  // REQ-EXCL-008 — @positive @priority-high
+  // ────────────────────────────────────────────────────────────────
+  test('Attachment tracked without exclusion, stat saved (#236)', async ({ browser }) => {
+    await setSlimstatSetting('ignore_content_types', '');
+
+    const slug = `e2e-attachment-track-${Date.now()}`;
+    const attachmentId = await createAttachmentPost('E2E Attachment Tracking Test', slug);
+    const attachmentUrl = `${BASE_URL}/?attachment_id=${attachmentId}`;
+
+    await clearStatsTable();
+
+    const anonCtx = await browser.newContext();
+    const anonPage = await anonCtx.newPage();
+    await anonPage.goto(attachmentUrl, { waitUntil: 'domcontentloaded' });
+
+    await expect.poll(
+      () => getStatCount(),
+      { timeout: 10_000, intervals: [500] }
+    ).toBeGreaterThan(0);
+
+    await anonPage.close();
+    await anonCtx.close();
   });
 });

--- a/tests/e2e/exclusion-filters.spec.ts
+++ b/tests/e2e/exclusion-filters.spec.ts
@@ -323,10 +323,12 @@ test.describe('Exclusion Filters (@tracking-exclusions)', () => {
     const anonPage = await anonCtx.newPage();
     await anonPage.goto(attachmentUrl, { waitUntil: 'domcontentloaded' });
 
+    // Attachment pageviews are stored against the resolved attachment permalink,
+    // so poll the slug-specific row rather than the global stat count.
     await expect.poll(
-      () => getStatCount(),
+      async () => (await getRecentStatByResource(slug))?.content_type ?? null,
       { timeout: 10_000, intervals: [500] }
-    ).toBeGreaterThan(0);
+    ).toBe('cpt:attachment');
 
     await anonPage.close();
     await anonCtx.close();


### PR DESCRIPTION
## Summary
- store attachment page views as `cpt:attachment` in both tracker content-info paths
- add standalone regression coverage for attachment content type and blacklist matching
- extend the exclusion E2E spec with attachment exclusion and tracking scenarios

## Testing
- `php tests/content-type-attachment-test.php`
- `composer test:all`
- `npx playwright test tests/e2e/exclusion-filters.spec.ts -g "Attachment .*#236"`

## Notes
- local `@tracking-exclusions` runs still show the older `#233` case failing in this environment
- the Local site normally loads `wp-slimstat/wp-slimstat.php`, so I temporarily activated this worktree plugin for live attachment verification and then restored the original active plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attachment pages are now consistently identified as cpt:attachment.

* **New Features**
  * You can exclude attachment pages from tracking using the cpt:attachment content-type exclusion.

* **Tests**
  * Added unit and E2E tests for attachment content-type behavior.
  * Added a composer test script to run the new attachment test.

* **Documentation**
  * Admin UI help text updated to show cpt:attachment in examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->