### PR TITLE
fix(tracking): require response-backed transport for initial pageview ID

### DIFF
--- a/wp-slimstat.js
+++ b/wp-slimstat.js
@@ -405,7 +405,21 @@ var SlimStat = (function () {
             var url = endpoints[method];
             if (!url) return trySend(i + 1);
             if (useBeacon && navigator.sendBeacon && i === 0) {
-                // Beacon is fire-and-forget; we assume success for queue processing
+                // Never use fire-and-forget transport when we still need a tracking ID
+                // from the first successful response. Beacon only tells us payload was queued,
+                // not that the server accepted it; treating that as success can create a silent
+                // failure in cached/proxied environments.
+                if (requiresIdResponse) {
+                    return sendXHR(
+                        url,
+                        function () {
+                            trySend(i + 1);
+                        },
+                        { useNonce: params.is_logged_in === "1" }
+                    );
+                }
+
+                // For non-ID updates (follow-up events), beacon is acceptable best-effort.
                 var ok = navigator.sendBeacon(url, payload);
                 if (ok) {
                     callback(true);


### PR DESCRIPTION
## Summary
Fixes a silent failure path in client-side tracking fallback flow where the first tracking request could use `sendBeacon` and be treated as success without confirming a server-issued tracking ID.

In cached/proxied environments (e.g. Cloudflare + page cache), this can leave `SlimStatParams.id` unset while queue processing proceeds, causing unreliable real-time updates and missing follow-up tracking events.

## Root cause
In `processQueueItem()` (`wp-slimstat.js`), when `useBeacon` was enabled and transport index was first in order:
- `navigator.sendBeacon()` returning `true` immediately called `callback(true)`
- For the **initial pageview** path (`requiresIdResponse === true`), this bypassed any response parsing and ID assignment
- Queue considered request successful even though no validated ID was available

## Fix
For initial pageview requests (`requiresIdResponse === true`):
- Skip fire-and-forget beacon path
- Force XHR transport for the selected endpoint to obtain and validate response ID
- Keep existing fallback chain behavior on failure

For non-initial updates (ID already available):
- Preserve existing beacon best-effort behavior

## Files changed
- `wp-slimstat.js`

## Why this is safe
- Narrow, conditional change scoped to first-hit ID acquisition
- No behavior change for normal follow-up event beacons
- Maintains existing nonce and fallback logic

## Issue
Fixes #259


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transmission reliability for events that require an ID from the server: the client now ensures an ID-response is obtained via a reliable request path and correctly falls back to subsequent attempts when needed.
  * Preserved best-effort use of beacon-style sends for non-ID cases while ensuring failover progresses when beacon delivery is not confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->