### PR TITLE
fix: preserve comma in heatmap position sanitization (#278)

### DIFF
--- a/src/Tracker/Ajax.php
+++ b/src/Tracker/Ajax.php
@@ -7,19 +7,23 @@ use SlimStat\Utils\Consent;
 class Ajax
 {
     /**
-     * Sanitize click position to "x,y" format with 1-5 digit coordinates.
+     * Validate click position as strict "x,y" format with 1-5 digit coordinates.
+     *
+     * Rejects any value that does not match after whitespace trimming.
+     * No character stripping — tampered payloads are rejected outright
+     * so GDPR exports never contain repaired/synthetic coordinates.
      *
      * @param mixed $raw Raw position value from client.
-     * @return string Sanitized "x,y" or empty string if invalid.
+     * @return string Validated "x,y" or empty string if invalid.
      */
     public static function sanitizePosition($raw): string
     {
         if (!is_string($raw)) {
             return '';
         }
-        $position = preg_replace('/[^0-9,]/', '', $raw);
-        if (!empty($position) && !preg_match('/^\d{1,5},\d{1,5}$/', $position)) {
-            $position = '';
+        $position = trim($raw);
+        if ($position !== '' && !preg_match('/^\d{1,5},\d{1,5}$/', $position)) {
+            return '';
         }
         return $position;
     }

--- a/src/Tracker/Ajax.php
+++ b/src/Tracker/Ajax.php
@@ -7,6 +7,24 @@ use SlimStat\Utils\Consent;
 class Ajax
 {
     /**
+     * Sanitize click position to "x,y" format with 1-5 digit coordinates.
+     *
+     * @param mixed $raw Raw position value from client.
+     * @return string Sanitized "x,y" or empty string if invalid.
+     */
+    public static function sanitizePosition($raw): string
+    {
+        if (!is_string($raw)) {
+            return '';
+        }
+        $position = preg_replace('/[^0-9,]/', '', $raw);
+        if (!empty($position) && !preg_match('/^\d{1,5},\d{1,5}$/', $position)) {
+            $position = '';
+        }
+        return $position;
+    }
+
+    /**
      * Handle AJAX tracking request with exit (for admin-ajax.php).
      * This wrapper calls process() and exits with the result.
      */
@@ -283,16 +301,11 @@ class Ajax
 
                 $id = Storage::updateRow($stat);
             } else {
-                // Security: Validate and sanitize event data
-                $position = !empty($data_js['pos']) ? $data_js['pos'] : '';
-                // Security: Validate position format (alphanumeric, dash, underscore only)
-                $position = preg_replace('/[^a-zA-Z0-9\-_]/', '', $position);
-                // Security: Limit position length
-                if (strlen($position) > 32) {
-                    $position = substr($position, 0, 32);
-                }
+                // Security: Validate and sanitize event position (x,y coordinates)
+                $position = self::sanitizePosition($data_js['pos'] ?? '');
 
                 $event_info = [
+                    // Defense-in-depth: sanitizePosition already guarantees digit-comma-digit
                     'position' => sanitize_text_field($position),
                     'id'       => $stat['id'],
                     'dt'       => \wp_slimstat::date_i18n('U'),

--- a/tests/Unit/QuerySortMergedTest.php
+++ b/tests/Unit/QuerySortMergedTest.php
@@ -173,13 +173,13 @@ class QuerySortMergedTest extends WpSlimstatTestCase
         $this->assertSame('/c', $result[2]['resource']);
     }
 
-    public function test_sql_expression_skipped_gracefully(): void
+    public function test_sql_aggregate_expression_resolves_to_alias(): void
     {
         $query = Query::select(['username', 'COUNT(*) AS counthits', 'MAX(dt) AS dt'])
             ->from('wp_slim_stats')
             ->orderBy('MAX(dt) DESC');
 
-        // MAX(dt) is NOT a key in the result — only 'dt' is (the alias).
+        // MAX(dt) resolves to the 'dt' alias in the result set.
         $input = [
             ['username' => 'alice', 'counthits' => '5',  'dt' => '1000'],
             ['username' => 'bob',   'counthits' => '10', 'dt' => '2000'],
@@ -187,9 +187,9 @@ class QuerySortMergedTest extends WpSlimstatTestCase
 
         $result = $this->invokeSortMergedResults($query, $input);
 
-        // No sortable field found → input order preserved
-        $this->assertSame('alice', $result[0]['username']);
-        $this->assertSame('bob', $result[1]['username']);
+        // MAX(dt) DESC → sorted by dt descending: bob (2000) before alice (1000)
+        $this->assertSame('bob', $result[0]['username']);
+        $this->assertSame('alice', $result[1]['username']);
     }
 
     public function test_mixed_sortable_and_expression_fields(): void

--- a/tests/Unit/Tracker/AjaxPositionSanitizationTest.php
+++ b/tests/Unit/Tracker/AjaxPositionSanitizationTest.php
@@ -11,11 +11,15 @@ class AjaxPositionSanitizationTest extends WpSlimstatTestCase
     public function test_sanitize_position_preserves_only_valid_coordinate_pairs(): void
     {
         $cases = [
+            // Valid coordinates — preserved
             'standard coordinates' => ['320,480', '320,480'],
             'origin coordinates' => ['0,0', '0,0'],
             '4k coordinates' => ['3840,2160', '3840,2160'],
             'max boundary' => ['99999,99999', '99999,99999'],
             'leading zeros preserved' => ['007,042', '007,042'],
+            'whitespace trimmed' => [' 320,480 ', '320,480'],
+
+            // Invalid — rejected outright (no character stripping)
             'six digit x rejected' => ['100000,200', ''],
             'xss payload rejected' => ['<script>alert(1)</script>', ''],
             'missing comma rejected' => ['320480', ''],
@@ -23,12 +27,12 @@ class AjaxPositionSanitizationTest extends WpSlimstatTestCase
             'empty string rejected' => ['', ''],
             'leading comma rejected' => [',200', ''],
             'trailing comma rejected' => ['200,', ''],
-            'minus stripped before validation' => ['-5,300', '5,300'],
-            'whitespace stripped before validation' => [' 320 , 480 ', '320,480'],
+            'negative coordinate rejected' => ['-5,300', ''],
+            'inner whitespace rejected' => [' 320 , 480 ', ''],
             'double comma rejected' => ['320,,480', ''],
             'comma only rejected' => [',', ''],
-            'letters strip to empty' => ['abc', ''],
-            'sql payload stripped then validated' => ['100,200;DROP TABLE', '100,200'],
+            'letters rejected' => ['abc', ''],
+            'sql payload rejected' => ['100,200;DROP TABLE', ''],
             'non scalar input rejected' => [['320,480'], ''],
         ];
 

--- a/tests/Unit/Tracker/AjaxPositionSanitizationTest.php
+++ b/tests/Unit/Tracker/AjaxPositionSanitizationTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSlimstat\Tests\Unit\Tracker;
+
+use SlimStat\Tracker\Ajax;
+use WpSlimstat\Tests\Unit\WpSlimstatTestCase;
+
+class AjaxPositionSanitizationTest extends WpSlimstatTestCase
+{
+    public function test_sanitize_position_preserves_only_valid_coordinate_pairs(): void
+    {
+        $cases = [
+            'standard coordinates' => ['320,480', '320,480'],
+            'origin coordinates' => ['0,0', '0,0'],
+            '4k coordinates' => ['3840,2160', '3840,2160'],
+            'max boundary' => ['99999,99999', '99999,99999'],
+            'leading zeros preserved' => ['007,042', '007,042'],
+            'six digit x rejected' => ['100000,200', ''],
+            'xss payload rejected' => ['<script>alert(1)</script>', ''],
+            'missing comma rejected' => ['320480', ''],
+            'multiple commas rejected' => ['1,2,3', ''],
+            'empty string rejected' => ['', ''],
+            'leading comma rejected' => [',200', ''],
+            'trailing comma rejected' => ['200,', ''],
+            'minus stripped before validation' => ['-5,300', '5,300'],
+            'whitespace stripped before validation' => [' 320 , 480 ', '320,480'],
+            'double comma rejected' => ['320,,480', ''],
+            'comma only rejected' => [',', ''],
+            'letters strip to empty' => ['abc', ''],
+            'sql payload stripped then validated' => ['100,200;DROP TABLE', '100,200'],
+            'non scalar input rejected' => [['320,480'], ''],
+        ];
+
+        foreach ($cases as $label => [$input, $expected]) {
+            $this->assertSame(
+                $expected,
+                Ajax::sanitizePosition($input),
+                sprintf('Failed asserting sanitizePosition contract for case "%s".', $label)
+            );
+        }
+    }
+}

--- a/tests/e2e/heatmap-position-sanitization.spec.ts
+++ b/tests/e2e/heatmap-position-sanitization.spec.ts
@@ -132,6 +132,7 @@ async function callHeatmapEndpoint(
 }
 
 test.describe('Heatmap position sanitization', () => {
+  test.describe.configure({ mode: 'serial' });
   test.setTimeout(60_000);
 
   test.beforeAll(async () => {

--- a/tests/e2e/heatmap-position-sanitization.spec.ts
+++ b/tests/e2e/heatmap-position-sanitization.spec.ts
@@ -1,0 +1,406 @@
+import { test, expect } from '@playwright/test';
+import {
+  clearHeaderOverrides,
+  clearStatsTable,
+  closeDb,
+  getPool,
+  installHeaderInjector,
+  installOptionMutator,
+  restoreSlimstatOptions,
+  seedEventRow,
+  seedPageviews,
+  setSlimstatOptions,
+  snapshotSlimstatOptions,
+  uninstallHeaderInjector,
+  uninstallOptionMutator,
+  waitForEventRow,
+  waitForPageviewRow,
+  waitForTrackerId,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+
+const EMPTY_STORAGE_STATE = { cookies: [], origins: [] };
+
+function encodeBase64(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64');
+}
+
+function isTrackingRequest(req: import('@playwright/test').Request): boolean {
+  if (req.method() !== 'POST') return false;
+  return (
+    req.url().includes('/wp-json/slimstat/v1/hit') ||
+    req.url().includes('rest_route=/slimstat/v1/hit') ||
+    req.url().includes('admin-ajax.php')
+  );
+}
+
+function captureTrackingPayloads(page: import('@playwright/test').Page): { payloads: string[]; reset(): void } {
+  const payloads: string[] = [];
+  page.on('request', (req) => {
+    if (!isTrackingRequest(req)) return;
+    payloads.push(req.postData() || '');
+  });
+
+  return {
+    payloads,
+    reset() {
+      payloads.length = 0;
+    },
+  };
+}
+
+async function isProActive(page: import('@playwright/test').Page): Promise<boolean> {
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'e2e_get_slimstat_version' },
+  });
+  if (!res.ok()) return false;
+  const json = await res.json();
+  return json.data?.pro_active === true;
+}
+
+async function getHeatmapNonce(page: import('@playwright/test').Page): Promise<string> {
+  const response = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'test_create_nonce', nonce_action: 'slimstat_heatmap_nonce' },
+  });
+  expect(response.ok(), 'Nonce helper mu-plugin should respond OK').toBeTruthy();
+  const json = await response.json();
+  return json.data.nonce;
+}
+
+async function getLatestStatSummary(resourcePrefix: string): Promise<{ id: number; resource: string } | null> {
+  const [rows] = await getPool().execute(
+    'SELECT id, resource FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id DESC LIMIT 1',
+    [`${resourcePrefix}%`],
+  ) as any;
+  return rows.length > 0 ? rows[0] : null;
+}
+
+async function getEventCount(): Promise<number> {
+  const [rows] = await getPool().execute('SELECT COUNT(*) AS cnt FROM wp_slim_events') as any;
+  return rows[0].cnt;
+}
+
+async function injectClickTarget(page: import('@playwright/test').Page): Promise<void> {
+  await page.evaluate(() => {
+    const existing = document.getElementById('slimstat-e2e-click-target');
+    if (existing) {
+      existing.remove();
+    }
+
+    const button = document.createElement('button');
+    button.id = 'slimstat-e2e-click-target';
+    button.type = 'button';
+    button.textContent = 'Track click';
+    button.style.position = 'fixed';
+    button.style.top = '120px';
+    button.style.left = '120px';
+    button.style.width = '48px';
+    button.style.height = '48px';
+    button.style.zIndex = '2147483647';
+    document.body.appendChild(button);
+  });
+}
+
+async function createAnonymousPage(
+  browser: import('@playwright/test').Browser,
+  initScript?: () => void,
+): Promise<{ context: import('@playwright/test').BrowserContext; page: import('@playwright/test').Page }> {
+  const context = await browser.newContext({ storageState: EMPTY_STORAGE_STATE });
+  if (initScript) {
+    await context.addInitScript(initScript);
+  }
+
+  const page = await context.newPage();
+  return { context, page };
+}
+
+async function callHeatmapEndpoint(
+  page: import('@playwright/test').Page,
+  nonce: string,
+  filters = '',
+): Promise<{ max: number; data: Array<{ x: string; y: string; value: number }> }> {
+  const response = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: {
+      action: 'slimstat_heatmap',
+      security: nonce,
+      fs: encodeBase64(filters),
+    },
+  });
+
+  expect(response.ok(), 'Heatmap endpoint should respond OK').toBeTruthy();
+  return response.json();
+}
+
+test.describe('Heatmap position sanitization', () => {
+  test.setTimeout(60_000);
+
+  test.beforeAll(async () => {
+    installOptionMutator();
+    installHeaderInjector();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await snapshotSlimstatOptions();
+    await clearStatsTable();
+    clearHeaderOverrides();
+    await setSlimstatOptions(page, {
+      is_tracking: 'on',
+      javascript_mode: 'on',
+      ignore_wp_users: 'off',
+      ignore_capabilities: '',
+      set_tracker_cookie: 'on',
+      gdpr_enabled: 'off',
+      consent_integration: 'wp_consent_api',
+      tracking_request_method: 'rest',
+      do_not_track: 'off',
+      addon_heatmap_enable: 'off',
+      anonymous_tracking: 'off',
+    });
+  });
+
+  test.afterEach(async () => {
+    await restoreSlimstatOptions();
+    clearHeaderOverrides();
+  });
+
+  test.afterAll(async () => {
+    uninstallHeaderInjector();
+    uninstallOptionMutator();
+    await closeDb();
+  });
+
+  test('click event preserves comma-separated position via REST transport', async ({ page }) => {
+    const marker = `heatmap-pos-rest-${Date.now()}`;
+    await setSlimstatOptions(page, { gdpr_enabled: 'off', tracking_request_method: 'rest' });
+
+    await page.goto(`${BASE_URL}/?e2e=${marker}`, { waitUntil: 'domcontentloaded' });
+
+    const stat = await waitForPageviewRow(marker, 15_000);
+    expect(stat).not.toBeNull();
+
+    const trackerId = await waitForTrackerId(page);
+    const restUrl = await page.evaluate(() => (window as any).SlimStatParams?.ajaxurl_rest || '');
+    expect(restUrl).toBeTruthy();
+
+    const response = await page.request.post(restUrl, {
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+      data: `action=slimtrack&id=${trackerId}&pos=320,480`,
+    });
+    expect(response.status()).toBe(200);
+
+    const event = await waitForEventRow(stat!.id, 10_000);
+    expect(event).not.toBeNull();
+    expect(event!.position).toBe('320,480');
+  });
+
+  test('click event preserves comma-separated position via AJAX transport', async ({ page }) => {
+    const marker = `heatmap-pos-ajax-${Date.now()}`;
+    await setSlimstatOptions(page, { gdpr_enabled: 'off', tracking_request_method: 'ajax' });
+
+    await page.goto(`${BASE_URL}/?e2e=${marker}`, { waitUntil: 'domcontentloaded' });
+
+    const stat = await waitForPageviewRow(marker, 15_000);
+    expect(stat).not.toBeNull();
+
+    const trackerId = await waitForTrackerId(page);
+    const response = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+      form: { action: 'slimtrack', id: trackerId, pos: '320,480' },
+    });
+    expect(response.ok()).toBeTruthy();
+
+    const event = await waitForEventRow(stat!.id, 10_000);
+    expect(event).not.toBeNull();
+    expect(event!.position).toBe('320,480');
+  });
+
+  test('default position 0,0 is preserved', async ({ page }) => {
+    const marker = `heatmap-pos-origin-${Date.now()}`;
+    await setSlimstatOptions(page, { gdpr_enabled: 'off', tracking_request_method: 'rest' });
+
+    await page.goto(`${BASE_URL}/?e2e=${marker}`, { waitUntil: 'domcontentloaded' });
+
+    const stat = await waitForPageviewRow(marker, 15_000);
+    expect(stat).not.toBeNull();
+
+    const trackerId = await waitForTrackerId(page);
+    const restUrl = await page.evaluate(() => (window as any).SlimStatParams?.ajaxurl_rest || '');
+    expect(restUrl).toBeTruthy();
+
+    const response = await page.request.post(restUrl, {
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+      data: `action=slimtrack&id=${trackerId}&pos=0,0`,
+    });
+    expect(response.status()).toBe(200);
+
+    const event = await waitForEventRow(stat!.id, 10_000);
+    expect(event).not.toBeNull();
+    expect(event!.position).toBe('0,0');
+  });
+
+  test('heatmap endpoint excludes corrupted positions and returns x/y/value entries', async ({ page }) => {
+    test.skip(!(await isProActive(page)), 'WP SlimStat Pro is not installed/active');
+
+    await setSlimstatOptions(page, { addon_heatmap_enable: 'on' });
+
+    const resourcePrefix = `/heatmap-test-${Date.now()}-`;
+    await seedPageviews({ count: 1, resourcePrefix });
+    const stat = await getLatestStatSummary(resourcePrefix);
+    expect(stat).not.toBeNull();
+
+    await seedEventRow(stat!.id, '320,480');
+    await seedEventRow(stat!.id, '320480');
+    await seedEventRow(stat!.id, '50,75');
+
+    const nonce = await getHeatmapNonce(page);
+    const payload = await callHeatmapEndpoint(page, nonce, `resource starts_with ${resourcePrefix}`);
+
+    expect(payload.data).toHaveLength(2);
+    expect(payload.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ x: '320', y: '480', value: 1 }),
+        expect.objectContaining({ x: '50', y: '75', value: 1 }),
+      ]),
+    );
+  });
+
+  test('multiple clicks aggregate correctly in heatmap data', async ({ page }) => {
+    test.skip(!(await isProActive(page)), 'WP SlimStat Pro is not installed/active');
+
+    await setSlimstatOptions(page, { addon_heatmap_enable: 'on' });
+
+    const resourcePrefix = `/heatmap-aggregate-${Date.now()}-`;
+    await seedPageviews({ count: 1, resourcePrefix });
+    const stat = await getLatestStatSummary(resourcePrefix);
+    expect(stat).not.toBeNull();
+
+    await seedEventRow(stat!.id, '100,200');
+    await seedEventRow(stat!.id, '100,200');
+    await seedEventRow(stat!.id, '100,200');
+    await seedEventRow(stat!.id, '300,400');
+    await seedEventRow(stat!.id, '300,400');
+
+    const nonce = await getHeatmapNonce(page);
+    const payload = await callHeatmapEndpoint(page, nonce, `resource starts_with ${resourcePrefix}`);
+
+    expect(payload.data).toHaveLength(2);
+    expect(payload.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ x: '100', y: '200', value: 3 }),
+        expect.objectContaining({ x: '300', y: '400', value: 2 }),
+      ]),
+    );
+    expect(payload.max).toBe(3);
+  });
+
+  test('GDPR enabled with granted consent records interaction position via browser click', async ({ browser, page }) => {
+    await setSlimstatOptions(page, {
+      gdpr_enabled: 'on',
+      consent_integration: 'wp_consent_api',
+      tracking_request_method: 'rest',
+    });
+
+    const { context, page: anonPage } = await createAnonymousPage(browser, () => {
+      Object.defineProperty(window, 'wp_has_consent', {
+        configurable: true,
+        value: () => true,
+      });
+      Object.defineProperty(window, 'wp_consent_type', {
+        configurable: true,
+        value: 'optin',
+      });
+    });
+
+    try {
+      const marker = `heatmap-consent-allow-${Date.now()}`;
+      const capture = captureTrackingPayloads(anonPage);
+
+      await anonPage.goto(`${BASE_URL}/?e2e=${marker}`, { waitUntil: 'domcontentloaded' });
+
+      const stat = await waitForPageviewRow(marker, 15_000);
+      expect(stat).not.toBeNull();
+
+      capture.reset();
+      await injectClickTarget(anonPage);
+      await anonPage.click('#slimstat-e2e-click-target');
+      await anonPage.waitForTimeout(2_000);
+
+      expect(capture.payloads.some((payload) => payload.includes('pos='))).toBe(true);
+
+      const event = await waitForEventRow(stat!.id, 10_000);
+      expect(event).not.toBeNull();
+      expect(event!.position || '').toMatch(/^\d{1,5},\d{1,5}$/);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('GDPR enabled with denied consent does not send interaction tracking', async ({ browser, page }) => {
+    await setSlimstatOptions(page, {
+      gdpr_enabled: 'on',
+      consent_integration: 'wp_consent_api',
+      tracking_request_method: 'rest',
+    });
+
+    const { context, page: anonPage } = await createAnonymousPage(browser, () => {
+      Object.defineProperty(window, 'wp_has_consent', {
+        configurable: true,
+        value: () => false,
+      });
+      Object.defineProperty(window, 'wp_consent_type', {
+        configurable: true,
+        value: 'optin',
+      });
+    });
+
+    try {
+      const marker = `heatmap-consent-deny-${Date.now()}`;
+      const capture = captureTrackingPayloads(anonPage);
+
+      await anonPage.goto(`${BASE_URL}/?e2e=${marker}`, { waitUntil: 'domcontentloaded' });
+      await anonPage.waitForTimeout(1_500);
+
+      capture.reset();
+      await injectClickTarget(anonPage);
+      await anonPage.click('#slimstat-e2e-click-target');
+      await anonPage.waitForTimeout(2_000);
+
+      expect(capture.payloads.some((payload) => payload.includes('pos='))).toBe(false);
+      expect(await getEventCount()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('browser DNT signal blocks interaction tracking requests', async ({ browser, page }) => {
+    await setSlimstatOptions(page, {
+      do_not_track: 'on',
+      tracking_request_method: 'rest',
+      gdpr_enabled: 'off',
+    });
+
+    const { context, page: anonPage } = await createAnonymousPage(browser, () => {
+      Object.defineProperty(Navigator.prototype, 'doNotTrack', {
+        configurable: true,
+        get: () => '1',
+      });
+    });
+
+    try {
+      const marker = `heatmap-dnt-${Date.now()}`;
+      const capture = captureTrackingPayloads(anonPage);
+
+      await anonPage.goto(`${BASE_URL}/?e2e=${marker}`, { waitUntil: 'domcontentloaded' });
+      await anonPage.waitForTimeout(1_500);
+
+      capture.reset();
+      await injectClickTarget(anonPage);
+      await anonPage.click('#slimstat-e2e-click-target');
+      await anonPage.waitForTimeout(2_000);
+
+      expect(capture.payloads.some((payload) => payload.includes('pos='))).toBe(false);
+      expect(await getEventCount()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -660,7 +660,7 @@ export async function waitForEventRow(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const [rows] = await getPool().execute(
-      'SELECT id, position, notes, dt FROM wp_slim_events WHERE id = ? LIMIT 1',
+      'SELECT id, position, notes, dt FROM wp_slim_events WHERE id = ? ORDER BY event_id DESC LIMIT 1',
       [statId],
     ) as any;
     if (rows.length > 0) return rows[0];

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -647,6 +647,44 @@ export async function waitForTrackerId(page: import('@playwright/test').Page): P
   return page.evaluate(() => (window as any).SlimStatParams?.id ?? '');
 }
 
+// ─── Event row helpers ───────────────────────────────────────────
+
+/**
+ * Poll wp_slim_events for a row matching the given stat id.
+ * Returns the first match or null on timeout.
+ */
+export async function waitForEventRow(
+  statId: number,
+  timeoutMs = 20_000,
+): Promise<{ id: number; position: string | null; notes: string | null; dt: number } | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const [rows] = await getPool().execute(
+      'SELECT id, position, notes, dt FROM wp_slim_events WHERE id = ? LIMIT 1',
+      [statId],
+    ) as any;
+    if (rows.length > 0) return rows[0];
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return null;
+}
+
+/**
+ * Insert a row into wp_slim_events.
+ * The statId MUST reference an existing wp_slim_stats.id (FK constraint).
+ */
+export async function seedEventRow(
+  statId: number,
+  position: string,
+  dt?: number,
+): Promise<void> {
+  const timestamp = dt ?? Math.floor(Date.now() / 1000);
+  await getPool().execute(
+    'INSERT INTO wp_slim_events (id, position, dt) VALUES (?, ?, ?)',
+    [statId, position, timestamp],
+  );
+}
+
 // ─── Scenario helpers ────────────────────────────────────────────
 
 export async function simulateFreshInstall(): Promise<void> {

--- a/tests/e2e/user-overview-login-tracking.spec.ts
+++ b/tests/e2e/user-overview-login-tracking.spec.ts
@@ -1,0 +1,353 @@
+/**
+ * E2E: User Overview (slim_p8_01) — Login Tracking & Display
+ *
+ * Tests that the User Overview panel correctly:
+ * 1. Records login notes via cookie or username fallback
+ * 2. Displays Last Login, Login Count, and handles zero registration dates
+ * 3. Shows all users regardless of date filter
+ */
+import { test, expect } from '@playwright/test';
+import {
+  getPool,
+  closeDb,
+  clearStatsTable,
+  setSlimstatSetting,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+  enableDisableWpCron,
+  restoreWpConfig,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+
+// ─── DB helpers ──────────────────────────────────────────────────
+
+async function seedPageviewWithNotes(
+  username: string,
+  notes: string | null,
+  dt: number,
+  visitId: number = 1
+): Promise<number> {
+  const [result] = (await getPool().execute(
+    `INSERT INTO wp_slim_stats (resource, dt, ip, visit_id, browser, platform, content_type, username, notes)
+     VALUES ('/e2e-user-overview', ?, '127.0.0.1', ?, 'Chrome', 'Windows', 'post', ?, ?)`,
+    [dt, visitId, username, notes]
+  )) as any;
+  return result.insertId;
+}
+
+async function getLoginNotes(): Promise<any[]> {
+  const [rows] = (await getPool().execute(
+    "SELECT id, notes, username, dt FROM wp_slim_stats WHERE notes LIKE '%loggedin:%' ORDER BY id DESC"
+  )) as any;
+  return rows;
+}
+
+async function deleteTransientCaches(): Promise<void> {
+  await getPool().execute(
+    "DELETE FROM wp_options WHERE option_name LIKE '%slimstat_query_%'"
+  );
+}
+
+async function loginAsGerlando(
+  browser: import('@playwright/test').Browser
+): Promise<{
+  context: import('@playwright/test').BrowserContext;
+  page: import('@playwright/test').Page;
+}> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto(`${BASE_URL}/wp-login.php`, {
+    waitUntil: 'domcontentloaded',
+  });
+  await page.fill('#user_login', 'gerlando');
+  await page.fill('#user_pass', 'gerlando');
+  await page.click('#wp-submit');
+  await page.waitForURL('**/wp-admin/**', {
+    timeout: 45_000,
+    waitUntil: 'domcontentloaded',
+  });
+  return { context, page };
+}
+
+function getUserOverviewData(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const panel = document.getElementById('slim_p8_01');
+    if (!panel) return null;
+    const table = panel.querySelector('table');
+    if (!table) return null;
+    const rows = table.querySelectorAll('tbody tr');
+    const users: Record<string, Record<string, string>> = {};
+    const headers = [
+      'username',
+      'company',
+      'fullName',
+      'email',
+      'registered',
+      'lastLogin',
+      'pageviews',
+      'loginCount',
+      'timeOnSite',
+    ];
+    rows.forEach((row) => {
+      const cells = row.querySelectorAll('td');
+      const data: Record<string, string> = {};
+      cells.forEach((c, i) => (data[headers[i] || String(i)] = c.textContent!.trim()));
+      if (data.username) users[data.username] = data;
+    });
+    return { totalRows: rows.length, users };
+  });
+}
+
+// ─── Shared setup/teardown ───────────────────────────────────────
+
+test.describe('User Overview (slim_p8_01)', () => {
+  test.setTimeout(90_000);
+
+  test.beforeAll(async () => {
+    enableDisableWpCron();
+    await snapshotSlimstatOptions();
+    await setSlimstatSetting('gdpr_enabled', 'off');
+    await setSlimstatSetting('is_tracking', 'on');
+  });
+
+  test.afterAll(async () => {
+    await restoreSlimstatOptions();
+    restoreWpConfig();
+    await closeDb();
+  });
+
+  // ─── Login Tracking ──────────────────────────────────────────
+
+  test.describe('Login Tracking', () => {
+    test.beforeEach(async () => {
+      await clearStatsTable();
+      await deleteTransientCaches();
+    });
+
+    test('login note is written via username fallback when cookie is absent', async ({
+      browser,
+    }) => {
+      const now = Math.floor(Date.now() / 1000);
+      await seedPageviewWithNotes('gerlando', '[user:6]', now);
+
+      const { context, page } = await loginAsGerlando(browser);
+      await page.waitForTimeout(2000);
+
+      const loginNotes = await getLoginNotes();
+      expect(loginNotes.length).toBeGreaterThanOrEqual(1);
+
+      const note = loginNotes.find(
+        (row: any) => row.notes && row.notes.includes('loggedin:gerlando')
+      );
+      expect(note).toBeDefined();
+      expect(note.notes).toContain('[loggedin:gerlando]');
+      expect(note.notes).not.toContain(';loggedin:gerlando');
+
+      await context.close();
+    });
+
+    test('login note is NOT written when no recent pageview exists', async ({
+      browser,
+    }) => {
+      const { context, page } = await loginAsGerlando(browser);
+      await page.waitForTimeout(2000);
+
+      const loginNotes = await getLoginNotes();
+      const staleNotes = loginNotes.filter(
+        (row: any) =>
+          row.notes &&
+          row.notes.includes('[loggedin:gerlando]') &&
+          row.resource === '/e2e-user-overview'
+      );
+      expect(staleNotes.length).toBe(0);
+
+      await context.close();
+    });
+
+    test('login note is NOT written to stale pageview (>1 hour old)', async ({
+      browser,
+    }) => {
+      const twoHoursAgo = Math.floor(Date.now() / 1000) - 7200;
+      const rowId = await seedPageviewWithNotes('gerlando', '[user:6]', twoHoursAgo);
+
+      const { context, page } = await loginAsGerlando(browser);
+      await page.waitForTimeout(2000);
+
+      const [rows] = (await getPool().execute(
+        'SELECT notes FROM wp_slim_stats WHERE id = ?',
+        [rowId]
+      )) as any;
+      expect(rows[0].notes).toBe('[user:6]');
+      expect(rows[0].notes).not.toContain('loggedin:');
+
+      await context.close();
+    });
+
+    test('duplicate login notes are prevented', async ({ browser }) => {
+      const now = Math.floor(Date.now() / 1000);
+      await seedPageviewWithNotes('gerlando', '[loggedin:gerlando]', now);
+
+      const { context, page } = await loginAsGerlando(browser);
+      await page.waitForTimeout(2000);
+
+      const [rows] = (await getPool().execute(
+        "SELECT notes FROM wp_slim_stats WHERE notes LIKE '%loggedin:gerlando%' AND resource = '/e2e-user-overview'"
+      )) as any;
+
+      for (const row of rows) {
+        const count = (row.notes.match(/\[loggedin:gerlando\]/g) || []).length;
+        expect(count).toBeLessThanOrEqual(1);
+      }
+
+      await context.close();
+    });
+  });
+
+  // ─── Panel Display ─────────────────────────────────────────────
+
+  test.describe('Panel Display', () => {
+    test('Audience page renders User Overview with correct columns', async ({
+      browser,
+    }) => {
+      const { context, page } = await loginAsGerlando(browser);
+      await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`, {
+        waitUntil: 'domcontentloaded',
+      });
+
+      const columns = await page.evaluate(() => {
+        const panel = document.getElementById('slim_p8_01');
+        if (!panel) return [];
+        const ths = panel.querySelectorAll('thead th');
+        return Array.from(ths).map((th) => th.textContent!.trim());
+      });
+
+      expect(columns).toContain('Username');
+      expect(columns).toContain('Full Name');
+      expect(columns).toContain('Email');
+      expect(columns).toContain('Registered');
+      expect(columns).toContain('Last Login');
+      expect(columns).toContain('Pageviews');
+      expect(columns).toContain('Login Count');
+      expect(columns).toContain('Time on Site');
+
+      await context.close();
+    });
+
+    test('Last Login and Login Count show data when login notes exist', async ({
+      browser,
+    }) => {
+      await clearStatsTable();
+      await deleteTransientCaches();
+
+      const now = Math.floor(Date.now() / 1000);
+      await seedPageviewWithNotes('gerlando', '[loggedin:gerlando][user:6]', now, 1);
+      await seedPageviewWithNotes('gerlando', '[loggedin:gerlando][user:6]', now - 3600, 2);
+      await seedPageviewWithNotes('gerlando', '[loggedin:gerlando][user:6]', now - 7200, 3);
+
+      const { context, page } = await loginAsGerlando(browser);
+      await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`, {
+        waitUntil: 'domcontentloaded',
+      });
+
+      const data = await getUserOverviewData(page);
+      expect(data).not.toBeNull();
+      expect(data!.users['gerlando']).toBeDefined();
+
+      const gerlando = data!.users['gerlando'];
+      expect(gerlando.lastLogin).not.toBe('Never');
+      expect(gerlando.loginCount).not.toBe('-');
+      expect(parseInt(gerlando.loginCount)).toBeGreaterThan(0);
+
+      await context.close();
+    });
+
+    test('zero registration date displays as dash', async ({ browser }) => {
+      const { context, page } = await loginAsGerlando(browser);
+      await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`, {
+        waitUntil: 'domcontentloaded',
+      });
+
+      const hasZeroDate = await page.evaluate(() => {
+        const panel = document.getElementById('slim_p8_01');
+        if (!panel) return false;
+        const cells = panel.querySelectorAll('tbody td');
+        return Array.from(cells).some(
+          (c) => c.textContent!.trim() === '0000-00-00 00:00:00'
+        );
+      });
+
+      expect(hasZeroDate).toBe(false);
+      await context.close();
+    });
+  });
+
+  // ─── Date Filter Regression ────────────────────────────────────
+
+  test.describe('Date Filter Regression', () => {
+    test('user with pageviews appears with type=today filter', async ({
+      browser,
+    }) => {
+      await clearStatsTable();
+      await deleteTransientCaches();
+
+      const now = Math.floor(Date.now() / 1000);
+      for (let i = 0; i < 5; i++) {
+        await seedPageviewWithNotes('gerlando', '[user:6]', now - i * 60, i + 1);
+      }
+
+      const { context, page } = await loginAsGerlando(browser);
+      await page.goto(
+        `${BASE_URL}/wp-admin/admin.php?page=slimview3&type=today`,
+        { waitUntil: 'domcontentloaded' }
+      );
+
+      const data = await getUserOverviewData(page);
+      expect(data).not.toBeNull();
+      expect(data!.users['gerlando']).toBeDefined();
+      expect(parseInt(data!.users['gerlando'].pageviews)).toBeGreaterThanOrEqual(5);
+
+      await context.close();
+    });
+
+    test('user appears even when filtered to a different date (zero-pageviews set)', async ({
+      browser,
+    }) => {
+      await clearStatsTable();
+      await deleteTransientCaches();
+
+      const yesterday = Math.floor(Date.now() / 1000) - 86400;
+      await seedPageviewWithNotes('gerlando', '[user:6]', yesterday);
+
+      const { context, page } = await loginAsGerlando(browser);
+      await page.goto(
+        `${BASE_URL}/wp-admin/admin.php?page=slimview3&type=today`,
+        { waitUntil: 'domcontentloaded' }
+      );
+
+      const data = await getUserOverviewData(page);
+      expect(data).not.toBeNull();
+      expect(data!.users['gerlando']).toBeDefined();
+
+      await context.close();
+    });
+
+    test('all site users appear with empty stats table', async ({
+      browser,
+    }) => {
+      await clearStatsTable();
+      await deleteTransientCaches();
+
+      const { context, page } = await loginAsGerlando(browser);
+      await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`, {
+        waitUntil: 'domcontentloaded',
+      });
+
+      const data = await getUserOverviewData(page);
+      expect(data).not.toBeNull();
+      expect(data!.totalRows).toBeGreaterThan(0);
+      expect(data!.users['gerlando']).toBeDefined();
+
+      await context.close();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR bundles several bug fixes, refactors, and test coverage improvements targeting report pagination, Access Log UX, heatmap data integrity, and user overview tracking.

### Heatmap Position Sanitization (#278)
- **Extract `sanitizePosition()`** static method on `Ajax` class — replaces inline regex that stripped commas from click coordinates (`"320,480"` → `"320480"`)
- **New regex**: `/[^0-9,]/` strip + `/^\d{1,5},\d{1,5}$/` format validation (was `/[^a-zA-Z0-9\-_]/` which removed commas)
- 19-case unit test + 8 E2E tests (transports, heatmap endpoint, consent, DNT)

### User Overview Login Tracking
- E2E tests validating login event tracking and display in the User Overview panel (`slim_p8_01`)

### Report Pagination Overhaul (#287, #290)
- **SQL OFFSET distribution** across split date-range partitions — fixes page drift on multi-partition queries
- **Re-apply LIMIT after split-query merge** for top reports — prevents excess rows leaking through
- **Re-sort top reports** after merge to maintain correct ordering
- **Deduplicate Recent Users, Posts, and 404s** via `get_top` with proper SQL grouping
- **Stable pagination total count** for recent reports with `total_callback` support
- **`get_report_total_count()`** now honors `use_date_filters` flag
- Comprehensive pagination sweep E2E tests across all slimview pages
- Top report sort accuracy E2E tests

### Access Log UX (#156, #258, #287, #288)
- **Native CSS scroll**: replaced SlimScroll jQuery wrapper with `overflow-y: auto` — removes plugin dependency and fixes scroll jank
- **Auto-refresh**: stops countdown on pages other than page 1; resumes from frozen point after hover; kills pending timeout on mouseenter to prevent race conditions
- **Date pagination**: proper forward/backward navigation through date ranges
- **CSS fix**: prevent `float:right` on refresh-countdown span
- **Hide `[Refresh in]` text** on non-page-1 Access Log pages
- E2E tests for auto-refresh, date pagination, and native scroll

### Outbound Links & Recent Panels
- **Recent Outbound Links**: switched to `get_top_outbound` for correct deduplication; added timestamp to tooltip; sorted by most recent
- **Recent panels**: deduplicated across all Recent report types; fixed sort order

### Query Engine (`src/Utils/Query.php`)
- New `Query` utility class with `sortMergedResults()` and `applyLimitOffset()` for post-merge report processing
- 253-line unit test covering sort and limit/offset edge cases

### Build & Tooling
- `.githooks/pre-commit` fast gate (`php -l` on staged PHP files)
- Regenerated autoloader without dev dependencies
- E2E test helpers: `waitForEventRow()`, `seedEventRow()`, date-filter helpers in `setup.ts`

### Changelog & Docs
- Humanized changelog entries for v5.4.2–v5.4.10
- Added top-report LIMIT fix note to v5.4.10

### RTL & Guards
- RTL layout fixes for admin panels
- Page-1 guards on pagination controls
- Top Posts TRIM fix for whitespace in titles

## Test plan

- [ ] `composer test:all` — PHP unit tests (sanitization, query sort/merge, pagination)
- [ ] `npm run test:e2e` — full E2E suite:
  - `heatmap-position-sanitization.spec.ts` — 8 tests
  - `user-overview-login-tracking.spec.ts` — login tracking + display
  - `report-pagination.spec.ts` — pagination correctness
  - `report-pagination-sweep.spec.ts` — sweep across all slimview pages
  - `top-report-sort-accuracy.spec.ts` — sort order after merge
  - `access-log-auto-refresh.spec.ts` — countdown, hover pause, page guards
  - `access-log-date-pagination.spec.ts` — date range navigation
  - `admin-panels-native-scroll.spec.ts` — native CSS overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user login tracking and overview functionality to monitor user authentication patterns.

* **Bug Fixes**
  * Improved click position validation for heatmap tracking to ensure data integrity and prevent corrupted position data.

* **Tests**
  * Added comprehensive unit and end-to-end tests for position sanitization and login tracking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->