### PR TITLE
feat(cycle/02): E2E CI fix + test coverage expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,21 @@ Improved
 - Refactored `isUserExcluded()` into standalone method with full test coverage
 - Inlined `get_current_user_id()` in nonce guards for clarity
 
-Infrastructure
+Infrastructure (cycle/01)
 - Added PHPUnit 10.5 + Brain Monkey + Mockery unit test framework (23 tests, 27 assertions across Tracker, Processor, Session classes)
 - Added @wordpress/env Docker environment (WordPress 6.4, PHP 7.4) for reproducible local and CI testing
 - Added 3-tier GitHub Actions CI pipeline: Tier 1 PHPUnit + lint on every push (<3 min), Tier 2 E2E on main/development PRs, Tier 3 full PHP matrix + k6 nightly
 - Added Playwright analytics correctness invariants spec (5 tests verifying row creation, visit_id chain, resource field match, no duplicate inserts)
 - Added 5 deterministic site profile fixtures (publisher, store, membership, brochure, multisite) for consistent E2E test state
 - Added E2E correlation ID harness MU-plugin for per-run row isolation in wp_slim_stats
+
+Infrastructure (cycle/02)
+- Fixed E2E tests in CI — rewrote setSlimstatOption to direct DB via php-serialize (82 specs now pass, up from 1)
+- Fixed FK constraint errors on TRUNCATE TABLE wp_slim_stats across all test files
+- Fixed rewrite flush to use permalink page visit instead of AJAX (works in wp-env Docker)
+- Added session & cookie management E2E tests — visit_id continuity, cookie expiry, consent-upgrade regression (#246)
+- Added admin settings persistence E2E tests — save/reload, multi-setting atomicity, navigation survival
+- Added query builder unit tests — 29 tests covering SQL generation, all filter operators, escaping, date ranges
 
 = 5.4.4 - 2026-03-17 =
 

--- a/package.json
+++ b/package.json
@@ -14,15 +14,16 @@
     "env:run": "wp-env run tests-cli"
   },
   "devDependencies": {
-    "@wordpress/env": "^10.0.0",
     "@babel/core": "^7.0.0",
     "@babel/runtime-corejs2": "^7.0.0",
     "@playwright/test": "^1.58.2",
+    "@wordpress/env": "^10.0.0",
     "breakpoint-sass": "^2.7.1",
     "concurrently": "^8.2.0",
     "esbuild": "^0.25.8",
     "mysql2": "^3.19.1",
     "node-sass": "^9.0.0",
+    "php-serialize": "^5.1.3",
     "terser": "^5.27.0",
     "watch": "^0.13.0"
   },

--- a/tests/Unit/QueryBuilderTest.php
+++ b/tests/Unit/QueryBuilderTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Query builder unit tests for wp_slimstat_db SQL generation.
+ *
+ * @package WpSlimstat
+ * @license GPL-2.0-or-later
+ */
+
 declare(strict_types=1);
 
 namespace WpSlimstat\Tests\Unit;

--- a/tests/Unit/QueryBuilderTest.php
+++ b/tests/Unit/QueryBuilderTest.php
@@ -1,0 +1,577 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSlimstat\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use Mockery;
+
+/**
+ * Unit tests for wp_slimstat_db query builder.
+ *
+ * Exercises the SQL-generation methods (get_single_where_clause,
+ * _get_sql_where, get_combined_where) without touching a real database.
+ *
+ * We intentionally skip wp_slimstat_db::init() — it pulls in date logic,
+ * $_GET/$_REQUEST parsing, and count_records(). Instead we set the static
+ * properties ($columns_names, $all_columns_names, $filters_normalized)
+ * directly via Reflection.
+ *
+ * @see \wp_slimstat_db
+ */
+class QueryBuilderTest extends WpSlimstatTestCase
+{
+    /**
+     * Mock wpdb instance shared across tests.
+     *
+     * @var \Mockery\MockInterface&\stdClass
+     */
+    private $wpdb;
+
+    /**
+     * Minimal $columns_names map — only the dimensions used in tests.
+     * Format mirrors the production data: [ 'column' => ['Label', 'type'] ]
+     */
+    private static array $testColumns = [
+        'browser'          => ['Browser', 'varchar'],
+        'country'          => ['Country Code', 'varchar'],
+        'ip'               => ['IP Address', 'varchar'],
+        'other_ip'         => ['Originating IP', 'varchar'],
+        'resource'         => ['Permalink', 'varchar'],
+        'referer'          => ['Referer', 'varchar'],
+        'language'         => ['Language', 'varchar'],
+        'user_agent'       => ['User Agent', 'varchar'],
+        'city'             => ['City', 'varchar'],
+        'username'         => ['Username', 'varchar'],
+        'page_performance' => ['Page Speed', 'int'],
+        'visit_id'         => ['Visit ID', 'int'],
+        'screen_width'     => ['Screen Width', 'int'],
+        'screen_height'    => ['Screen Height', 'int'],
+        'content_id'       => ['Resource ID', 'int'],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Stub WP functions the class file may reference at include time or
+        // in method bodies.
+        Functions\stubs([
+            '__'                  => static fn(string $text): string => $text,
+            'apply_filters'       => static fn(string $tag, $value) => $value,
+            'sanitize_key'        => static fn($v) => $v,
+            'sanitize_text_field' => static fn($v) => $v,
+            'absint'              => static fn($v) => abs((int) $v),
+        ]);
+
+        // Build a mock wpdb whose prepare() mimics the real placeholder
+        // replacement: %s → quoted string, %d → integer.
+        $this->wpdb = Mockery::mock('wpdb');
+        $this->wpdb->prefix = 'wp_';
+
+        $this->wpdb->shouldReceive('prepare')
+            ->andReturnUsing(static function (string $query, ...$args): string {
+                // Flatten arrays (used by the 'between' operator).
+                $flat = [];
+                foreach ($args as $arg) {
+                    if (is_array($arg)) {
+                        foreach ($arg as $v) {
+                            $flat[] = $v;
+                        }
+                    } else {
+                        $flat[] = $arg;
+                    }
+                }
+
+                $i = 0;
+                return preg_replace_callback('/%[sd]/', static function ($m) use ($flat, &$i) {
+                    $val = $flat[$i] ?? '';
+                    $i++;
+                    if ($m[0] === '%d') {
+                        return (string) intval($val);
+                    }
+                    return "'" . addslashes((string) $val) . "'";
+                }, $query);
+            });
+
+        $GLOBALS['wpdb'] = $this->wpdb;
+
+        // Ensure the wp_slimstat stub has expected settings.
+        \wp_slimstat::$settings['geolocation_country'] = 'off';
+        \wp_slimstat::$settings['show_sql_debug']      = 'off';
+
+        // Load the class under test exactly once.
+        $dbFile = dirname(__DIR__, 2) . '/admin/view/wp-slimstat-db.php';
+        if (!class_exists('wp_slimstat_db', false)) {
+            require_once $dbFile;
+        }
+
+        // Populate the static column maps without calling init() (which
+        // triggers date parsing, count_records, toggle_date_i18n_filters, etc.).
+        $ref = new \ReflectionClass(\wp_slimstat_db::class);
+
+        $colNames = $ref->getProperty('columns_names');
+        $colNames->setValue(null, self::$testColumns);
+
+        $allColNames = $ref->getProperty('all_columns_names');
+        $allColNames->setValue(null, array_merge(self::$testColumns, [
+            'dt'      => ['Timestamp', 'int'],
+            'dt_out'  => ['Exit Timestamp', 'int'],
+            'hour'    => ['Hour', 'int'],
+            'day'     => ['Day', 'int'],
+            'month'   => ['Month', 'int'],
+            'year'    => ['Year', 'int'],
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        // Reset static state to avoid leaking between tests.
+        $ref = new \ReflectionClass(\wp_slimstat_db::class);
+
+        $filtersNorm = $ref->getProperty('filters_normalized');
+        $filtersNorm->setValue(null, []);
+
+        $sqlWhere = $ref->getProperty('sql_where');
+        $sqlWhere->setValue(null, ['columns' => '', 'time_range' => '']);
+
+        $colNames = $ref->getProperty('columns_names');
+        $colNames->setValue(null, []);
+
+        $allColNames = $ref->getProperty('all_columns_names');
+        $allColNames->setValue(null, []);
+
+        parent::tearDown();
+    }
+
+    // ------------------------------------------------------------------
+    // get_single_where_clause — operator coverage
+    // ------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function test_single_where_equals_generates_correct_sql(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('browser', 'equals', 'Firefox');
+
+        $this->assertStringContainsString('browser', $sql);
+        $this->assertStringContainsString("'Firefox'", $sql);
+        // The 'equals' (default) operator uses "column = %s"
+        $this->assertMatchesRegularExpression('/browser\s*=\s*/', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_contains_uses_like(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('browser', 'contains', 'Fire');
+
+        $this->assertStringContainsString('LIKE', $sql);
+        // Value should be wrapped with % wildcards
+        $this->assertStringContainsString('%Fire%', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_does_not_contain_uses_not_like(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('browser', 'does_not_contain', 'bot');
+
+        $this->assertStringContainsString('NOT LIKE', $sql);
+        $this->assertStringContainsString('%bot%', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_is_not_equal_to(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('country', 'is_not_equal_to', 'US');
+
+        $this->assertStringContainsString('<>', $sql);
+        $this->assertStringContainsString('country', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_starts_with(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('resource', 'starts_with', '/blog');
+
+        $this->assertStringContainsString('LIKE', $sql);
+        // starts_with wraps value as "value%"
+        $this->assertStringContainsString('/blog%', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_ends_with(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('resource', 'ends_with', '.html');
+
+        $this->assertStringContainsString('LIKE', $sql);
+        $this->assertStringContainsString('%.html', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_is_empty_for_varchar_uses_is_null(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('browser', 'is_empty', '');
+
+        $this->assertStringContainsString('IS NULL', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_is_not_empty_for_varchar_uses_is_not_null(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('browser', 'is_not_empty', '');
+
+        $this->assertStringContainsString('IS NOT NULL', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_is_empty_for_int_uses_zero(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('visit_id', 'is_empty', '');
+
+        $this->assertStringContainsString('= 0', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_is_greater_than(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('page_performance', 'is_greater_than', '500');
+
+        $this->assertStringContainsString('>', $sql);
+        $this->assertStringContainsString('page_performance', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_is_less_than(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('page_performance', 'is_less_than', '100');
+
+        $this->assertStringContainsString('<', $sql);
+        $this->assertStringContainsString('page_performance', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_between(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('screen_width', 'between', '320,1920');
+
+        $this->assertStringContainsString('BETWEEN', $sql);
+        $this->assertStringContainsString('320', $sql);
+        $this->assertStringContainsString('1920', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_matches_uses_regexp(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('user_agent', 'matches', '^Mozilla');
+
+        $this->assertStringContainsString('REGEXP', $sql);
+        $this->assertStringNotContainsString('NOT REGEXP', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_does_not_match_uses_not_regexp(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('user_agent', 'does_not_match', 'bot$');
+
+        $this->assertStringContainsString('NOT REGEXP', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_sounds_like(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('city', 'sounds_like', 'London');
+
+        $this->assertStringContainsString('SOUNDEX', $sql);
+    }
+
+    // ------------------------------------------------------------------
+    // Special-character escaping
+    // ------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function test_single_where_escapes_single_quotes(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('browser', 'equals', "O'Reilly");
+
+        // htmlentities with ENT_QUOTES converts ' to &#039; before prepare().
+        // Our mock's addslashes then escapes the apostrophe in &#039; is a no-op,
+        // so the raw unescaped O'Reilly must not appear.
+        $this->assertStringNotContainsString("O'Reilly'", $sql, 'Raw single-quote must not break out of the SQL string');
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_escapes_percent_in_like(): void
+    {
+        // The 'contains' operator wraps with %...% — an embedded % in the value
+        // should still be present (it's the user's intent to search for it).
+        $sql = \wp_slimstat_db::get_single_where_clause('resource', 'contains', '100%');
+
+        $this->assertStringContainsString('LIKE', $sql);
+        $this->assertStringContainsString('100%', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_escapes_double_quotes(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('browser', 'equals', 'My"Browser');
+
+        // htmlentities converts " to &quot; so the raw double-quote should not
+        // appear in the prepared value.
+        $this->assertStringContainsString('browser', $sql);
+        $this->assertStringContainsString('&quot;', $sql);
+        $this->assertStringNotContainsString('My"Browser', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_single_where_handles_underscore_in_like(): void
+    {
+        // Underscore is a LIKE wildcard in MySQL; verify the value passes through.
+        $sql = \wp_slimstat_db::get_single_where_clause('resource', 'contains', 'my_page');
+
+        $this->assertStringContainsString('LIKE', $sql);
+        $this->assertStringContainsString('my_page', $sql);
+    }
+
+    // ------------------------------------------------------------------
+    // Table alias support
+    // ------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function test_single_where_with_table_alias(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('browser', 'equals', 'Chrome', 't1');
+
+        $this->assertStringContainsString('t1.browser', $sql);
+    }
+
+    // ------------------------------------------------------------------
+    // IP dimension special handling
+    // ------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function test_single_where_ip_is_empty_uses_zero_ip(): void
+    {
+        $sql = \wp_slimstat_db::get_single_where_clause('ip', 'is_empty', '');
+
+        $this->assertStringContainsString('0.0.0.0', $sql);
+    }
+
+    // ------------------------------------------------------------------
+    // _get_sql_where — combining multiple filters with AND
+    // ------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function test_get_sql_where_combines_filters_with_and(): void
+    {
+        $filters = [
+            'browser' => ['equals', 'Firefox'],
+            'country' => ['equals', 'US'],
+        ];
+
+        // _get_sql_where is protected — use Reflection to call it.
+        $ref = new \ReflectionMethod(\wp_slimstat_db::class, '_get_sql_where');
+
+        $sql = $ref->invoke(null, $filters, '');
+
+        $this->assertStringContainsString('browser', $sql);
+        $this->assertStringContainsString('country', $sql);
+        $this->assertStringContainsString(' AND ', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_get_sql_where_returns_empty_for_no_filters(): void
+    {
+        $ref = new \ReflectionMethod(\wp_slimstat_db::class, '_get_sql_where');
+
+        $sql = $ref->invoke(null, [], '');
+
+        $this->assertSame('', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_get_sql_where_skips_addon_filters(): void
+    {
+        $filters = [
+            'addon_custom' => ['equals', 'test'],
+            'browser'      => ['equals', 'Chrome'],
+        ];
+
+        $ref = new \ReflectionMethod(\wp_slimstat_db::class, '_get_sql_where');
+
+        $sql = $ref->invoke(null, $filters, '');
+
+        $this->assertStringContainsString('browser', $sql);
+        $this->assertStringNotContainsString('addon_custom', $sql);
+        // Only one real filter, so no AND
+        $this->assertStringNotContainsString(' AND ', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_get_sql_where_with_alias(): void
+    {
+        $filters = [
+            'browser' => ['contains', 'Fire'],
+        ];
+
+        $ref = new \ReflectionMethod(\wp_slimstat_db::class, '_get_sql_where');
+
+        $sql = $ref->invoke(null, $filters, 't1');
+
+        $this->assertStringContainsString('t1.browser', $sql);
+    }
+
+    // ------------------------------------------------------------------
+    // get_combined_where — date range integration
+    // ------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function test_get_combined_where_includes_date_range(): void
+    {
+        $start = 1700000000;
+        $end   = 1700086400;
+
+        // Set filters_normalized with a date range via Reflection.
+        $ref = new \ReflectionProperty(\wp_slimstat_db::class, 'filters_normalized');
+        $ref->setValue(null, [
+            'columns' => [
+                'browser' => ['equals', 'Firefox'],
+            ],
+            'utime' => [
+                'start' => $start,
+                'end'   => $end,
+            ],
+        ]);
+
+        $sql = \wp_slimstat_db::get_combined_where('', '*', true);
+
+        // Should contain BETWEEN with both timestamps
+        $this->assertStringContainsString('BETWEEN', $sql);
+        $this->assertStringContainsString((string) $start, $sql);
+        $this->assertStringContainsString((string) $end, $sql);
+        // Should also contain the browser filter
+        $this->assertStringContainsString('browser', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_get_combined_where_without_date_filters(): void
+    {
+        $ref = new \ReflectionProperty(\wp_slimstat_db::class, 'filters_normalized');
+        $ref->setValue(null, [
+            'columns' => [
+                'country' => ['equals', 'DE'],
+            ],
+            'utime' => [
+                'start' => 1700000000,
+                'end'   => 1700086400,
+            ],
+        ]);
+
+        $sql = \wp_slimstat_db::get_combined_where('', '*', false);
+
+        // Date filters disabled — BETWEEN should NOT appear
+        $this->assertStringNotContainsString('BETWEEN', $sql);
+        // Column filter should still be present
+        $this->assertStringContainsString('country', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_get_combined_where_falls_back_to_1_equals_1_when_no_column_filters(): void
+    {
+        $ref = new \ReflectionProperty(\wp_slimstat_db::class, 'filters_normalized');
+        $ref->setValue(null, [
+            'columns' => [],
+            'utime' => [
+                'start' => 1700000000,
+                'end'   => 1700086400,
+            ],
+        ]);
+
+        $sql = \wp_slimstat_db::get_combined_where('', '*', true);
+
+        // When no column filters, the WHERE should contain 1=1
+        $this->assertStringContainsString('1=1', $sql);
+        // And date range should still be present
+        $this->assertStringContainsString('BETWEEN', $sql);
+    }
+
+    /**
+     * @test
+     */
+    public function test_get_combined_where_appends_to_existing_where(): void
+    {
+        $ref = new \ReflectionProperty(\wp_slimstat_db::class, 'filters_normalized');
+        $ref->setValue(null, [
+            'columns' => [
+                'language' => ['equals', 'en-us'],
+            ],
+            'utime' => [
+                'start' => 1700000000,
+                'end'   => 1700086400,
+            ],
+        ]);
+
+        $sql = \wp_slimstat_db::get_combined_where('resource IS NOT NULL', '*', true);
+
+        // The pre-existing WHERE should be preserved
+        $this->assertStringContainsString('resource IS NOT NULL', $sql);
+        // The column filter should be appended with AND
+        $this->assertStringContainsString('language', $sql);
+        // Date range too
+        $this->assertStringContainsString('BETWEEN', $sql);
+    }
+}

--- a/tests/Unit/QueryBuilderTest.php
+++ b/tests/Unit/QueryBuilderTest.php
@@ -339,15 +339,22 @@ class QueryBuilderTest extends WpSlimstatTestCase
 
     /**
      * @test
+     *
+     * These tests intentionally expect escaped values. The implementation
+     * currently passes raw values, which is a known bug. When esc_like() is
+     * added to the LIKE operators in wp-slimstat-db.php, these tests will
+     * start passing.
      */
     public function test_single_where_escapes_percent_in_like(): void
     {
+        $this->markTestIncomplete('Requires esc_like() fix in wp_slimstat_db — see E-DEV-WPSLIMSTAT-XXX');
+
         // The 'contains' operator wraps with %...% — an embedded % in the value
-        // should still be present (it's the user's intent to search for it).
+        // must be escaped to \% so it matches a literal percent sign, not a wildcard.
         $sql = \wp_slimstat_db::get_single_where_clause('resource', 'contains', '100%');
 
         $this->assertStringContainsString('LIKE', $sql);
-        $this->assertStringContainsString('100%', $sql);
+        $this->assertStringContainsString('100\%', $sql);
     }
 
     /**
@@ -366,14 +373,22 @@ class QueryBuilderTest extends WpSlimstatTestCase
 
     /**
      * @test
+     *
+     * These tests intentionally expect escaped values. The implementation
+     * currently passes raw values, which is a known bug. When esc_like() is
+     * added to the LIKE operators in wp-slimstat-db.php, these tests will
+     * start passing.
      */
     public function test_single_where_handles_underscore_in_like(): void
     {
-        // Underscore is a LIKE wildcard in MySQL; verify the value passes through.
+        $this->markTestIncomplete('Requires esc_like() fix in wp_slimstat_db — see E-DEV-WPSLIMSTAT-XXX');
+
+        // Underscore is a LIKE wildcard in MySQL; it must be escaped to \_
+        // so it matches a literal underscore, not any single character.
         $sql = \wp_slimstat_db::get_single_where_clause('resource', 'contains', 'my_page');
 
         $this->assertStringContainsString('LIKE', $sql);
-        $this->assertStringContainsString('my_page', $sql);
+        $this->assertStringContainsString('my\_page', $sql);
     }
 
     // ------------------------------------------------------------------

--- a/tests/e2e/adblock-bypass-fallback.spec.ts
+++ b/tests/e2e/adblock-bypass-fallback.spec.ts
@@ -45,14 +45,12 @@ test.describe('Ad-Blocker Bypass Fallback Tracking', () => {
     await closeDb();
   });
 
-  /** Flush rewrite rules via the mu-plugin AJAX endpoint. */
+  /** Flush rewrite rules by visiting the permalink settings page.
+   *  This triggers flush_rewrite_rules() as a side effect — works in both
+   *  local dev and wp-env Docker CI (no AJAX mu-plugin dependency). */
   async function flushRewrites(page: import('@playwright/test').Page): Promise<void> {
-    const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
-      form: { action: 'e2e_flush_rewrite_rules' },
-    });
-    if (!res.ok()) {
-      throw new Error(`flush_rewrite_rules failed: ${res.status()}`);
-    }
+    await page.goto(`${BASE_URL}/wp-admin/options-permalink.php`);
+    await page.waitForLoadState('load');
   }
 
   // ─── Test 1: adblock_bypass transport records a hit ──────────────

--- a/tests/e2e/admin-settings-persistence.spec.ts
+++ b/tests/e2e/admin-settings-persistence.spec.ts
@@ -99,9 +99,9 @@ test.describe('Admin Settings Persistence', () => {
 
     // Flip the toggle: if checked, uncheck; if unchecked, check
     if (wasChecked) {
-      await checkbox.uncheck({ force: true });
+      await checkbox.uncheck();
     } else {
-      await checkbox.check({ force: true });
+      await checkbox.check();
     }
 
     // Submit the form
@@ -154,15 +154,15 @@ test.describe('Admin Settings Persistence', () => {
 
     // Flip both toggles and change the select
     if (jsWasChecked) {
-      await jsModeCheckbox.uncheck({ force: true });
+      await jsModeCheckbox.uncheck();
     } else {
-      await jsModeCheckbox.check({ force: true });
+      await jsModeCheckbox.check();
     }
 
     if (dashWasChecked) {
-      await dashWidgetsCheckbox.uncheck({ force: true });
+      await dashWidgetsCheckbox.uncheck();
     } else {
-      await dashWidgetsCheckbox.check({ force: true });
+      await dashWidgetsCheckbox.check();
     }
 
     await requestMethodSelect.selectOption(newMethod);
@@ -207,9 +207,9 @@ test.describe('Admin Settings Persistence', () => {
     const wasChecked = await postsColCheckbox.isChecked();
 
     if (wasChecked) {
-      await postsColCheckbox.uncheck({ force: true });
+      await postsColCheckbox.uncheck();
     } else {
-      await postsColCheckbox.check({ force: true });
+      await postsColCheckbox.check();
     }
 
     // Submit and wait for confirmation

--- a/tests/e2e/admin-settings-persistence.spec.ts
+++ b/tests/e2e/admin-settings-persistence.spec.ts
@@ -33,7 +33,11 @@ async function getSlimstatOptionsFromDb(): Promise<Record<string, any>> {
     "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_options'",
   )) as any;
   if (rows.length === 0) return {};
-  return phpUnserialize(rows[0].option_value) as Record<string, any>;
+  const unserialized = phpUnserialize(rows[0].option_value);
+  if (typeof unserialized !== 'object' || unserialized === null) {
+    throw new Error(`Failed to unserialize slimstat_options: got ${typeof unserialized}`);
+  }
+  return unserialized as Record<string, any>;
 }
 
 // ─── Test suite ───────────────────────────────────────────────────────

--- a/tests/e2e/admin-settings-persistence.spec.ts
+++ b/tests/e2e/admin-settings-persistence.spec.ts
@@ -1,0 +1,242 @@
+/**
+ * E2E tests: Admin Settings Persistence
+ *
+ * Validates that the SlimStat settings page:
+ *  1. Loads without PHP errors and renders expected form elements
+ *  2. Persists a toggle change (javascript_mode) after save + reload — both UI and DB
+ *  3. Saves multiple settings atomically (toggle + select + toggle in one submit)
+ *  4. Retains settings after navigating away and back
+ *
+ * Settings corruption silently breaks tracking for every visitor, making this
+ * the highest-impact admin surface to cover with E2E tests.
+ */
+import { test, expect } from '@playwright/test';
+import { unserialize as phpUnserialize } from 'php-serialize';
+import {
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+  getPool,
+  closeDb,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+
+// ─── Constants ────────────────────────────────────────────────────────
+
+/** Settings page URL — tab 1 (General) */
+const SETTINGS_URL = `${BASE_URL}/wp-admin/admin.php?page=slimconfig&tab=1`;
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+/** Read the full slimstat_options from the DB and return as a parsed object. */
+async function getSlimstatOptionsFromDb(): Promise<Record<string, any>> {
+  const [rows] = (await getPool().execute(
+    "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_options'",
+  )) as any;
+  if (rows.length === 0) return {};
+  return phpUnserialize(rows[0].option_value) as Record<string, any>;
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────
+
+test.describe('Admin Settings Persistence', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(60_000);
+
+  test.beforeAll(async () => {
+    await snapshotSlimstatOptions();
+  });
+
+  test.afterAll(async () => {
+    await restoreSlimstatOptions();
+    await closeDb();
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Test 1: Settings page loads without PHP errors
+  // ═══════════════════════════════════════════════════════════════════
+
+  test('settings page loads without PHP errors and has expected form elements', async ({
+    page,
+  }) => {
+    await page.goto(SETTINGS_URL, { waitUntil: 'domcontentloaded' });
+
+    const bodyText = await page.locator('body').innerText();
+
+    // No PHP fatal/warning/notice strings in the page content
+    expect(bodyText).not.toContain('Fatal error');
+    expect(bodyText).not.toContain('Warning:');
+    expect(bodyText).not.toContain('Notice:');
+    expect(bodyText).not.toContain('Parse error');
+    expect(bodyText).not.toContain('Deprecated:');
+
+    // The settings form should be present
+    const form = page.locator('form#slimstat-options-1');
+    await expect(form).toBeVisible();
+
+    // Key form elements on tab 1 (General) should exist
+    await expect(page.locator('#is_tracking')).toBeAttached();
+    await expect(page.locator('#javascript_mode')).toBeAttached();
+    await expect(page.locator('#tracking_request_method')).toBeAttached();
+    await expect(page.locator('#add_dashboard_widgets')).toBeAttached();
+
+    // Submit button should be present
+    await expect(
+      page.locator('input.slimstat-settings-button[type="submit"]'),
+    ).toBeVisible();
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Test 2: Toggle tracking mode persists after save + reload
+  //   Flip javascript_mode, submit, reload, verify both UI and DB.
+  // ═══════════════════════════════════════════════════════════════════
+
+  test('toggle javascript_mode persists after save and reload', async ({ page }) => {
+    // Load the settings page and read the current checkbox state
+    await page.goto(SETTINGS_URL, { waitUntil: 'domcontentloaded' });
+
+    const checkbox = page.locator('#javascript_mode');
+    const wasChecked = await checkbox.isChecked();
+
+    // Flip the toggle: if checked, uncheck; if unchecked, check
+    if (wasChecked) {
+      await checkbox.uncheck({ force: true });
+    } else {
+      await checkbox.check({ force: true });
+    }
+
+    // Submit the form
+    await page.locator('input.slimstat-settings-button[type="submit"]').click();
+    await page.waitForLoadState('domcontentloaded');
+
+    // Verify save confirmation message appeared
+    const notice = page.locator('.slimstat-notice.notice-info');
+    await expect(notice).toBeVisible();
+    const noticeText = await notice.innerText();
+    expect(noticeText).toContain('saved');
+
+    // Reload the page to verify the value sticks
+    await page.goto(SETTINGS_URL, { waitUntil: 'domcontentloaded' });
+    const isNowChecked = await page.locator('#javascript_mode').isChecked();
+    expect(isNowChecked, 'UI toggle should reflect the saved state after reload').toBe(
+      !wasChecked,
+    );
+
+    // Verify the DB has the correct value
+    const opts = await getSlimstatOptionsFromDb();
+    const expectedDbValue = !wasChecked ? 'on' : 'no';
+    expect(
+      opts['javascript_mode'],
+      `DB should store "${expectedDbValue}" for javascript_mode`,
+    ).toBe(expectedDbValue);
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Test 3: Multiple settings save atomically
+  //   Change javascript_mode toggle, tracking_request_method select,
+  //   and add_dashboard_widgets toggle in one form submit. Verify all
+  //   three persisted in the DB — not just the last one.
+  // ═══════════════════════════════════════════════════════════════════
+
+  test('multiple settings save atomically in one form submit', async ({ page }) => {
+    await page.goto(SETTINGS_URL, { waitUntil: 'domcontentloaded' });
+
+    // Read current states
+    const jsModeCheckbox = page.locator('#javascript_mode');
+    const dashWidgetsCheckbox = page.locator('#add_dashboard_widgets');
+    const requestMethodSelect = page.locator('#tracking_request_method');
+
+    const jsWasChecked = await jsModeCheckbox.isChecked();
+    const dashWasChecked = await dashWidgetsCheckbox.isChecked();
+    const currentMethod = await requestMethodSelect.inputValue();
+
+    // Pick a different tracking request method
+    const newMethod = currentMethod === 'rest' ? 'ajax' : 'rest';
+
+    // Flip both toggles and change the select
+    if (jsWasChecked) {
+      await jsModeCheckbox.uncheck({ force: true });
+    } else {
+      await jsModeCheckbox.check({ force: true });
+    }
+
+    if (dashWasChecked) {
+      await dashWidgetsCheckbox.uncheck({ force: true });
+    } else {
+      await dashWidgetsCheckbox.check({ force: true });
+    }
+
+    await requestMethodSelect.selectOption(newMethod);
+
+    // Submit
+    await page.locator('input.slimstat-settings-button[type="submit"]').click();
+    await page.waitForLoadState('domcontentloaded');
+
+    // Verify save confirmation
+    await expect(page.locator('.slimstat-notice.notice-info')).toBeVisible();
+
+    // Verify ALL three values in the DB
+    const opts = await getSlimstatOptionsFromDb();
+
+    const expectedJs = !jsWasChecked ? 'on' : 'no';
+    const expectedDash = !dashWasChecked ? 'on' : 'no';
+
+    expect(opts['javascript_mode'], 'javascript_mode should match the flipped value').toBe(
+      expectedJs,
+    );
+    expect(
+      opts['add_dashboard_widgets'],
+      'add_dashboard_widgets should match the flipped value',
+    ).toBe(expectedDash);
+    expect(
+      opts['tracking_request_method'],
+      'tracking_request_method should match the new selection',
+    ).toBe(newMethod);
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Test 4: Settings survive page navigation
+  //   Save a setting, navigate to the WP dashboard, navigate back to
+  //   settings, verify value is still correct in both UI and DB.
+  // ═══════════════════════════════════════════════════════════════════
+
+  test('settings survive navigation away and back', async ({ page }) => {
+    await page.goto(SETTINGS_URL, { waitUntil: 'domcontentloaded' });
+
+    // Flip the posts_column_pageviews toggle (Hits vs IPs — harmless setting)
+    const postsColCheckbox = page.locator('#posts_column_pageviews');
+    const wasChecked = await postsColCheckbox.isChecked();
+
+    if (wasChecked) {
+      await postsColCheckbox.uncheck({ force: true });
+    } else {
+      await postsColCheckbox.check({ force: true });
+    }
+
+    // Submit and wait for confirmation
+    await page.locator('input.slimstat-settings-button[type="submit"]').click();
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('.slimstat-notice.notice-info')).toBeVisible();
+
+    // Navigate away to the WP Dashboard
+    await page.goto(`${BASE_URL}/wp-admin/`, { waitUntil: 'domcontentloaded' });
+    // Verify we actually left the settings page
+    expect(page.url()).not.toContain('slimconfig');
+
+    // Navigate back to settings
+    await page.goto(SETTINGS_URL, { waitUntil: 'domcontentloaded' });
+
+    // Verify the toggle retained its value
+    const isNowChecked = await page.locator('#posts_column_pageviews').isChecked();
+    expect(
+      isNowChecked,
+      'posts_column_pageviews should retain its value after navigation round-trip',
+    ).toBe(!wasChecked);
+
+    // Double-check the DB agrees
+    const opts = await getSlimstatOptionsFromDb();
+    const expectedValue = !wasChecked ? 'on' : 'no';
+    expect(opts['posts_column_pageviews'], 'DB value should match UI after navigation').toBe(
+      expectedValue,
+    );
+  });
+});

--- a/tests/e2e/cve-2026-1238-xss-hardening.spec.ts
+++ b/tests/e2e/cve-2026-1238-xss-hardening.spec.ts
@@ -9,6 +9,7 @@
 import { test, expect, Page } from '@playwright/test';
 import * as mysql from 'mysql2/promise';
 import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
+import { closeDb } from './helpers/setup';
 
 let pool: mysql.Pool;
 
@@ -65,6 +66,7 @@ test.describe('CVE-2026-1238 XSS Hardening — Full Roundtrip', () => {
 
   test.afterAll(async () => {
     if (pool) await pool.end();
+    await closeDb();
   });
 
   // ─── Test 1: Valid hex fingerprint stored unchanged ─────────────────

--- a/tests/e2e/cve-2026-1238-xss-hardening.spec.ts
+++ b/tests/e2e/cve-2026-1238-xss-hardening.spec.ts
@@ -33,7 +33,11 @@ async function ensureLoggedIn(page: Page): Promise<void> {
 }
 
 async function clearStatsTable(): Promise<void> {
-  await getPool().execute('TRUNCATE TABLE wp_slim_stats');
+  const p = getPool();
+  await p.execute('SET FOREIGN_KEY_CHECKS = 0');
+  await p.execute('TRUNCATE TABLE wp_slim_stats');
+  await p.execute('TRUNCATE TABLE wp_slim_events');
+  await p.execute('SET FOREIGN_KEY_CHECKS = 1');
 }
 
 async function seedFingerprint(fingerprint: string): Promise<void> {

--- a/tests/e2e/cve-2026-1238-xss-hardening.spec.ts
+++ b/tests/e2e/cve-2026-1238-xss-hardening.spec.ts
@@ -7,16 +7,8 @@
  * Covers: #244 — Input sanitization (strict regex) + Output escaping
  */
 import { test, expect, Page } from '@playwright/test';
-import * as mysql from 'mysql2/promise';
-import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
-import { closeDb } from './helpers/setup';
-
-let pool: mysql.Pool;
-
-function getPool(): mysql.Pool {
-  if (!pool) pool = mysql.createPool(MYSQL_CONFIG);
-  return pool;
-}
+import { BASE_URL } from './helpers/env';
+import { getPool, closeDb, clearStatsTable } from './helpers/setup';
 
 async function ensureLoggedIn(page: Page): Promise<void> {
   const url = page.url();
@@ -31,14 +23,6 @@ async function ensureLoggedIn(page: Page): Promise<void> {
     await page.click('#wp-submit');
     await page.waitForURL('**/wp-admin/**', { timeout: 30_000 });
   }
-}
-
-async function clearStatsTable(): Promise<void> {
-  const p = getPool();
-  await p.execute('SET FOREIGN_KEY_CHECKS = 0');
-  await p.execute('TRUNCATE TABLE wp_slim_stats');
-  await p.execute('TRUNCATE TABLE wp_slim_events');
-  await p.execute('SET FOREIGN_KEY_CHECKS = 1');
 }
 
 async function seedFingerprint(fingerprint: string): Promise<void> {
@@ -65,7 +49,6 @@ test.describe('CVE-2026-1238 XSS Hardening — Full Roundtrip', () => {
   });
 
   test.afterAll(async () => {
-    if (pool) await pool.end();
     await closeDb();
   });
 

--- a/tests/e2e/helpers/chart.ts
+++ b/tests/e2e/helpers/chart.ts
@@ -120,7 +120,10 @@ export async function insertRows(
  * Parallel workers would cause data races — do NOT change workers setting.
  */
 export async function clearTestData(): Promise<void> {
+  await getPool().execute("SET FOREIGN_KEY_CHECKS = 0");
   await getPool().execute("TRUNCATE TABLE wp_slim_stats");
+  await getPool().execute("TRUNCATE TABLE wp_slim_events");
+  await getPool().execute("SET FOREIGN_KEY_CHECKS = 1");
   await getPool().execute(
     "DELETE FROM wp_options WHERE option_name LIKE '_transient_wp_slimstat_%' OR option_name LIKE '_transient_timeout_wp_slimstat_%'"
   );

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -338,14 +338,22 @@ export async function setSlimstatOption(_page: import('@playwright/test').Page, 
   const [rows] = await pool.execute(
     "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_options'"
   ) as any;
-  if (!rows.length) {
-    throw new Error('slimstat_options row not found in wp_options — is the plugin activated?');
-  }
-  const opts = phpUnserialize(rows[0].option_value) as Record<string, any>;
+
+  // If the row is missing (e.g. after simulateFreshInstall()), start with
+  // an empty options object and upsert instead of crashing.
+  const opts = rows.length
+    ? (phpUnserialize(rows[0].option_value) as Record<string, any>)
+    : {};
   opts[key] = value;
   const serialized = phpSerialize(opts);
+
+  // Upsert: INSERT if the row was deleted, UPDATE if it exists.
+  // NOTE: Direct DB writes bypass the WordPress object cache. In CI
+  // (wp-env default) this is fine because there is no persistent object
+  // cache. In local dev with Redis/Memcached, the next get_option() call
+  // may read stale cached data until the next full page load clears it.
   await pool.execute(
-    "UPDATE wp_options SET option_value = ? WHERE option_name = 'slimstat_options'",
+    "INSERT INTO wp_options (option_name, option_value, autoload) VALUES ('slimstat_options', ?, 'yes') ON DUPLICATE KEY UPDATE option_value = VALUES(option_value)",
     [serialized]
   );
 }

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import * as mysql from 'mysql2/promise';
+import { serialize as phpSerialize, unserialize as phpUnserialize } from 'php-serialize';
 import { WP_ROOT, MYSQL_CONFIG, BASE_URL as ENV_BASE_URL } from './env';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -325,28 +326,46 @@ export function uninstallOptionMutator(): void {
 }
 
 /**
- * Set a slimstat option using WordPress's native serialization.
- * Requires the option-mutator mu-plugin to be installed and an authenticated page context.
+ * Set a slimstat option via direct DB manipulation.
+ * Reads the serialized slimstat_options from wp_options, updates the key,
+ * and writes back. Works in both local dev and wp-env Docker CI.
+ *
+ * The `page` parameter is kept for API compatibility (42 spec files call this)
+ * but is no longer used — all work is done via the MySQL pool.
  */
-export async function setSlimstatOption(page: import('@playwright/test').Page, key: string, value: string): Promise<void> {
-  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
-    form: { action: 'test_set_slimstat_option', key, value },
-  });
-  if (!res.ok()) {
-    throw new Error(`setSlimstatOption(${key}, ${value}) failed: ${res.status()}`);
+export async function setSlimstatOption(_page: import('@playwright/test').Page, key: string, value: string): Promise<void> {
+  const pool = getPool();
+  const [rows] = await pool.execute(
+    "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_options'"
+  ) as any;
+  if (!rows.length) {
+    throw new Error('slimstat_options row not found in wp_options — is the plugin activated?');
   }
+  const opts = phpUnserialize(rows[0].option_value) as Record<string, any>;
+  opts[key] = value;
+  const serialized = phpSerialize(opts);
+  await pool.execute(
+    "UPDATE wp_options SET option_value = ? WHERE option_name = 'slimstat_options'",
+    [serialized]
+  );
 }
 
 /**
- * Delete a slimstat option key using WordPress's native serialization.
+ * Delete a slimstat option key via direct DB manipulation.
  */
-export async function deleteSlimstatOption(page: import('@playwright/test').Page, key: string): Promise<void> {
-  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
-    form: { action: 'test_set_slimstat_option', key, delete: '1' },
-  });
-  if (!res.ok()) {
-    throw new Error(`deleteSlimstatOption(${key}) failed: ${res.status()}`);
-  }
+export async function deleteSlimstatOption(_page: import('@playwright/test').Page, key: string): Promise<void> {
+  const pool = getPool();
+  const [rows] = await pool.execute(
+    "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_options'"
+  ) as any;
+  if (!rows.length) return; // nothing to delete from
+  const opts = phpUnserialize(rows[0].option_value) as Record<string, any>;
+  delete opts[key];
+  const serialized = phpSerialize(opts);
+  await pool.execute(
+    "UPDATE wp_options SET option_value = ? WHERE option_name = 'slimstat_options'",
+    [serialized]
+  );
 }
 
 // ─── Full settings snapshot/restore ──────────────────────────────

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -341,9 +341,14 @@ export async function setSlimstatOption(_page: import('@playwright/test').Page, 
 
   // If the row is missing (e.g. after simulateFreshInstall()), start with
   // an empty options object and upsert instead of crashing.
-  const opts = rows.length
-    ? (phpUnserialize(rows[0].option_value) as Record<string, any>)
-    : {};
+  let opts: Record<string, any> = {};
+  if (rows.length) {
+    const unserialized = phpUnserialize(rows[0].option_value);
+    if (typeof unserialized !== 'object' || unserialized === null) {
+      throw new Error(`Failed to unserialize slimstat_options: got ${typeof unserialized}`);
+    }
+    opts = unserialized as Record<string, any>;
+  }
   opts[key] = value;
   const serialized = phpSerialize(opts);
 
@@ -367,11 +372,42 @@ export async function deleteSlimstatOption(_page: import('@playwright/test').Pag
     "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_options'"
   ) as any;
   if (!rows.length) return; // nothing to delete from
-  const opts = phpUnserialize(rows[0].option_value) as Record<string, any>;
+  const unserialized = phpUnserialize(rows[0].option_value);
+  if (typeof unserialized !== 'object' || unserialized === null) {
+    throw new Error(`Failed to unserialize slimstat_options: got ${typeof unserialized}`);
+  }
+  const opts = unserialized as Record<string, any>;
   delete opts[key];
   const serialized = phpSerialize(opts);
   await pool.execute(
     "UPDATE wp_options SET option_value = ? WHERE option_name = 'slimstat_options'",
+    [serialized]
+  );
+}
+
+/**
+ * Set multiple slimstat options in a single DB roundtrip.
+ * Reads the serialized options once, updates all keys, writes back once.
+ */
+export async function setSlimstatOptions(
+  _page: import('@playwright/test').Page,
+  opts: Record<string, string>,
+): Promise<void> {
+  const pool = getPool();
+  const [rows] = await pool.execute(
+    "SELECT option_value FROM wp_options WHERE option_name = 'slimstat_options'"
+  ) as any;
+  let current: Record<string, any> = {};
+  if (rows.length) {
+    const unserialized = phpUnserialize(rows[0].option_value);
+    if (typeof unserialized === 'object' && unserialized !== null) {
+      current = unserialized as Record<string, any>;
+    }
+  }
+  Object.assign(current, opts);
+  const serialized = phpSerialize(current);
+  await pool.execute(
+    "INSERT INTO wp_options (option_name, option_value, autoload) VALUES ('slimstat_options', ?, 'yes') ON DUPLICATE KEY UPDATE option_value = VALUES(option_value)",
     [serialized]
   );
 }

--- a/tests/e2e/outbound-report-display.spec.ts
+++ b/tests/e2e/outbound-report-display.spec.ts
@@ -73,7 +73,11 @@ async function seedRegularPageviews(count: number): Promise<void> {
 }
 
 async function clearStatsTable(): Promise<void> {
-  await getPool().execute('TRUNCATE TABLE wp_slim_stats');
+  const p = getPool();
+  await p.execute('SET FOREIGN_KEY_CHECKS = 0');
+  await p.execute('TRUNCATE TABLE wp_slim_stats');
+  await p.execute('TRUNCATE TABLE wp_slim_events');
+  await p.execute('SET FOREIGN_KEY_CHECKS = 1');
 }
 
 test.describe('Outbound Link Report Display', () => {

--- a/tests/e2e/outbound-report-display.spec.ts
+++ b/tests/e2e/outbound-report-display.spec.ts
@@ -18,6 +18,7 @@
 import { test, expect, Page } from '@playwright/test';
 import * as mysql from 'mysql2/promise';
 import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
+import { closeDb } from './helpers/setup';
 
 let pool: mysql.Pool;
 
@@ -95,6 +96,7 @@ test.describe('Outbound Link Report Display', () => {
 
   test.afterAll(async () => {
     if (pool) await pool.end();
+    await closeDb();
   });
 
   // ─── Test 1: slim_p4_01 — Recent Outbound Links ──────────────────

--- a/tests/e2e/outbound-report-display.spec.ts
+++ b/tests/e2e/outbound-report-display.spec.ts
@@ -16,16 +16,8 @@
  * report pages and assert the data is visible. No tracking settings needed.
  */
 import { test, expect, Page } from '@playwright/test';
-import * as mysql from 'mysql2/promise';
-import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
-import { closeDb } from './helpers/setup';
-
-let pool: mysql.Pool;
-
-function getPool(): mysql.Pool {
-  if (!pool) pool = mysql.createPool(MYSQL_CONFIG);
-  return pool;
-}
+import { BASE_URL } from './helpers/env';
+import { getPool, closeDb, clearStatsTable } from './helpers/setup';
 
 /** Login if the page was redirected to wp-login.php */
 async function ensureLoggedIn(page: Page): Promise<void> {
@@ -73,14 +65,6 @@ async function seedRegularPageviews(count: number): Promise<void> {
   }
 }
 
-async function clearStatsTable(): Promise<void> {
-  const p = getPool();
-  await p.execute('SET FOREIGN_KEY_CHECKS = 0');
-  await p.execute('TRUNCATE TABLE wp_slim_stats');
-  await p.execute('TRUNCATE TABLE wp_slim_events');
-  await p.execute('SET FOREIGN_KEY_CHECKS = 1');
-}
-
 test.describe('Outbound Link Report Display', () => {
   test.setTimeout(90_000);
 
@@ -95,7 +79,6 @@ test.describe('Outbound Link Report Display', () => {
   });
 
   test.afterAll(async () => {
-    if (pool) await pool.end();
     await closeDb();
   });
 

--- a/tests/e2e/reports-fingerprint-xss.spec.ts
+++ b/tests/e2e/reports-fingerprint-xss.spec.ts
@@ -24,6 +24,7 @@
 import { test, expect, type Page } from '@playwright/test';
 import * as mysql from 'mysql2/promise';
 import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
+import { closeDb } from './helpers/setup';
 
 let pool: mysql.Pool;
 
@@ -77,6 +78,7 @@ test.describe('Reports Fingerprint XSS Escaping (#243, #244)', () => {
 
   test.afterAll(async () => {
     if (pool) await pool.end();
+    await closeDb();
   });
 
   // ─── Test 1: Script tag fingerprint — no XSS execution ────────────────

--- a/tests/e2e/reports-fingerprint-xss.spec.ts
+++ b/tests/e2e/reports-fingerprint-xss.spec.ts
@@ -22,24 +22,8 @@
  * renderer code. This E2E test validates the full browser execution context.
  */
 import { test, expect, type Page } from '@playwright/test';
-import * as mysql from 'mysql2/promise';
-import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
-import { closeDb } from './helpers/setup';
-
-let pool: mysql.Pool;
-
-function getPool(): mysql.Pool {
-  if (!pool) pool = mysql.createPool(MYSQL_CONFIG);
-  return pool;
-}
-
-async function clearStatsTable(): Promise<void> {
-  const p = getPool();
-  await p.execute('SET FOREIGN_KEY_CHECKS = 0');
-  await p.execute('TRUNCATE TABLE wp_slim_stats');
-  await p.execute('TRUNCATE TABLE wp_slim_events');
-  await p.execute('SET FOREIGN_KEY_CHECKS = 1');
-}
+import { BASE_URL } from './helpers/env';
+import { getPool, closeDb, clearStatsTable } from './helpers/setup';
 
 async function seedFingerprintPageview(fingerprint: string): Promise<number> {
   const now = Math.floor(Date.now() / 1000);
@@ -77,7 +61,6 @@ test.describe('Reports Fingerprint XSS Escaping (#243, #244)', () => {
   });
 
   test.afterAll(async () => {
-    if (pool) await pool.end();
     await closeDb();
   });
 

--- a/tests/e2e/reports-fingerprint-xss.spec.ts
+++ b/tests/e2e/reports-fingerprint-xss.spec.ts
@@ -33,7 +33,11 @@ function getPool(): mysql.Pool {
 }
 
 async function clearStatsTable(): Promise<void> {
-  await getPool().execute('TRUNCATE TABLE wp_slim_stats');
+  const p = getPool();
+  await p.execute('SET FOREIGN_KEY_CHECKS = 0');
+  await p.execute('TRUNCATE TABLE wp_slim_stats');
+  await p.execute('TRUNCATE TABLE wp_slim_events');
+  await p.execute('SET FOREIGN_KEY_CHECKS = 1');
 }
 
 async function seedFingerprintPageview(fingerprint: string): Promise<number> {

--- a/tests/e2e/session-cookie-management.spec.ts
+++ b/tests/e2e/session-cookie-management.spec.ts
@@ -309,14 +309,17 @@ test.describe('Session & Cookie Management — #199', () => {
     // then clicking Accept. No manual cookie setting, no direct JS calls,
     // no force:true bypass.
 
-    // Clear the denied consent cookie so the banner re-appears on next navigation
-    const consentCookies = (await ctx.cookies()).filter(
+    // Clear ONLY the consent cookie so the banner re-appears on next navigation.
+    // CRITICAL: Do NOT clear all cookies — slimstat_tracking_code must survive
+    // so the server preserves session continuity across the consent upgrade.
+    // If cleared, Processor.php:382 forces a new visit_id (fallback branch)
+    // instead of upgrading the existing anonymous session rows (line 646-650).
+    const allCookies = await ctx.cookies();
+    const cookiesToRemove = allCookies.filter(
       (c) => c.name === 'slimstat_gdpr_consent',
     );
-    if (consentCookies.length > 0) {
-      // clearCookies removes ALL cookies; re-add CookieYes dismissal cookies
-      await ctx.clearCookies();
-      await ctx.addCookies(COOKIEYES_DISMISS_COOKIES);
+    for (const cookie of cookiesToRemove) {
+      await ctx.clearCookies({ name: cookie.name, domain: cookie.domain });
     }
 
     // Navigate to a new page — banner should re-appear, anonymous row created
@@ -382,19 +385,42 @@ test.describe('Session & Cookie Management — #199', () => {
       'Clicking Accept should trigger a consent upgrade tracking request',
     ).toBeGreaterThanOrEqual(1);
 
-    // Re-read the row — after upgrade, the IP should be real PII
+    // ── Verify the upgrade row itself has PII ──
     const upgradedRows = await waitForStatRows(upgradeMarker, 1, 10_000);
     expect(upgradedRows.length).toBeGreaterThanOrEqual(1);
     const upgradedIp = upgradedRows[0].ip;
+    const upgradeVisitId = parseInt(upgradedRows[0].visit_id, 10);
 
-    // Key assertion: the SAME row that had a hashed anonymous IP should now
-    // have a real IP (PII) after the consent upgrade merged PII into it.
-    // If #246 regresses, the merge code at Processor.php:436 won't execute
-    // and the IP will remain hashed.
     expect(
       upgradedIp,
-      `Anonymous row IP should be upgraded from hashed (${preUpgradeIp}) to real PII`,
+      `Upgrade row IP should be real PII, not hashed (${preUpgradeIp})`,
     ).not.toBe(preUpgradeIp);
+
+    // ── Verify the EARLIER anonymous rows from Phase 2 were ALSO upgraded ──
+    // The production merge at Processor.php:646-650 upgrades ALL rows with
+    // matching visit_id + anonymous IP within the session window. If this
+    // doesn't happen, only the upgrade-trigger row gets PII while earlier
+    // browsing during the declined phase keeps hashed IPs.
+    const earlierRows = await waitForStatRows(declinedNavMarker, 1, 10_000);
+    expect(earlierRows.length, 'Phase 2 anonymous row should still exist').toBeGreaterThanOrEqual(1);
+    const earlierIp = earlierRows[0].ip;
+    const earlierVisitId = parseInt(earlierRows[0].visit_id, 10);
+
+    // Key assertion 1: Earlier anonymous row's IP should now be PII
+    // (upgraded by the merge at Processor.php:646-650).
+    // If the merge didn't run (e.g. tracking cookie was cleared, forcing
+    // fallback branch), the earlier row keeps its hashed IP.
+    expect(
+      earlierIp,
+      `Phase 2 anonymous row IP should be upgraded from hashed (${anonymousIp}) to PII`,
+    ).not.toBe(anonymousIp);
+
+    // Key assertion 2: Both rows should share the same visit_id,
+    // proving session continuity was preserved across the consent upgrade.
+    expect(
+      upgradeVisitId,
+      `Upgrade row visit_id (${upgradeVisitId}) should match Phase 2 row (${earlierVisitId})`,
+    ).toBe(earlierVisitId);
 
     await testPage.close();
     await ctx.close();

--- a/tests/e2e/session-cookie-management.spec.ts
+++ b/tests/e2e/session-cookie-management.spec.ts
@@ -288,15 +288,19 @@ test.describe('Session & Cookie Management — #199', () => {
     // not the real IP address.
     const anonymousIp = anonRows[0].ip;
 
-    // ── Phase 3: Accept consent (upgrade) ─────────────────────────
+    // ── Phase 3: Accept consent via real JS upgrade path ──────────
+    //
+    // The real consent upgrade flow:
+    //   1. JS: requestConsentUpgrade() calls sendPageview() with consentUpgrade: true
+    //   2. JS: sendPageview() adds &consent_upgrade=1&pageview_id=<id> to the request
+    //   3. Server Processor.php:409: $isConsentUpgrade gate triggers the merge
+    //
+    // We must call this ON THE SAME PAGE where the anonymous row was created,
+    // because SlimStatParams.id holds the anonymous pageview ID that the server
+    // needs to find and upgrade the correct row.
 
-    // Delete the denied cookie and set it to accepted — simulates the user
-    // changing their mind (e.g. clicking an "Accept" button on a re-shown banner
-    // or a "Manage Preferences" link). We manipulate the cookie directly and
-    // then navigate, which is the same flow as the JS consent upgrade path.
-    await ctx.clearCookies();
+    // Set the accepted consent cookie (simulates the banner handler setting it)
     await ctx.addCookies([
-      ...COOKIEYES_DISMISS_COOKIES,
       {
         name: 'slimstat_gdpr_consent',
         value: 'accepted',
@@ -305,58 +309,61 @@ test.describe('Session & Cookie Management — #199', () => {
       },
     ]);
 
-    // Reset tracking counter for acceptance phase
+    // Reset tracking counter to capture the upgrade request
     trackingRequests.length = 0;
 
-    const acceptMarker = `consent-accepted-${ts}`;
-    await testPage.goto(`${BASE_URL}/?e2e_marker=${acceptMarker}`, {
-      waitUntil: 'domcontentloaded',
+    // Trigger the real JS consent upgrade on the CURRENT page (not a new navigation).
+    // This sends consent_upgrade=1 + the current pageview_id to the server,
+    // which is the exact code path that #246 broke.
+    const upgradeResult = await testPage.evaluate(() => {
+      if (typeof (window as any).SlimStat?.requestConsentUpgrade === 'function') {
+        (window as any).SlimStat.requestConsentUpgrade({ force: true });
+        return 'triggered';
+      }
+      return 'SlimStat.requestConsentUpgrade not available';
     });
-    await testPage.waitForTimeout(3000);
 
-    // Banner should NOT be visible (consent cookie = accepted)
-    await expect(testPage.locator('#slimstat-gdpr-banner')).not.toBeVisible();
+    // Wait for the upgrade tracking request to complete
+    await testPage.waitForTimeout(5000);
 
-    // Navigate to a second page after consent upgrade
-    const acceptNav2Marker = `consent-accepted-nav2-${ts}`;
-    await testPage.goto(`${BASE_URL}/?e2e_marker=${acceptNav2Marker}`, {
-      waitUntil: 'domcontentloaded',
-    });
-    await testPage.waitForTimeout(3000);
+    // ── Phase 4: Verify the anonymous row was upgraded with PII ────
 
-    // ── Phase 4: Verify tracking resumed with PII ─────────────────
-
-    // At least one tracking request should have fired after acceptance
-    expect(
-      trackingRequests.length,
-      'Tracking requests should fire after consent upgrade',
-    ).toBeGreaterThanOrEqual(1);
-
-    // DB rows should exist for the accepted pages
-    const acceptRows = await waitForStatRows(acceptMarker, 1, 15_000);
-    expect(
-      acceptRows.length,
-      'At least one DB row should exist after consent upgrade',
-    ).toBeGreaterThanOrEqual(1);
-    const postConsentVisitId = parseInt(acceptRows[0].visit_id, 10);
-    expect(postConsentVisitId, 'Post-consent visit_id should be positive').toBeGreaterThan(0);
-
-    // Key assertion: post-consent rows should have a real IP (PII),
-    // which differs from the hashed IP stored during anonymous tracking.
-    const piiIp = acceptRows[0].ip;
-    expect(
-      piiIp,
-      'Post-consent IP (PII) should differ from anonymous hashed IP',
-    ).not.toBe(anonymousIp);
-
-    // If the second accepted page was also tracked, verify it shares the same visit_id
-    const acceptNav2Rows = await waitForStatRows(acceptNav2Marker, 1, 10_000);
-    if (acceptNav2Rows.length > 0) {
-      const nav2VisitId = parseInt(acceptNav2Rows[0].visit_id, 10);
+    if (upgradeResult === 'triggered') {
+      // The upgrade request should have fired
       expect(
-        nav2VisitId,
-        'Second page after consent upgrade should share visit_id with the first',
-      ).toBe(postConsentVisitId);
+        trackingRequests.length,
+        'requestConsentUpgrade() should send a tracking request with consent_upgrade=1',
+      ).toBeGreaterThanOrEqual(1);
+
+      // Re-read the anonymous row — after upgrade, the IP should now be real (PII),
+      // not the hashed anonymous value.
+      const upgradedRows = await waitForStatRows(declinedNavMarker, 1, 10_000);
+      expect(upgradedRows.length).toBeGreaterThanOrEqual(1);
+      const upgradedIp = upgradedRows[0].ip;
+
+      // Key assertion: the SAME row that had a hashed anonymous IP should now
+      // have a real IP (PII) after the consent upgrade merged PII into it.
+      // If #246 regresses, this assertion fails because the merge code at
+      // Processor.php:436 ($isAnonymousTracking && $piiAllowed) won't execute.
+      expect(
+        upgradedIp,
+        `Anonymous row IP should be upgraded from hashed (${anonymousIp}) to real PII`,
+      ).not.toBe(anonymousIp);
+    } else {
+      // SlimStat JS not loaded (e.g. server-mode or JS disabled) — fall back to
+      // verifying that a new navigation after accepting produces PII rows.
+      const acceptMarker = `consent-accepted-${ts}`;
+      await testPage.goto(`${BASE_URL}/?e2e_marker=${acceptMarker}`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await testPage.waitForTimeout(3000);
+
+      const acceptRows = await waitForStatRows(acceptMarker, 1, 15_000);
+      expect(acceptRows.length).toBeGreaterThanOrEqual(1);
+      expect(
+        acceptRows[0].ip,
+        'Post-consent IP should differ from anonymous hashed IP',
+      ).not.toBe(anonymousIp);
     }
 
     await testPage.close();

--- a/tests/e2e/session-cookie-management.spec.ts
+++ b/tests/e2e/session-cookie-management.spec.ts
@@ -99,43 +99,56 @@ test.describe('Session & Cookie Management — #199', () => {
   //   verify all DB rows share the same visit_id.
   // ═══════════════════════════════════════════════════════════════════
 
-  test('cross-page visit_id continuity — 3 pages share one visit_id', async ({ page }) => {
+  test('cross-page visit_id continuity — 3 pages share one visit_id', async ({ page, browser }) => {
     await clearStatsTable();
     await setSlimstatOption(page, 'gdpr_enabled', 'off');
     await setSlimstatOption(page, 'javascript_mode', 'on');
     await setSlimstatOption(page, 'set_tracker_cookie', 'on');
     await setSlimstatOption(page, 'tracking_request_method', 'rest');
+    await setSlimstatOption(page, 'ignore_wp_users', 'no');
 
-    const marker = `session-continuity-${Date.now()}`;
+    // Use a fresh ANONYMOUS browser context — not the admin page fixture.
+    // Real visitors are not logged into WordPress. The admin storageState
+    // carries auth cookies that can trigger isUserExcluded() and silently
+    // skip tracking.
+    const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    const anonPage = await ctx.newPage();
 
-    // Navigate to 3 distinct pages within the same browser context (session)
-    await page.goto(`${BASE_URL}/?e2e_marker=${marker}-p1`);
-    await page.waitForLoadState('load');
-    await page.waitForTimeout(3000);
+    try {
+      const marker = `session-continuity-${Date.now()}`;
 
-    await page.goto(`${BASE_URL}/?e2e_marker=${marker}-p2`);
-    await page.waitForLoadState('load');
-    await page.waitForTimeout(3000);
+      // Navigate to 3 distinct pages within the same anonymous session
+      await anonPage.goto(`${BASE_URL}/?e2e_marker=${marker}-p1`);
+      await anonPage.waitForLoadState('load');
+      await anonPage.waitForTimeout(3000);
 
-    await page.goto(`${BASE_URL}/?e2e_marker=${marker}-p3`);
-    await page.waitForLoadState('load');
-    await page.waitForTimeout(3000);
+      await anonPage.goto(`${BASE_URL}/?e2e_marker=${marker}-p2`);
+      await anonPage.waitForLoadState('load');
+      await anonPage.waitForTimeout(3000);
 
-    // Wait for all 3 rows to appear in the DB
-    const rows = await waitForStatRows(marker, 3, 20_000);
-    expect(rows.length, 'Expected 3 tracked pageviews').toBeGreaterThanOrEqual(3);
+      await anonPage.goto(`${BASE_URL}/?e2e_marker=${marker}-p3`);
+      await anonPage.waitForLoadState('load');
+      await anonPage.waitForTimeout(3000);
 
-    // All rows must share the same positive visit_id
-    const visitIds = rows
-      .map((r: any) => parseInt(r.visit_id, 10))
-      .filter((v: number) => v > 0);
-    expect(visitIds.length, 'All rows should have a positive visit_id').toBe(rows.length);
+      // Wait for all 3 rows to appear in the DB
+      const rows = await waitForStatRows(marker, 3, 20_000);
+      expect(rows.length, 'Expected 3 tracked pageviews').toBeGreaterThanOrEqual(3);
 
-    const uniqueIds = [...new Set(visitIds)];
-    expect(
-      uniqueIds,
-      `All 3 pageviews should share one visit_id but got ${JSON.stringify(uniqueIds)}`,
-    ).toHaveLength(1);
+      // All rows must share the same positive visit_id
+      const visitIds = rows
+        .map((r: any) => parseInt(r.visit_id, 10))
+        .filter((v: number) => v > 0);
+      expect(visitIds.length, 'All rows should have a positive visit_id').toBe(rows.length);
+
+      const uniqueIds = [...new Set(visitIds)];
+      expect(
+        uniqueIds,
+        `All 3 pageviews should share one visit_id but got ${JSON.stringify(uniqueIds)}`,
+      ).toHaveLength(1);
+    } finally {
+      await anonPage.close();
+      await ctx.close();
+    }
   });
 
   // ═══════════════════════════════════════════════════════════════════
@@ -288,47 +301,78 @@ test.describe('Session & Cookie Management — #199', () => {
     // not the real IP address.
     const anonymousIp = anonRows[0].ip;
 
-    // ── Phase 3: Accept consent via real JS upgrade path ──────────
+    // ── Phase 3: Accept consent via real banner accept flow ────────
     //
-    // The real consent upgrade flow:
-    //   1. JS: requestConsentUpgrade() calls sendPageview() with consentUpgrade: true
-    //   2. JS: sendPageview() adds &consent_upgrade=1&pageview_id=<id> to the request
-    //   3. Server Processor.php:409: $isConsentUpgrade gate triggers the merge
+    // The production accept handler in wp-slimstat.js:2232-2244 does:
+    //   1. Sets the consent cookie to 'accepted'
+    //   2. Calls sendConsentChangeToServer("slimstat_banner", parsedConsent, pageviewId)
+    //   3. Calls requestConsentUpgrade({ consent, consentNonce })
     //
-    // We must call this ON THE SAME PAGE where the anonymous row was created,
-    // because SlimStatParams.id holds the anonymous pageview ID that the server
-    // needs to find and upgrade the correct row.
+    // The merge logic at Processor.php:409 needs:
+    //   - $isConsentUpgrade (consent_upgrade=1 in the request)
+    //   - $isAnonymousTracking == true (settings['anonymous_tracking'] == 'on')
+    //   - pageview_id from SlimStatParams.id to find the anonymous row
+    //
+    // We must wait for SlimStatParams.id to be populated BEFORE triggering
+    // the upgrade, because that ID is how the server finds the anonymous row.
 
-    // Set the accepted consent cookie (simulates the banner handler setting it)
-    await ctx.addCookies([
-      {
-        name: 'slimstat_gdpr_consent',
-        value: 'accepted',
-        domain: COOKIE_DOMAIN,
-        path: '/',
-      },
-    ]);
+    // Wait for the anonymous pageview to be fully tracked and SlimStatParams.id set.
+    // This is the pageview ID of the anonymous row that the upgrade will target.
+    let anonPageviewId: string;
+    try {
+      await testPage.waitForFunction(
+        () => {
+          const p = (window as any).SlimStatParams;
+          return p && p.id && parseInt(p.id, 10) > 0;
+        },
+        { timeout: 15_000 },
+      );
+      anonPageviewId = await testPage.evaluate(
+        () => (window as any).SlimStatParams?.id ?? '',
+      );
+    } catch {
+      anonPageviewId = '';
+    }
 
     // Reset tracking counter to capture the upgrade request
     trackingRequests.length = 0;
 
-    // Trigger the real JS consent upgrade on the CURRENT page (not a new navigation).
-    // This sends consent_upgrade=1 + the current pageview_id to the server,
-    // which is the exact code path that #246 broke.
-    const upgradeResult = await testPage.evaluate(() => {
-      if (typeof (window as any).SlimStat?.requestConsentUpgrade === 'function') {
-        (window as any).SlimStat.requestConsentUpgrade({ force: true });
-        return 'triggered';
+    // Replicate the EXACT banner accept handler (wp-slimstat.js:2232-2244):
+    //   1. Set accepted cookie
+    //   2. Call sendConsentChangeToServer with the current pageview ID
+    //   3. Call requestConsentUpgrade with force:true
+    // All on the CURRENT page where the anonymous row was created.
+    const upgradeResult = await testPage.evaluate((pageviewId) => {
+      const win = window as any;
+
+      // Step 1: Set the consent cookie (mirrors the banner handler)
+      document.cookie = 'slimstat_gdpr_consent=accepted; path=/; SameSite=Lax';
+
+      // Step 2 & 3: Call the real JS functions if available
+      if (typeof win.SlimStat?.requestConsentUpgrade !== 'function') {
+        return 'SlimStat.requestConsentUpgrade not available';
       }
-      return 'SlimStat.requestConsentUpgrade not available';
-    });
+
+      // sendConsentChangeToServer (optional — may not be exposed)
+      try {
+        if (typeof win.SlimStat?.consent?.sendChange === 'function') {
+          const parsedConsent = { statistics: true };
+          const pvId = pageviewId ? parseInt(pageviewId, 10) : null;
+          win.SlimStat.consent.sendChange('slimstat_banner', parsedConsent, pvId);
+        }
+      } catch { /* non-fatal */ }
+
+      // requestConsentUpgrade — the critical call that sends consent_upgrade=1
+      win.SlimStat.requestConsentUpgrade({ force: true });
+      return 'triggered';
+    }, anonPageviewId);
 
     // Wait for the upgrade tracking request to complete
     await testPage.waitForTimeout(5000);
 
     // ── Phase 4: Verify the anonymous row was upgraded with PII ────
 
-    if (upgradeResult === 'triggered') {
+    if (upgradeResult === 'triggered' && anonPageviewId) {
       // The upgrade request should have fired
       expect(
         trackingRequests.length,
@@ -343,14 +387,13 @@ test.describe('Session & Cookie Management — #199', () => {
 
       // Key assertion: the SAME row that had a hashed anonymous IP should now
       // have a real IP (PII) after the consent upgrade merged PII into it.
-      // If #246 regresses, this assertion fails because the merge code at
-      // Processor.php:436 ($isAnonymousTracking && $piiAllowed) won't execute.
+      // If #246 regresses, the merge code at Processor.php:436 won't execute.
       expect(
         upgradedIp,
         `Anonymous row IP should be upgraded from hashed (${anonymousIp}) to real PII`,
       ).not.toBe(anonymousIp);
     } else {
-      // SlimStat JS not loaded (e.g. server-mode or JS disabled) — fall back to
+      // SlimStat JS not loaded or pageview ID not captured — fall back to
       // verifying that a new navigation after accepting produces PII rows.
       const acceptMarker = `consent-accepted-${ts}`;
       await testPage.goto(`${BASE_URL}/?e2e_marker=${acceptMarker}`, {

--- a/tests/e2e/session-cookie-management.spec.ts
+++ b/tests/e2e/session-cookie-management.spec.ts
@@ -120,15 +120,12 @@ test.describe('Session & Cookie Management — #199', () => {
       // Navigate to 3 distinct pages within the same anonymous session
       await anonPage.goto(`${BASE_URL}/?e2e_marker=${marker}-p1`);
       await anonPage.waitForLoadState('load');
-      await anonPage.waitForTimeout(3000);
 
       await anonPage.goto(`${BASE_URL}/?e2e_marker=${marker}-p2`);
       await anonPage.waitForLoadState('load');
-      await anonPage.waitForTimeout(3000);
 
       await anonPage.goto(`${BASE_URL}/?e2e_marker=${marker}-p3`);
       await anonPage.waitForLoadState('load');
-      await anonPage.waitForTimeout(3000);
 
       // Wait for all 3 rows to appear in the DB
       const rows = await waitForStatRows(marker, 3, 20_000);
@@ -177,7 +174,6 @@ test.describe('Session & Cookie Management — #199', () => {
       // Visit #1: establish a session
       await page.goto(`${BASE_URL}/?e2e_marker=${markerBefore}`);
       await page.waitForLoadState('load');
-      await page.waitForTimeout(3000);
 
       const rowsBefore = await waitForStatRows(markerBefore, 1, 15_000);
       expect(rowsBefore.length, 'First visit should produce a DB row').toBeGreaterThanOrEqual(1);
@@ -190,7 +186,6 @@ test.describe('Session & Cookie Management — #199', () => {
       // Visit #2: should start a new session
       await page.goto(`${BASE_URL}/?e2e_marker=${markerAfter}`);
       await page.waitForLoadState('load');
-      await page.waitForTimeout(3000);
 
       const rowsAfter = await waitForStatRows(markerAfter, 1, 15_000);
       expect(rowsAfter.length, 'Second visit should produce a DB row').toBeGreaterThanOrEqual(1);
@@ -258,7 +253,6 @@ test.describe('Session & Cookie Management — #199', () => {
     await testPage.goto(`${BASE_URL}/?e2e_marker=${declineMarker}`, {
       waitUntil: 'domcontentloaded',
     });
-    await testPage.waitForTimeout(3000);
 
     // Banner should be visible for a fresh visitor
     await expect(testPage.locator('#slimstat-gdpr-banner')).toBeVisible();
@@ -285,7 +279,6 @@ test.describe('Session & Cookie Management — #199', () => {
     await testPage.goto(`${BASE_URL}/?e2e_marker=${declinedNavMarker}`, {
       waitUntil: 'domcontentloaded',
     });
-    await testPage.waitForTimeout(3000);
 
     // Banner should NOT reappear (decision persisted)
     await expect(testPage.locator('#slimstat-gdpr-banner')).not.toBeVisible();

--- a/tests/e2e/session-cookie-management.spec.ts
+++ b/tests/e2e/session-cookie-management.spec.ts
@@ -332,19 +332,17 @@ test.describe('Session & Cookie Management — #199', () => {
       waitUntil: 'domcontentloaded',
     });
 
-    // Wait for the anonymous pageview to be tracked (SlimStatParams.id populated)
-    try {
-      await testPage.waitForFunction(
-        () => {
-          const p = (window as any).SlimStatParams;
-          return p && p.id && parseInt(p.id, 10) > 0;
-        },
-        { timeout: 15_000 },
-      );
-    } catch {
-      // If SlimStatParams.id isn't set, the upgrade won't target a specific row
-      // but the test can still verify the banner flow works.
-    }
+    // Wait for the anonymous pageview to be tracked (SlimStatParams.id populated).
+    // This MUST succeed — the consent upgrade needs the pageview ID to target
+    // the anonymous row for merging. If this times out, the test should fail
+    // because the upgrade assertion would be meaningless without it.
+    await testPage.waitForFunction(
+      () => {
+        const p = (window as any).SlimStatParams;
+        return p && p.id && parseInt(p.id, 10) > 0;
+      },
+      { timeout: 15_000 },
+    );
 
     // Banner should be visible again (consent cookie was cleared)
     await expect(testPage.locator('#slimstat-gdpr-banner')).toBeVisible({
@@ -366,7 +364,14 @@ test.describe('Session & Cookie Management — #199', () => {
     // banner handler: cookie set → sendConsentChangeToServer → requestConsentUpgrade
     // No manual cookie injection, no force:true, no direct JS calls.
     await testPage.locator('[data-consent="accepted"]').click();
-    await testPage.waitForTimeout(5000);
+
+    // Wait for the consent upgrade tracking request to complete.
+    // The banner handler sends a REST/AJAX request with consent_upgrade=1.
+    // Poll trackingRequests instead of a blind timeout.
+    const upgradeDeadline = Date.now() + 15_000;
+    while (trackingRequests.length === 0 && Date.now() < upgradeDeadline) {
+      await new Promise((r) => setTimeout(r, 500));
+    }
 
     // Verify the consent cookie is now 'accepted'
     const postAcceptCookies = await ctx.cookies();

--- a/tests/e2e/session-cookie-management.spec.ts
+++ b/tests/e2e/session-cookie-management.spec.ts
@@ -1,0 +1,363 @@
+/**
+ * E2E tests: Session & Cookie Management — ROADMAP #199
+ *
+ * Covers:
+ *  1. Cross-page visit_id continuity (same session, 3 pages, single visit_id)
+ *  2. Cookie expiry creates new session (clear cookies mid-session => new visit_id)
+ *  3. Consent upgrade preserves session (decline => no tracking => accept => tracking resumes)
+ *
+ * Related bugs: #246 (consent-upgrade path broke session merging in v5.4.5)
+ */
+import { test, expect } from '@playwright/test';
+import * as mysql from 'mysql2/promise';
+import {
+  setSlimstatOption,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+  clearStatsTable,
+  closeDb,
+} from './helpers/setup';
+import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
+
+const COOKIE_DOMAIN = new URL(BASE_URL).hostname;
+
+// CookieYes dismissal cookies — the test site has cookie-law-info active and
+// its overlay blocks the SlimStat banner buttons. Pre-set to dismiss it.
+const COOKIEYES_DISMISS_COOKIES = [
+  { name: 'viewed_cookie_policy', value: 'yes', domain: COOKIE_DOMAIN, path: '/' },
+  { name: 'CookieLawInfoConsent', value: 'true', domain: COOKIE_DOMAIN, path: '/' },
+  { name: 'cookielawinfo-checkbox-necessary', value: 'yes', domain: COOKIE_DOMAIN, path: '/' },
+  { name: 'cookielawinfo-checkbox-analytics', value: 'yes', domain: COOKIE_DOMAIN, path: '/' },
+];
+
+// ─── Local DB pool ────────────────────────────────────────────────────
+
+let pool: mysql.Pool;
+
+function getPool(): mysql.Pool {
+  if (!pool) {
+    pool = mysql.createPool(MYSQL_CONFIG);
+  }
+  return pool;
+}
+
+/** Poll DB until at least `minRows` rows matching the marker appear. */
+async function waitForStatRows(
+  marker: string,
+  minRows: number,
+  timeoutMs = 15_000,
+  intervalMs = 500,
+): Promise<Record<string, any>[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const [rows] = (await getPool().execute(
+      'SELECT * FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id ASC',
+      [`%${marker}%`],
+    )) as any;
+    if (rows.length >= minRows) return rows;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  // Return whatever we have (may be fewer than minRows)
+  const [rows] = (await getPool().execute(
+    'SELECT * FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id ASC',
+    [`%${marker}%`],
+  )) as any;
+  return rows;
+}
+
+/** Check whether a request is a SlimStat tracking hit. */
+function isSlimstatTrackingRequest(req: import('@playwright/test').Request): boolean {
+  const url = req.url();
+  if (url.includes('/wp-json/slimstat/v1/hit')) return true;
+  if (url.includes('rest_route=/slimstat/v1/hit')) return true;
+  if (req.method() === 'POST' && url.includes('admin-ajax.php')) {
+    const body = req.postData() || '';
+    if (body.includes('action=slimtrack')) return true;
+  }
+  return false;
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────
+
+test.describe('Session & Cookie Management — #199', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.setTimeout(120_000);
+
+  test.beforeAll(async () => {
+    await snapshotSlimstatOptions();
+  });
+
+  test.afterAll(async () => {
+    await restoreSlimstatOptions();
+    if (pool) await pool.end();
+    await closeDb();
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Test 1: Cross-page visit_id continuity
+  //   Navigate to 3 different pages in the same browser context and
+  //   verify all DB rows share the same visit_id.
+  // ═══════════════════════════════════════════════════════════════════
+
+  test('cross-page visit_id continuity — 3 pages share one visit_id', async ({ page }) => {
+    await clearStatsTable();
+    await setSlimstatOption(page, 'gdpr_enabled', 'off');
+    await setSlimstatOption(page, 'javascript_mode', 'on');
+    await setSlimstatOption(page, 'set_tracker_cookie', 'on');
+    await setSlimstatOption(page, 'tracking_request_method', 'rest');
+
+    const marker = `session-continuity-${Date.now()}`;
+
+    // Navigate to 3 distinct pages within the same browser context (session)
+    await page.goto(`${BASE_URL}/?e2e_marker=${marker}-p1`);
+    await page.waitForLoadState('load');
+    await page.waitForTimeout(3000);
+
+    await page.goto(`${BASE_URL}/?e2e_marker=${marker}-p2`);
+    await page.waitForLoadState('load');
+    await page.waitForTimeout(3000);
+
+    await page.goto(`${BASE_URL}/?e2e_marker=${marker}-p3`);
+    await page.waitForLoadState('load');
+    await page.waitForTimeout(3000);
+
+    // Wait for all 3 rows to appear in the DB
+    const rows = await waitForStatRows(marker, 3, 20_000);
+    expect(rows.length, 'Expected 3 tracked pageviews').toBeGreaterThanOrEqual(3);
+
+    // All rows must share the same positive visit_id
+    const visitIds = rows
+      .map((r: any) => parseInt(r.visit_id, 10))
+      .filter((v: number) => v > 0);
+    expect(visitIds.length, 'All rows should have a positive visit_id').toBe(rows.length);
+
+    const uniqueIds = [...new Set(visitIds)];
+    expect(
+      uniqueIds,
+      `All 3 pageviews should share one visit_id but got ${JSON.stringify(uniqueIds)}`,
+    ).toHaveLength(1);
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Test 2: Cookie expiry creates new session
+  //   Visit a page and record the visit_id, then clear cookies and
+  //   visit again. The second visit must get a different visit_id.
+  // ═══════════════════════════════════════════════════════════════════
+
+  test('clearing cookies creates a new session with a different visit_id', async ({ browser }) => {
+    await clearStatsTable();
+
+    // Use a fresh context so we control cookie lifecycle completely
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    // Configure tracking (GDPR off, JS mode, cookies on)
+    await setSlimstatOption(page, 'gdpr_enabled', 'off');
+    await setSlimstatOption(page, 'javascript_mode', 'on');
+    await setSlimstatOption(page, 'set_tracker_cookie', 'on');
+    await setSlimstatOption(page, 'tracking_request_method', 'rest');
+
+    const markerBefore = `session-before-${Date.now()}`;
+    const markerAfter = `session-after-${Date.now()}`;
+
+    // Visit #1: establish a session
+    await page.goto(`${BASE_URL}/?e2e_marker=${markerBefore}`);
+    await page.waitForLoadState('load');
+    await page.waitForTimeout(3000);
+
+    const rowsBefore = await waitForStatRows(markerBefore, 1, 15_000);
+    expect(rowsBefore.length, 'First visit should produce a DB row').toBeGreaterThanOrEqual(1);
+    const visitIdBefore = parseInt(rowsBefore[0].visit_id, 10);
+    expect(visitIdBefore, 'First visit_id should be positive').toBeGreaterThan(0);
+
+    // Clear ALL cookies — simulates cookie expiry
+    await ctx.clearCookies();
+
+    // Visit #2: should start a new session
+    await page.goto(`${BASE_URL}/?e2e_marker=${markerAfter}`);
+    await page.waitForLoadState('load');
+    await page.waitForTimeout(3000);
+
+    const rowsAfter = await waitForStatRows(markerAfter, 1, 15_000);
+    expect(rowsAfter.length, 'Second visit should produce a DB row').toBeGreaterThanOrEqual(1);
+    const visitIdAfter = parseInt(rowsAfter[0].visit_id, 10);
+    expect(visitIdAfter, 'Second visit_id should be positive').toBeGreaterThan(0);
+
+    // The two visit_ids MUST differ — cookie loss means new session
+    expect(
+      visitIdAfter,
+      `visit_id after cookie clear (${visitIdAfter}) must differ from before (${visitIdBefore})`,
+    ).not.toBe(visitIdBefore);
+
+    await page.close();
+    await ctx.close();
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Test 3: Consent upgrade preserves session
+  //   With GDPR enabled, decline tracking and navigate (should NOT
+  //   track). Then accept consent and navigate — tracking should
+  //   resume with a NEW visit_id.
+  //
+  //   Regression for bug #246 where consent-upgrade broke session merge.
+  // ═══════════════════════════════════════════════════════════════════
+
+  test('consent upgrade — decline then accept resumes tracking with new visit_id', async ({
+    page,
+  }) => {
+    await clearStatsTable();
+
+    // Enable GDPR with SlimStat banner
+    await setSlimstatOption(page, 'gdpr_enabled', 'on');
+    await setSlimstatOption(page, 'consent_integration', 'slimstat_banner');
+    await setSlimstatOption(page, 'use_slimstat_banner', 'on');
+    await setSlimstatOption(page, 'javascript_mode', 'on');
+    await setSlimstatOption(page, 'set_tracker_cookie', 'on');
+    await setSlimstatOption(page, 'tracking_request_method', 'rest');
+    await setSlimstatOption(page, 'anonymous_tracking', 'off');
+
+    const browser = page.context().browser()!;
+    const ts = Date.now();
+
+    // Fresh context — no prior consent
+    const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    await ctx.addCookies(COOKIEYES_DISMISS_COOKIES);
+    const testPage = await ctx.newPage();
+
+    // Track network requests for debugging
+    const trackingRequests: string[] = [];
+    testPage.on('request', (req) => {
+      if (isSlimstatTrackingRequest(req)) {
+        trackingRequests.push(req.url());
+      }
+    });
+
+    // ── Phase 1: Decline consent ──────────────────────────────────
+
+    const declineMarker = `consent-decline-${ts}`;
+    await testPage.goto(`${BASE_URL}/?e2e_marker=${declineMarker}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await testPage.waitForTimeout(3000);
+
+    // Banner should be visible for a fresh visitor
+    await expect(testPage.locator('#slimstat-gdpr-banner')).toBeVisible();
+
+    // Click Decline
+    await testPage.locator('[data-consent="denied"]').click();
+    await testPage.waitForTimeout(2000);
+
+    // Banner should disappear
+    await expect(testPage.locator('#slimstat-gdpr-banner')).not.toBeVisible();
+
+    // Verify consent cookie is 'denied'
+    let cookies = await ctx.cookies();
+    const deniedCookie = cookies.find((c) => c.name === 'slimstat_gdpr_consent');
+    expect(deniedCookie, 'slimstat_gdpr_consent cookie should exist after declining').toBeTruthy();
+    expect(deniedCookie!.value).toBe('denied');
+
+    // Reset tracking counter to isolate post-decline navigation
+    trackingRequests.length = 0;
+
+    // ── Phase 2: Navigate while declined — should NOT track ───────
+
+    const declinedNavMarker = `consent-declined-nav-${ts}`;
+    await testPage.goto(`${BASE_URL}/?e2e_marker=${declinedNavMarker}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await testPage.waitForTimeout(3000);
+
+    // Banner should NOT reappear (decision persisted)
+    await expect(testPage.locator('#slimstat-gdpr-banner')).not.toBeVisible();
+
+    // No tracking requests should have fired while consent is denied
+    expect(
+      trackingRequests.length,
+      'No tracking requests should fire while consent is denied',
+    ).toBe(0);
+
+    // Verify no DB rows for declined navigation
+    await new Promise((r) => setTimeout(r, 2000));
+    const [declinedRows] = (await getPool().execute(
+      'SELECT id FROM wp_slim_stats WHERE resource LIKE ?',
+      [`%${declinedNavMarker}%`],
+    )) as any;
+    expect(declinedRows.length, 'No DB rows should exist for declined navigation').toBe(0);
+
+    // ── Phase 3: Accept consent (upgrade) ─────────────────────────
+
+    // Delete the denied cookie and set it to accepted — simulates the user
+    // changing their mind (e.g. clicking an "Accept" button on a re-shown banner
+    // or a "Manage Preferences" link). We manipulate the cookie directly and
+    // then navigate, which is the same flow as the JS consent upgrade path.
+    await ctx.clearCookies();
+    await ctx.addCookies([
+      ...COOKIEYES_DISMISS_COOKIES,
+      {
+        name: 'slimstat_gdpr_consent',
+        value: 'accepted',
+        domain: COOKIE_DOMAIN,
+        path: '/',
+      },
+    ]);
+
+    // Reset tracking counter for acceptance phase
+    trackingRequests.length = 0;
+
+    const acceptMarker = `consent-accepted-${ts}`;
+    await testPage.goto(`${BASE_URL}/?e2e_marker=${acceptMarker}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await testPage.waitForTimeout(3000);
+
+    // Banner should NOT be visible (consent cookie = accepted)
+    await expect(testPage.locator('#slimstat-gdpr-banner')).not.toBeVisible();
+
+    // Navigate to a second page after consent upgrade
+    const acceptNav2Marker = `consent-accepted-nav2-${ts}`;
+    await testPage.goto(`${BASE_URL}/?e2e_marker=${acceptNav2Marker}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await testPage.waitForTimeout(3000);
+
+    // ── Phase 4: Verify tracking resumed ──────────────────────────
+
+    // At least one tracking request should have fired after acceptance
+    expect(
+      trackingRequests.length,
+      'Tracking requests should fire after consent upgrade',
+    ).toBeGreaterThanOrEqual(1);
+
+    // DB rows should exist for the accepted pages
+    const acceptRows = await waitForStatRows(acceptMarker, 1, 15_000);
+    expect(
+      acceptRows.length,
+      'At least one DB row should exist after consent upgrade',
+    ).toBeGreaterThanOrEqual(1);
+    const postConsentVisitId = parseInt(acceptRows[0].visit_id, 10);
+    expect(postConsentVisitId, 'Post-consent visit_id should be positive').toBeGreaterThan(0);
+
+    // Verify no rows exist for the decline-phase markers (tracking was correctly blocked)
+    const [declinePhaseRows] = (await getPool().execute(
+      'SELECT id FROM wp_slim_stats WHERE resource LIKE ?',
+      [`%${declineMarker}%`],
+    )) as any;
+    expect(
+      declinePhaseRows.length,
+      'No DB rows should exist for the initial declined page',
+    ).toBe(0);
+
+    // If the second accepted page was also tracked, verify it shares the same visit_id
+    const acceptNav2Rows = await waitForStatRows(acceptNav2Marker, 1, 10_000);
+    if (acceptNav2Rows.length > 0) {
+      const nav2VisitId = parseInt(acceptNav2Rows[0].visit_id, 10);
+      expect(
+        nav2VisitId,
+        'Second page after consent upgrade should share visit_id with the first',
+      ).toBe(postConsentVisitId);
+    }
+
+    await testPage.close();
+    await ctx.close();
+  });
+});

--- a/tests/e2e/session-cookie-management.spec.ts
+++ b/tests/e2e/session-cookie-management.spec.ts
@@ -301,24 +301,38 @@ test.describe('Session & Cookie Management — #199', () => {
     // not the real IP address.
     const anonymousIp = anonRows[0].ip;
 
-    // ── Phase 3: Accept consent via real banner accept flow ────────
+    // ── Phase 3: Click Accept on the real banner ──────────────────
     //
-    // The production accept handler in wp-slimstat.js:2232-2244 does:
-    //   1. Sets the consent cookie to 'accepted'
-    //   2. Calls sendConsentChangeToServer("slimstat_banner", parsedConsent, pageviewId)
-    //   3. Calls requestConsentUpgrade({ consent, consentNonce })
+    // Production flow (wp-slimstat.js:2232-2244):
+    //   1. User clicks [data-consent="accepted"] on the banner
+    //   2. JS sets slimstat_gdpr_consent=accepted cookie
+    //   3. JS calls sendConsentChangeToServer("slimstat_banner", consent, pageviewId)
+    //   4. JS calls requestConsentUpgrade({ consent, consentNonce })
+    //   5. Server Processor.php:409 receives consent_upgrade=1 + pageview_id
+    //   6. Server merges PII into the anonymous row
     //
-    // The merge logic at Processor.php:409 needs:
-    //   - $isConsentUpgrade (consent_upgrade=1 in the request)
-    //   - $isAnonymousTracking == true (settings['anonymous_tracking'] == 'on')
-    //   - pageview_id from SlimStatParams.id to find the anonymous row
-    //
-    // We must wait for SlimStatParams.id to be populated BEFORE triggering
-    // the upgrade, because that ID is how the server finds the anonymous row.
+    // We trigger this by navigating to a new page (which creates a fresh
+    // anonymous row + shows the banner again after we clear the consent cookie),
+    // then clicking Accept. No manual cookie setting, no direct JS calls,
+    // no force:true bypass.
 
-    // Wait for the anonymous pageview to be fully tracked and SlimStatParams.id set.
-    // This is the pageview ID of the anonymous row that the upgrade will target.
-    let anonPageviewId: string;
+    // Clear the denied consent cookie so the banner re-appears on next navigation
+    const consentCookies = (await ctx.cookies()).filter(
+      (c) => c.name === 'slimstat_gdpr_consent',
+    );
+    if (consentCookies.length > 0) {
+      // clearCookies removes ALL cookies; re-add CookieYes dismissal cookies
+      await ctx.clearCookies();
+      await ctx.addCookies(COOKIEYES_DISMISS_COOKIES);
+    }
+
+    // Navigate to a new page — banner should re-appear, anonymous row created
+    const upgradeMarker = `consent-upgrade-${ts}`;
+    await testPage.goto(`${BASE_URL}/?e2e_marker=${upgradeMarker}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // Wait for the anonymous pageview to be tracked (SlimStatParams.id populated)
     try {
       await testPage.waitForFunction(
         () => {
@@ -327,87 +341,62 @@ test.describe('Session & Cookie Management — #199', () => {
         },
         { timeout: 15_000 },
       );
-      anonPageviewId = await testPage.evaluate(
-        () => (window as any).SlimStatParams?.id ?? '',
-      );
     } catch {
-      anonPageviewId = '';
+      // If SlimStatParams.id isn't set, the upgrade won't target a specific row
+      // but the test can still verify the banner flow works.
     }
 
-    // Reset tracking counter to capture the upgrade request
+    // Banner should be visible again (consent cookie was cleared)
+    await expect(testPage.locator('#slimstat-gdpr-banner')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Record the anonymous row's IP before upgrade
+    const preUpgradeRows = await waitForStatRows(upgradeMarker, 1, 15_000);
+    expect(
+      preUpgradeRows.length,
+      'Anonymous row should exist before clicking Accept',
+    ).toBeGreaterThanOrEqual(1);
+    const preUpgradeIp = preUpgradeRows[0].ip;
+
+    // Reset tracking counter to isolate the upgrade request
     trackingRequests.length = 0;
 
-    // Replicate the EXACT banner accept handler (wp-slimstat.js:2232-2244):
-    //   1. Set accepted cookie
-    //   2. Call sendConsentChangeToServer with the current pageview ID
-    //   3. Call requestConsentUpgrade with force:true
-    // All on the CURRENT page where the anonymous row was created.
-    const upgradeResult = await testPage.evaluate((pageviewId) => {
-      const win = window as any;
-
-      // Step 1: Set the consent cookie (mirrors the banner handler)
-      document.cookie = 'slimstat_gdpr_consent=accepted; path=/; SameSite=Lax';
-
-      // Step 2 & 3: Call the real JS functions if available
-      if (typeof win.SlimStat?.requestConsentUpgrade !== 'function') {
-        return 'SlimStat.requestConsentUpgrade not available';
-      }
-
-      // sendConsentChangeToServer (optional — may not be exposed)
-      try {
-        if (typeof win.SlimStat?.consent?.sendChange === 'function') {
-          const parsedConsent = { statistics: true };
-          const pvId = pageviewId ? parseInt(pageviewId, 10) : null;
-          win.SlimStat.consent.sendChange('slimstat_banner', parsedConsent, pvId);
-        }
-      } catch { /* non-fatal */ }
-
-      // requestConsentUpgrade — the critical call that sends consent_upgrade=1
-      win.SlimStat.requestConsentUpgrade({ force: true });
-      return 'triggered';
-    }, anonPageviewId);
-
-    // Wait for the upgrade tracking request to complete
+    // Click the REAL Accept button — this triggers the full production
+    // banner handler: cookie set → sendConsentChangeToServer → requestConsentUpgrade
+    // No manual cookie injection, no force:true, no direct JS calls.
+    await testPage.locator('[data-consent="accepted"]').click();
     await testPage.waitForTimeout(5000);
+
+    // Verify the consent cookie is now 'accepted'
+    const postAcceptCookies = await ctx.cookies();
+    const acceptedCookie = postAcceptCookies.find(
+      (c) => c.name === 'slimstat_gdpr_consent',
+    );
+    expect(acceptedCookie, 'Consent cookie should be set after clicking Accept').toBeTruthy();
+    expect(acceptedCookie!.value).toBe('accepted');
 
     // ── Phase 4: Verify the anonymous row was upgraded with PII ────
 
-    if (upgradeResult === 'triggered' && anonPageviewId) {
-      // The upgrade request should have fired
-      expect(
-        trackingRequests.length,
-        'requestConsentUpgrade() should send a tracking request with consent_upgrade=1',
-      ).toBeGreaterThanOrEqual(1);
+    // At least one upgrade tracking request should have fired
+    expect(
+      trackingRequests.length,
+      'Clicking Accept should trigger a consent upgrade tracking request',
+    ).toBeGreaterThanOrEqual(1);
 
-      // Re-read the anonymous row — after upgrade, the IP should now be real (PII),
-      // not the hashed anonymous value.
-      const upgradedRows = await waitForStatRows(declinedNavMarker, 1, 10_000);
-      expect(upgradedRows.length).toBeGreaterThanOrEqual(1);
-      const upgradedIp = upgradedRows[0].ip;
+    // Re-read the row — after upgrade, the IP should be real PII
+    const upgradedRows = await waitForStatRows(upgradeMarker, 1, 10_000);
+    expect(upgradedRows.length).toBeGreaterThanOrEqual(1);
+    const upgradedIp = upgradedRows[0].ip;
 
-      // Key assertion: the SAME row that had a hashed anonymous IP should now
-      // have a real IP (PII) after the consent upgrade merged PII into it.
-      // If #246 regresses, the merge code at Processor.php:436 won't execute.
-      expect(
-        upgradedIp,
-        `Anonymous row IP should be upgraded from hashed (${anonymousIp}) to real PII`,
-      ).not.toBe(anonymousIp);
-    } else {
-      // SlimStat JS not loaded or pageview ID not captured — fall back to
-      // verifying that a new navigation after accepting produces PII rows.
-      const acceptMarker = `consent-accepted-${ts}`;
-      await testPage.goto(`${BASE_URL}/?e2e_marker=${acceptMarker}`, {
-        waitUntil: 'domcontentloaded',
-      });
-      await testPage.waitForTimeout(3000);
-
-      const acceptRows = await waitForStatRows(acceptMarker, 1, 15_000);
-      expect(acceptRows.length).toBeGreaterThanOrEqual(1);
-      expect(
-        acceptRows[0].ip,
-        'Post-consent IP should differ from anonymous hashed IP',
-      ).not.toBe(anonymousIp);
-    }
+    // Key assertion: the SAME row that had a hashed anonymous IP should now
+    // have a real IP (PII) after the consent upgrade merged PII into it.
+    // If #246 regresses, the merge code at Processor.php:436 won't execute
+    // and the IP will remain hashed.
+    expect(
+      upgradedIp,
+      `Anonymous row IP should be upgraded from hashed (${preUpgradeIp}) to real PII`,
+    ).not.toBe(preUpgradeIp);
 
     await testPage.close();
     await ctx.close();

--- a/tests/e2e/session-cookie-management.spec.ts
+++ b/tests/e2e/session-cookie-management.spec.ts
@@ -51,7 +51,7 @@ async function waitForStatRows(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const [rows] = (await getPool().execute(
-      'SELECT * FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id ASC',
+      'SELECT id, visit_id, resource FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id ASC LIMIT 20',
       [`%${marker}%`],
     )) as any;
     if (rows.length >= minRows) return rows;
@@ -59,7 +59,7 @@ async function waitForStatRows(
   }
   // Return whatever we have (may be fewer than minRows)
   const [rows] = (await getPool().execute(
-    'SELECT * FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id ASC',
+    'SELECT id, visit_id, resource FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id ASC LIMIT 20',
     [`%${marker}%`],
   )) as any;
   return rows;
@@ -151,46 +151,48 @@ test.describe('Session & Cookie Management — #199', () => {
     const ctx = await browser.newContext();
     const page = await ctx.newPage();
 
-    // Configure tracking (GDPR off, JS mode, cookies on)
-    await setSlimstatOption(page, 'gdpr_enabled', 'off');
-    await setSlimstatOption(page, 'javascript_mode', 'on');
-    await setSlimstatOption(page, 'set_tracker_cookie', 'on');
-    await setSlimstatOption(page, 'tracking_request_method', 'rest');
+    try {
+      // Configure tracking (GDPR off, JS mode, cookies on)
+      await setSlimstatOption(page, 'gdpr_enabled', 'off');
+      await setSlimstatOption(page, 'javascript_mode', 'on');
+      await setSlimstatOption(page, 'set_tracker_cookie', 'on');
+      await setSlimstatOption(page, 'tracking_request_method', 'rest');
 
-    const markerBefore = `session-before-${Date.now()}`;
-    const markerAfter = `session-after-${Date.now()}`;
+      const markerBefore = `session-before-${Date.now()}`;
+      const markerAfter = `session-after-${Date.now()}`;
 
-    // Visit #1: establish a session
-    await page.goto(`${BASE_URL}/?e2e_marker=${markerBefore}`);
-    await page.waitForLoadState('load');
-    await page.waitForTimeout(3000);
+      // Visit #1: establish a session
+      await page.goto(`${BASE_URL}/?e2e_marker=${markerBefore}`);
+      await page.waitForLoadState('load');
+      await page.waitForTimeout(3000);
 
-    const rowsBefore = await waitForStatRows(markerBefore, 1, 15_000);
-    expect(rowsBefore.length, 'First visit should produce a DB row').toBeGreaterThanOrEqual(1);
-    const visitIdBefore = parseInt(rowsBefore[0].visit_id, 10);
-    expect(visitIdBefore, 'First visit_id should be positive').toBeGreaterThan(0);
+      const rowsBefore = await waitForStatRows(markerBefore, 1, 15_000);
+      expect(rowsBefore.length, 'First visit should produce a DB row').toBeGreaterThanOrEqual(1);
+      const visitIdBefore = parseInt(rowsBefore[0].visit_id, 10);
+      expect(visitIdBefore, 'First visit_id should be positive').toBeGreaterThan(0);
 
-    // Clear ALL cookies — simulates cookie expiry
-    await ctx.clearCookies();
+      // Clear ALL cookies — simulates cookie expiry
+      await ctx.clearCookies();
 
-    // Visit #2: should start a new session
-    await page.goto(`${BASE_URL}/?e2e_marker=${markerAfter}`);
-    await page.waitForLoadState('load');
-    await page.waitForTimeout(3000);
+      // Visit #2: should start a new session
+      await page.goto(`${BASE_URL}/?e2e_marker=${markerAfter}`);
+      await page.waitForLoadState('load');
+      await page.waitForTimeout(3000);
 
-    const rowsAfter = await waitForStatRows(markerAfter, 1, 15_000);
-    expect(rowsAfter.length, 'Second visit should produce a DB row').toBeGreaterThanOrEqual(1);
-    const visitIdAfter = parseInt(rowsAfter[0].visit_id, 10);
-    expect(visitIdAfter, 'Second visit_id should be positive').toBeGreaterThan(0);
+      const rowsAfter = await waitForStatRows(markerAfter, 1, 15_000);
+      expect(rowsAfter.length, 'Second visit should produce a DB row').toBeGreaterThanOrEqual(1);
+      const visitIdAfter = parseInt(rowsAfter[0].visit_id, 10);
+      expect(visitIdAfter, 'Second visit_id should be positive').toBeGreaterThan(0);
 
-    // The two visit_ids MUST differ — cookie loss means new session
-    expect(
-      visitIdAfter,
-      `visit_id after cookie clear (${visitIdAfter}) must differ from before (${visitIdBefore})`,
-    ).not.toBe(visitIdBefore);
-
-    await page.close();
-    await ctx.close();
+      // The two visit_ids MUST differ — cookie loss means new session
+      expect(
+        visitIdAfter,
+        `visit_id after cookie clear (${visitIdAfter}) must differ from before (${visitIdBefore})`,
+      ).not.toBe(visitIdBefore);
+    } finally {
+      await page.close();
+      await ctx.close();
+    }
   });
 
   // ═══════════════════════════════════════════════════════════════════

--- a/tests/e2e/session-cookie-management.spec.ts
+++ b/tests/e2e/session-cookie-management.spec.ts
@@ -290,9 +290,13 @@ test.describe('Session & Cookie Management — #199', () => {
       anonRows.length,
       'Anonymous tracking should record a row even when consent is denied',
     ).toBeGreaterThanOrEqual(1);
-    // Store the anonymous IP for later comparison — it should be a hash,
-    // not the real IP address.
+    // Capture the anonymous row's IP and visit_id BEFORE any upgrade runs.
+    // The IP should be hashed (anonymous tracking strips PII).
+    // The visit_id is the original session identifier — we'll verify it
+    // survives the consent upgrade unchanged (not rewritten to a new value).
     const anonymousIp = anonRows[0].ip;
+    const preUpgradeVisitId = parseInt(anonRows[0].visit_id, 10);
+    expect(preUpgradeVisitId, 'Phase 2 visit_id should be positive before upgrade').toBeGreaterThan(0);
 
     // ── Phase 3: Click Accept on the real banner ──────────────────
     //
@@ -415,8 +419,18 @@ test.describe('Session & Cookie Management — #199', () => {
       `Phase 2 anonymous row IP should be upgraded from hashed (${anonymousIp}) to PII`,
     ).not.toBe(anonymousIp);
 
-    // Key assertion 2: Both rows should share the same visit_id,
-    // proving session continuity was preserved across the consent upgrade.
+    // Key assertion 2: The Phase 2 visit_id must be UNCHANGED after upgrade.
+    // We captured preUpgradeVisitId BEFORE clicking Accept. If the merge code
+    // at Processor.php:615 rewrites all rows to a fresh visit_id, this fails.
+    // This proves the ORIGINAL session identifier was preserved, not just that
+    // rows were rewritten together.
+    expect(
+      earlierVisitId,
+      `Phase 2 visit_id (${earlierVisitId}) must match pre-upgrade value (${preUpgradeVisitId}) — session identity preserved`,
+    ).toBe(preUpgradeVisitId);
+
+    // Key assertion 3: Both rows should share the same visit_id,
+    // proving session continuity across the consent upgrade.
     expect(
       upgradeVisitId,
       `Upgrade row visit_id (${upgradeVisitId}) should match Phase 2 row (${earlierVisitId})`,

--- a/tests/e2e/session-cookie-management.spec.ts
+++ b/tests/e2e/session-cookie-management.spec.ts
@@ -51,7 +51,7 @@ async function waitForStatRows(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const [rows] = (await getPool().execute(
-      'SELECT id, visit_id, resource FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id ASC LIMIT 20',
+      'SELECT id, visit_id, ip, resource FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id ASC LIMIT 20',
       [`%${marker}%`],
     )) as any;
     if (rows.length >= minRows) return rows;
@@ -59,7 +59,7 @@ async function waitForStatRows(
   }
   // Return whatever we have (may be fewer than minRows)
   const [rows] = (await getPool().execute(
-    'SELECT id, visit_id, resource FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id ASC LIMIT 20',
+    'SELECT id, visit_id, ip, resource FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id ASC LIMIT 20',
     [`%${marker}%`],
   )) as any;
   return rows;
@@ -197,26 +197,31 @@ test.describe('Session & Cookie Management — #199', () => {
 
   // ═══════════════════════════════════════════════════════════════════
   // Test 3: Consent upgrade preserves session
-  //   With GDPR enabled, decline tracking and navigate (should NOT
-  //   track). Then accept consent and navigate — tracking should
-  //   resume with a NEW visit_id.
+  //   With GDPR + anonymous_tracking enabled, decline consent and
+  //   navigate — anonymous rows (hashed IP, no PII) should be recorded.
+  //   Then accept consent and navigate — tracking should continue with
+  //   full PII (real IP). Exercises the real merge/upgrade code path in
+  //   Processor.php ($isAnonymousTracking && $piiAllowed).
   //
   //   Regression for bug #246 where consent-upgrade broke session merge.
   // ═══════════════════════════════════════════════════════════════════
 
-  test('consent upgrade — decline then accept resumes tracking with new visit_id', async ({
+  test('consent upgrade — anonymous rows while declined, PII rows after accept', async ({
     page,
   }) => {
     await clearStatsTable();
 
-    // Enable GDPR with SlimStat banner
+    // Enable GDPR with SlimStat banner + anonymous tracking so that
+    // declined visitors still get tracked without PII. This exercises
+    // the real merge/upgrade path in Processor.php (gated on
+    // $isAnonymousTracking && $piiAllowed).
     await setSlimstatOption(page, 'gdpr_enabled', 'on');
     await setSlimstatOption(page, 'consent_integration', 'slimstat_banner');
     await setSlimstatOption(page, 'use_slimstat_banner', 'on');
     await setSlimstatOption(page, 'javascript_mode', 'on');
     await setSlimstatOption(page, 'set_tracker_cookie', 'on');
     await setSlimstatOption(page, 'tracking_request_method', 'rest');
-    await setSlimstatOption(page, 'anonymous_tracking', 'off');
+    await setSlimstatOption(page, 'anonymous_tracking', 'on');
 
     const browser = page.context().browser()!;
     const ts = Date.now();
@@ -261,7 +266,7 @@ test.describe('Session & Cookie Management — #199', () => {
     // Reset tracking counter to isolate post-decline navigation
     trackingRequests.length = 0;
 
-    // ── Phase 2: Navigate while declined — should NOT track ───────
+    // ── Phase 2: Navigate while declined — anonymous tracking records a row ─
 
     const declinedNavMarker = `consent-declined-nav-${ts}`;
     await testPage.goto(`${BASE_URL}/?e2e_marker=${declinedNavMarker}`, {
@@ -272,19 +277,16 @@ test.describe('Session & Cookie Management — #199', () => {
     // Banner should NOT reappear (decision persisted)
     await expect(testPage.locator('#slimstat-gdpr-banner')).not.toBeVisible();
 
-    // No tracking requests should have fired while consent is denied
+    // With anonymous_tracking=on, the tracker still fires even when consent
+    // is denied — it just strips PII (IP is hashed, no username/email).
+    const anonRows = await waitForStatRows(declinedNavMarker, 1, 15_000);
     expect(
-      trackingRequests.length,
-      'No tracking requests should fire while consent is denied',
-    ).toBe(0);
-
-    // Verify no DB rows for declined navigation
-    await new Promise((r) => setTimeout(r, 2000));
-    const [declinedRows] = (await getPool().execute(
-      'SELECT id FROM wp_slim_stats WHERE resource LIKE ?',
-      [`%${declinedNavMarker}%`],
-    )) as any;
-    expect(declinedRows.length, 'No DB rows should exist for declined navigation').toBe(0);
+      anonRows.length,
+      'Anonymous tracking should record a row even when consent is denied',
+    ).toBeGreaterThanOrEqual(1);
+    // Store the anonymous IP for later comparison — it should be a hash,
+    // not the real IP address.
+    const anonymousIp = anonRows[0].ip;
 
     // ── Phase 3: Accept consent (upgrade) ─────────────────────────
 
@@ -322,7 +324,7 @@ test.describe('Session & Cookie Management — #199', () => {
     });
     await testPage.waitForTimeout(3000);
 
-    // ── Phase 4: Verify tracking resumed ──────────────────────────
+    // ── Phase 4: Verify tracking resumed with PII ─────────────────
 
     // At least one tracking request should have fired after acceptance
     expect(
@@ -339,15 +341,13 @@ test.describe('Session & Cookie Management — #199', () => {
     const postConsentVisitId = parseInt(acceptRows[0].visit_id, 10);
     expect(postConsentVisitId, 'Post-consent visit_id should be positive').toBeGreaterThan(0);
 
-    // Verify no rows exist for the decline-phase markers (tracking was correctly blocked)
-    const [declinePhaseRows] = (await getPool().execute(
-      'SELECT id FROM wp_slim_stats WHERE resource LIKE ?',
-      [`%${declineMarker}%`],
-    )) as any;
+    // Key assertion: post-consent rows should have a real IP (PII),
+    // which differs from the hashed IP stored during anonymous tracking.
+    const piiIp = acceptRows[0].ip;
     expect(
-      declinePhaseRows.length,
-      'No DB rows should exist for the initial declined page',
-    ).toBe(0);
+      piiIp,
+      'Post-consent IP (PII) should differ from anonymous hashed IP',
+    ).not.toBe(anonymousIp);
 
     // If the second accepted page was also tracked, verify it shares the same visit_id
     const acceptNav2Rows = await waitForStatRows(acceptNav2Marker, 1, 10_000);

--- a/tests/e2e/upgrade-data-integrity.spec.ts
+++ b/tests/e2e/upgrade-data-integrity.spec.ts
@@ -241,7 +241,7 @@ test.describe('Upgrade Data Integrity', () => {
     await setSlimstatOption(page, 'gdpr_enabled', 'off'); // Ensure tracking not blocked by GDPR
 
     // Clear stats so we get a clean read
-    await getPool().execute('TRUNCATE TABLE wp_slim_stats');
+    await clearStatsTable();
 
     // Inject CF headers for a known location
     await context.setExtraHTTPHeaders({


### PR DESCRIPTION
## Summary

- Rewrite `setSlimstatOption()` / `deleteSlimstatOption()` to use direct DB via `php-serialize` — unblocks 42 of 67 E2E specs that fail in wp-env Docker CI
- Expand test coverage: session/cookie, Pro heatmap, admin settings, query builder

## Cycle 02 Sprint Plan
Sprint plan: `jaan-to/outputs/pm/sprint-plan/02-sprint-plan/02-sprint-plan.md`

## Test plan
- [ ] E2E pass rate improves from ~2% to >50%
- [ ] `setSlimstatOption()` works in wp-env Docker
- [ ] PHPUnit tests pass on PHP 7.4 + 8.2
- [ ] No regressions in existing passing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a PHP serialization dev dependency.

* **Tests**
  * E2E helpers now manipulate PHP-serialized options directly and use more robust DB cleanup (temporarily disabling foreign-key checks and truncating related tables).
  * Improved rewrite-flush handling for stability by relying on permalink page side-effects.
  * Added E2E suites for session/cookie management and admin settings persistence.

* **Unit Tests**
  * Added comprehensive unit tests validating SQL/query generation and filtering logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->