### PR TITLE
fix: close mobile-bot safety net gap and extend BOT_GENERIC_REGEX (#14843 v2)

### DIFF
--- a/src/Services/Browscap.php
+++ b/src/Services/Browscap.php
@@ -71,10 +71,9 @@ class Browscap
             $browser['browser_version'] = $browser_version['browser_version'];
         }
 
-        // Safety net: detect bots by UA keywords when Browscap did not flag as crawler.
-        // Runs for any non-crawler type (0=desktop, 2=mobile, 3=touch) so mobile
-        // Chrome-based Googlebot/Bingbot UAs that Browscap classifies as type=2
-        // still get re-checked against BOT_GENERIC_REGEX. See #291, ticket #14843 v2.
+        // Safety net: re-check any non-crawler type (desktop/mobile/touch) against
+        // BOT_GENERIC_REGEX. Browscap misclassifies Chrome-based Googlebot mobile
+        // UAs as type=2 because Android/Mobile signals match before the bot suffix.
         if (1 !== (int) $browser['browser_type']) {
             $browser = self::apply_bot_safety_net($browser);
         }

--- a/src/Services/Browscap.php
+++ b/src/Services/Browscap.php
@@ -72,9 +72,10 @@ class Browscap
         }
 
         // Safety net: detect bots by UA keywords when Browscap did not flag as crawler.
-        // Catches Chrome-based crawlers (Googlebot, Bingbot) that Browscap may
-        // identify as regular browsers without setting crawler=true. See #291.
-        if (0 === (int) $browser['browser_type']) {
+        // Runs for any non-crawler type (0=desktop, 2=mobile, 3=touch) so mobile
+        // Chrome-based Googlebot/Bingbot UAs that Browscap classifies as type=2
+        // still get re-checked against BOT_GENERIC_REGEX. See #291, ticket #14843 v2.
+        if (1 !== (int) $browser['browser_type']) {
             $browser = self::apply_bot_safety_net($browser);
         }
 

--- a/src/Utils/UADetector.php
+++ b/src/Utils/UADetector.php
@@ -9,16 +9,7 @@ class UADetector
     //		1: crawler
     //		2: mobile
 
-    /**
-     * Generic bot detection regex — shared with Browscap::apply_bot_safety_net().
-     *
-     * Extended in ticket #14843 v2 with vendor-specific tokens for bare-name bots
-     * that don't expose a URL or conventional bot keyword: Mediapartners-Google,
-     * Google-InspectionTool, Google-Site-Verification (via verif-family), Google
-     * Favicon, GoogleOther, GoogleAgent-Mariner, Google-Safety, DuplexWeb-Google,
-     * BingPreview, YandexDirect, YandexFavicons, WhatsApp preview fetcher,
-     * SkypeUriPreview, anthropic-ai, cohere-ai.
-     */
+    /** Generic bot detection regex — shared with Browscap::apply_bot_safety_net(). */
     public const BOT_GENERIC_REGEX = '#(robot|bot[\s\-_\/\)]|bot$|blog|checker|crawl|feed|fetcher|libwww|[^\.e]link\s?|parser|reader|spider|verif(?:ier|ication|y)|href|https?\://|.+(?:\@|\s?at\s?)[a-z0-9_\-]+(?:\.|\s?dot\s?)|www[0-9]?\.[a-z0-9_\-]+\..+|\/.+\.(s?html?|aspx?|php5?|cgi)|mediapartners|inspectiontool|googleother|googleagent|google-safety|duplexweb|google\sfavicon|yandex(?:direct|favicons)|anthropic-ai|cohere-ai|bingpreview|whatsapp\/|skypeuripreview)#i';
 
     public static function get_browser($_user_agent = '')

--- a/src/Utils/UADetector.php
+++ b/src/Utils/UADetector.php
@@ -9,8 +9,17 @@ class UADetector
     //		1: crawler
     //		2: mobile
 
-    /** Generic bot detection regex — shared with Browscap::apply_bot_safety_net(). */
-    public const BOT_GENERIC_REGEX = '#(robot|bot[\s\-_\/\)]|bot$|blog|checker|crawl|feed|fetcher|libwww|[^\.e]link\s?|parser|reader|spider|verifier|href|https?\://|.+(?:\@|\s?at\s?)[a-z0-9_\-]+(?:\.|\s?dot\s?)|www[0-9]?\.[a-z0-9_\-]+\..+|\/.+\.(s?html?|aspx?|php5?|cgi))#i';
+    /**
+     * Generic bot detection regex — shared with Browscap::apply_bot_safety_net().
+     *
+     * Extended in ticket #14843 v2 with vendor-specific tokens for bare-name bots
+     * that don't expose a URL or conventional bot keyword: Mediapartners-Google,
+     * Google-InspectionTool, Google-Site-Verification (via verif-family), Google
+     * Favicon, GoogleOther, GoogleAgent-Mariner, Google-Safety, DuplexWeb-Google,
+     * BingPreview, YandexDirect, YandexFavicons, WhatsApp preview fetcher,
+     * SkypeUriPreview, anthropic-ai, cohere-ai.
+     */
+    public const BOT_GENERIC_REGEX = '#(robot|bot[\s\-_\/\)]|bot$|blog|checker|crawl|feed|fetcher|libwww|[^\.e]link\s?|parser|reader|spider|verif(?:ier|ication|y)|href|https?\://|.+(?:\@|\s?at\s?)[a-z0-9_\-]+(?:\.|\s?dot\s?)|www[0-9]?\.[a-z0-9_\-]+\..+|\/.+\.(s?html?|aspx?|php5?|cgi)|mediapartners|inspectiontool|googleother|googleagent|google-safety|duplexweb|google\sfavicon|yandex(?:direct|favicons)|anthropic-ai|cohere-ai|bingpreview|whatsapp\/|skypeuripreview)#i';
 
     public static function get_browser($_user_agent = '')
     {

--- a/tests/Unit/Utils/UADetectorBotTest.php
+++ b/tests/Unit/Utils/UADetectorBotTest.php
@@ -106,173 +106,61 @@ class UADetectorBotTest extends WpSlimstatTestCase
         $this->assertSame(1, $browser['browser_type'], 'Simple Googlebot UA must be browser_type=1');
     }
 
-    // ─────────────────────────────────────────────────────────────────────
-    // Extended bot coverage (#14843 v2) — UAs that previously slipped
-    // through BOT_GENERIC_REGEX because they lacked a bot keyword or URL.
-    // ─────────────────────────────────────────────────────────────────────
-
-    /** @test */
-    public function test_mediapartners_google_detected_as_crawler(): void
+    /**
+     * Extended bot coverage — UAs that previously slipped through
+     * BOT_GENERIC_REGEX because they lacked a bot keyword or URL.
+     *
+     * @test
+     * @dataProvider vendorBotProvider
+     */
+    public function test_vendor_bot_detected_as_crawler(string $label, string $ua): void
     {
-        $ua = 'Mediapartners-Google';
         $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'Mediapartners-Google must be browser_type=1');
+        $this->assertSame(1, $browser['browser_type'], "{$label} must be browser_type=1");
     }
 
-    /** @test */
-    public function test_google_inspection_tool_desktop_detected_as_crawler(): void
+    public function vendorBotProvider(): array
     {
-        $ua = 'Mozilla/5.0 (compatible; Google-InspectionTool/1.0)';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'Google-InspectionTool desktop must be browser_type=1');
+        return [
+            'Mediapartners-Google'          => ['Mediapartners-Google', 'Mediapartners-Google'],
+            'Google-InspectionTool desktop' => ['Google-InspectionTool desktop', 'Mozilla/5.0 (compatible; Google-InspectionTool/1.0)'],
+            'Google-InspectionTool mobile'  => ['Google-InspectionTool mobile', 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.6723.117 Mobile Safari/537.36 (compatible; Google-InspectionTool/1.0)'],
+            'Google-Site-Verification'      => ['Google-Site-Verification', 'Mozilla/5.0 (compatible; Google-Site-Verification/1.0)'],
+            'Google Favicon'                => ['Google Favicon', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36 Google Favicon'],
+            'GoogleOther'                   => ['GoogleOther', 'GoogleOther'],
+            'GoogleOther-Image'             => ['GoogleOther-Image', 'GoogleOther-Image/1.0'],
+            'GoogleAgent-Mariner'           => ['GoogleAgent-Mariner', 'GoogleAgent-Mariner'],
+            'Google-Safety'                 => ['Google-Safety', 'Google-Safety'],
+            'DuplexWeb-Google'              => ['DuplexWeb-Google', 'Mozilla/5.0 (Linux; Android 11; Pixel 2) AppleWebKit/537.36 DuplexWeb-Google/1.0'],
+            'BingPreview'                   => ['BingPreview', 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36 BingPreview/1.0b'],
+            'YandexDirect'                  => ['YandexDirect', 'YandexDirect/3.0'],
+            'YandexFavicons'                => ['YandexFavicons', 'YandexFavicons/1.0'],
+            'WhatsApp preview'              => ['WhatsApp preview', 'WhatsApp/2.19.81 A'],
+            'SkypeUriPreview'               => ['SkypeUriPreview', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 SkypeUriPreview Preview/0.5'],
+            'anthropic-ai'                  => ['anthropic-ai', 'anthropic-ai/1.0'],
+            'cohere-ai'                     => ['cohere-ai', 'cohere-ai'],
+        ];
     }
 
-    /** @test */
-    public function test_google_inspection_tool_mobile_detected_as_crawler(): void
+    /**
+     * Real browsers must never be flagged as crawlers. Guards against regex
+     * false positives introduced by future vendor-token additions.
+     *
+     * @test
+     * @dataProvider realBrowserProvider
+     */
+    public function test_real_browser_not_flagged(string $label, string $ua): void
     {
-        $ua = 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.6723.117 Mobile Safari/537.36 (compatible; Google-InspectionTool/1.0)';
         $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'Google-InspectionTool mobile must be browser_type=1');
+        $this->assertNotSame(1, $browser['browser_type'], "{$label} must NOT be browser_type=1");
     }
 
-    /** @test */
-    public function test_google_site_verification_detected_as_crawler(): void
+    public function realBrowserProvider(): array
     {
-        $ua = 'Mozilla/5.0 (compatible; Google-Site-Verification/1.0)';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'Google-Site-Verification must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_google_favicon_detected_as_crawler(): void
-    {
-        $ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36 Google Favicon';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'Google Favicon must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_googleother_detected_as_crawler(): void
-    {
-        $ua = 'GoogleOther';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'GoogleOther must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_googleother_image_detected_as_crawler(): void
-    {
-        $ua = 'GoogleOther-Image/1.0';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'GoogleOther-Image must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_googleagent_mariner_detected_as_crawler(): void
-    {
-        $ua = 'GoogleAgent-Mariner';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'GoogleAgent-Mariner must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_google_safety_detected_as_crawler(): void
-    {
-        $ua = 'Google-Safety';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'Google-Safety must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_duplexweb_google_detected_as_crawler(): void
-    {
-        $ua = 'Mozilla/5.0 (Linux; Android 11; Pixel 2) AppleWebKit/537.36 DuplexWeb-Google/1.0';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'DuplexWeb-Google must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_bingpreview_detected_as_crawler(): void
-    {
-        $ua = 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36 BingPreview/1.0b';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'BingPreview must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_yandexdirect_detected_as_crawler(): void
-    {
-        $ua = 'YandexDirect/3.0';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'YandexDirect must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_yandexfavicons_detected_as_crawler(): void
-    {
-        $ua = 'YandexFavicons/1.0';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'YandexFavicons must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_whatsapp_preview_detected_as_crawler(): void
-    {
-        $ua = 'WhatsApp/2.19.81 A';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'WhatsApp preview fetcher must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_skypeuripreview_detected_as_crawler(): void
-    {
-        $ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 SkypeUriPreview Preview/0.5';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'SkypeUriPreview must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_anthropic_ai_detected_as_crawler(): void
-    {
-        $ua = 'anthropic-ai/1.0';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'anthropic-ai must be browser_type=1');
-    }
-
-    /** @test */
-    public function test_cohere_ai_detected_as_crawler(): void
-    {
-        $ua = 'cohere-ai';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertSame(1, $browser['browser_type'], 'cohere-ai must be browser_type=1');
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // Real browser guards — ensure extended regex hasn't introduced false
-    // positives. These must pass BEFORE and AFTER the regex extension.
-    // ─────────────────────────────────────────────────────────────────────
-
-    /** @test */
-    public function test_real_edge_not_flagged(): void
-    {
-        $ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertNotSame(1, $browser['browser_type'], 'Real Edge must NOT be browser_type=1');
-    }
-
-    /** @test */
-    public function test_real_safari_ios_not_flagged(): void
-    {
-        $ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertNotSame(1, $browser['browser_type'], 'Real Safari iOS must NOT be browser_type=1');
-    }
-
-    /** @test */
-    public function test_real_chrome_android_not_flagged(): void
-    {
-        $ua = 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Mobile Safari/537.36';
-        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
-        $this->assertNotSame(1, $browser['browser_type'], 'Real Chrome Android must NOT be browser_type=1');
+        return [
+            'Edge'            => ['Real Edge', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0'],
+            'Safari iOS'      => ['Real Safari iOS', 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'],
+            'Chrome Android'  => ['Real Chrome Android', 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Mobile Safari/537.36'],
+        ];
     }
 }

--- a/tests/Unit/Utils/UADetectorBotTest.php
+++ b/tests/Unit/Utils/UADetectorBotTest.php
@@ -119,7 +119,7 @@ class UADetectorBotTest extends WpSlimstatTestCase
         $this->assertSame(1, $browser['browser_type'], "{$label} must be browser_type=1");
     }
 
-    public function vendorBotProvider(): array
+    public static function vendorBotProvider(): array
     {
         return [
             'Mediapartners-Google'          => ['Mediapartners-Google', 'Mediapartners-Google'],
@@ -155,7 +155,7 @@ class UADetectorBotTest extends WpSlimstatTestCase
         $this->assertNotSame(1, $browser['browser_type'], "{$label} must NOT be browser_type=1");
     }
 
-    public function realBrowserProvider(): array
+    public static function realBrowserProvider(): array
     {
         return [
             'Edge'            => ['Real Edge', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0'],

--- a/tests/Unit/Utils/UADetectorBotTest.php
+++ b/tests/Unit/Utils/UADetectorBotTest.php
@@ -105,4 +105,174 @@ class UADetectorBotTest extends WpSlimstatTestCase
 
         $this->assertSame(1, $browser['browser_type'], 'Simple Googlebot UA must be browser_type=1');
     }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Extended bot coverage (#14843 v2) — UAs that previously slipped
+    // through BOT_GENERIC_REGEX because they lacked a bot keyword or URL.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /** @test */
+    public function test_mediapartners_google_detected_as_crawler(): void
+    {
+        $ua = 'Mediapartners-Google';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'Mediapartners-Google must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_google_inspection_tool_desktop_detected_as_crawler(): void
+    {
+        $ua = 'Mozilla/5.0 (compatible; Google-InspectionTool/1.0)';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'Google-InspectionTool desktop must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_google_inspection_tool_mobile_detected_as_crawler(): void
+    {
+        $ua = 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.6723.117 Mobile Safari/537.36 (compatible; Google-InspectionTool/1.0)';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'Google-InspectionTool mobile must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_google_site_verification_detected_as_crawler(): void
+    {
+        $ua = 'Mozilla/5.0 (compatible; Google-Site-Verification/1.0)';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'Google-Site-Verification must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_google_favicon_detected_as_crawler(): void
+    {
+        $ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36 Google Favicon';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'Google Favicon must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_googleother_detected_as_crawler(): void
+    {
+        $ua = 'GoogleOther';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'GoogleOther must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_googleother_image_detected_as_crawler(): void
+    {
+        $ua = 'GoogleOther-Image/1.0';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'GoogleOther-Image must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_googleagent_mariner_detected_as_crawler(): void
+    {
+        $ua = 'GoogleAgent-Mariner';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'GoogleAgent-Mariner must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_google_safety_detected_as_crawler(): void
+    {
+        $ua = 'Google-Safety';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'Google-Safety must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_duplexweb_google_detected_as_crawler(): void
+    {
+        $ua = 'Mozilla/5.0 (Linux; Android 11; Pixel 2) AppleWebKit/537.36 DuplexWeb-Google/1.0';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'DuplexWeb-Google must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_bingpreview_detected_as_crawler(): void
+    {
+        $ua = 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36 BingPreview/1.0b';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'BingPreview must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_yandexdirect_detected_as_crawler(): void
+    {
+        $ua = 'YandexDirect/3.0';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'YandexDirect must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_yandexfavicons_detected_as_crawler(): void
+    {
+        $ua = 'YandexFavicons/1.0';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'YandexFavicons must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_whatsapp_preview_detected_as_crawler(): void
+    {
+        $ua = 'WhatsApp/2.19.81 A';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'WhatsApp preview fetcher must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_skypeuripreview_detected_as_crawler(): void
+    {
+        $ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 SkypeUriPreview Preview/0.5';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'SkypeUriPreview must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_anthropic_ai_detected_as_crawler(): void
+    {
+        $ua = 'anthropic-ai/1.0';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'anthropic-ai must be browser_type=1');
+    }
+
+    /** @test */
+    public function test_cohere_ai_detected_as_crawler(): void
+    {
+        $ua = 'cohere-ai';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertSame(1, $browser['browser_type'], 'cohere-ai must be browser_type=1');
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Real browser guards — ensure extended regex hasn't introduced false
+    // positives. These must pass BEFORE and AFTER the regex extension.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /** @test */
+    public function test_real_edge_not_flagged(): void
+    {
+        $ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertNotSame(1, $browser['browser_type'], 'Real Edge must NOT be browser_type=1');
+    }
+
+    /** @test */
+    public function test_real_safari_ios_not_flagged(): void
+    {
+        $ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertNotSame(1, $browser['browser_type'], 'Real Safari iOS must NOT be browser_type=1');
+    }
+
+    /** @test */
+    public function test_real_chrome_android_not_flagged(): void
+    {
+        $ua = 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Mobile Safari/537.36';
+        $browser = \SlimStat\Utils\UADetector::get_browser($ua);
+        $this->assertNotSame(1, $browser['browser_type'], 'Real Chrome Android must NOT be browser_type=1');
+    }
 }

--- a/tests/browscap-bot-safety-net-test.php
+++ b/tests/browscap-bot-safety-net-test.php
@@ -137,8 +137,8 @@ safety_assert(
 // ═══════════════════════════════════════════════════════════════════════════
 $required_regex_tokens = [
     'mediapartners', 'inspectiontool', 'googleother', 'googleagent',
-    'google-safety', 'duplexweb', 'bingpreview', 'yandexdirect',
-    'yandexfavicons', 'anthropic-ai', 'cohere-ai', 'skypeuripreview',
+    'google-safety', 'duplexweb', 'bingpreview', 'yandex',
+    'direct|favicons', 'anthropic-ai', 'cohere-ai', 'skypeuripreview',
     'whatsapp', 'favicon', 'verif',
 ];
 foreach ($required_regex_tokens as $token) {

--- a/tests/browscap-bot-safety-net-test.php
+++ b/tests/browscap-bot-safety-net-test.php
@@ -75,11 +75,18 @@ safety_assert(
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
-// TEST 6: Safety net must only run when browser_type is 0
+// TEST 6: Safety net gate must run for any non-crawler type (#14843 v2).
+// Previously only fired on type=0 — mobile bot UAs (type=2) slipped through.
+// The gate must be `1 !== (int) $browser['browser_type']` so types 0, 2, 3
+// all re-run the UA keyword check.
 // ═══════════════════════════════════════════════════════════════════════════
 safety_assert(
-    (bool) preg_match('/0\s*===.*browser_type.*apply_bot_safety_net/s', $browscap_src),
-    'TEST 6: Safety net call must be guarded by browser_type === 0 check'
+    (bool) preg_match('/1\s*!==.*browser_type.*apply_bot_safety_net/s', $browscap_src),
+    'TEST 6: Safety net call must be guarded by `1 !== (int) browser_type` (not `0 ===`)'
+);
+safety_assert(
+    false === strpos($browscap_src, "0 === (int) \$browser['browser_type']"),
+    'TEST 6b: Safety net must not use the old `0 === (int) browser_type` gate'
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -120,5 +127,25 @@ safety_assert(
     false !== strpos($ajax_src, "ignore_bots") && false !== strpos($ajax_src, 'Browscap::get_browser'),
     'TEST 10: Ajax.php must check ignore_bots via Browscap::get_browser() for follow-up events'
 );
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TEST 11: BOT_GENERIC_REGEX must include the 16 new keywords (#14843 v2)
+// Closes gaps for: Mediapartners-Google, Google-InspectionTool, Google-Site-
+// Verification, Google Favicon, GoogleOther, GoogleAgent-Mariner, Google-Safety,
+// DuplexWeb-Google, BingPreview, YandexDirect, YandexFavicons, WhatsApp,
+// SkypeUriPreview, anthropic-ai, cohere-ai.
+// ═══════════════════════════════════════════════════════════════════════════
+$required_regex_tokens = [
+    'mediapartners', 'inspectiontool', 'googleother', 'googleagent',
+    'google-safety', 'duplexweb', 'bingpreview', 'yandexdirect',
+    'yandexfavicons', 'anthropic-ai', 'cohere-ai', 'skypeuripreview',
+    'whatsapp', 'favicon', 'verif',
+];
+foreach ($required_regex_tokens as $token) {
+    safety_assert(
+        false !== stripos($uadetector_src, $token),
+        "TEST 11: BOT_GENERIC_REGEX must contain '{$token}' keyword"
+    );
+}
 
 echo "All {$assertions} assertions passed in browscap-bot-safety-net-test.php\n";


### PR DESCRIPTION
## Summary

Bob Boyd (ticket #14843) reported that Google bots are still being tracked on v5.4.11 — confirmed in his access log by `66.249.79.*` hits showing `type2.png` (browser_type=2 = mobile), not type=1 (crawler). The safety net we shipped in PR #292 only fired when `browser_type === 0`, so mobile-classified Chrome-based Googlebot UAs slipped past it.

This PR closes the gap plus 16 other real-world bot UAs found during a systematic audit.

## Root Cause

`Browscap::get_browser()` at line 77 gated the safety net on `0 === browser_type`. The mobile Googlebot UA (`Mozilla/5.0 (Linux; Android…) Chrome/… Mobile Safari/… (compatible; Googlebot/2.1; …)`) triggers Browscap's Android/Mobile branch first (returns type=2) before it ever considers the Googlebot suffix. Safety net skipped → exclusion check at `Processor.php:363` sees type=2, not type=1 → bot tracked.

## Changes

### Fix 1 — Safety net gate (`src/Services/Browscap.php:76`)

Change the condition to re-check any non-crawler type:

```diff
-if (0 === (int) $browser['browser_type']) {
+if (1 !== (int) $browser['browser_type']) {
     $browser = self::apply_bot_safety_net($browser);
}
```

`apply_bot_safety_net()` only upgrades the type when `BOT_GENERIC_REGEX` matches, so this is safe for real mobile browsers (verified via unit tests including Chrome Android, Safari iOS).

### Fix 2 — Extend `BOT_GENERIC_REGEX` (`src/Utils/UADetector.php:13`)

Added 15 vendor-specific alternations for bare-name bots that lack a URL or conventional bot keyword:

- `mediapartners` — Mediapartners-Google
- `inspectiontool` — Google-InspectionTool (desktop + mobile)
- `verif(?:ier|ication|y)` — replaces `verifier`, now catches Google-Site-Verification
- `google\sfavicon` — Google Favicon (Chrome-suffix form)
- `googleother` — GoogleOther / GoogleOther-Image / GoogleOther-Video
- `googleagent` — GoogleAgent-Mariner (new March 2026)
- `google-safety` — Google-Safety
- `duplexweb` — DuplexWeb-Google
- `bingpreview` — BingPreview
- `yandex(?:direct|favicons)` — YandexDirect, YandexFavicons
- `whatsapp\/` — WhatsApp link-preview fetcher
- `skypeuripreview` — Skype link preview
- `anthropic-ai` — Anthropic AI crawler
- `cohere-ai` — Cohere AI crawler

## Test Results

| Check | `development` branch | This branch |
|---|---|---|
| Bot regex audit (63 real-world bot UAs) | 45/63 detected | **63/63 detected** |
| False positives on 6 real browsers | 0/6 | 0/6 |
| UADetector unit tests | 13/27 pass (14 fail) | **27/27 pass** |
| Inline source verification | FAIL (TEST 6) | **All 30 assertions pass** |

Bob's exact scenario now resolves:

| UA | `development` | This branch |
|---|---|---|
| Mobile Chrome Googlebot | TRACKED (bug) | BLOCKED |
| Chrome-based Bingbot | BLOCKED | BLOCKED |
| Mediapartners-Google | TRACKED (bug) | BLOCKED |
| Real Chrome (desktop + mobile) | TRACKED | TRACKED |

## Tests Added

- `tests/Unit/Utils/UADetectorBotTest.php` — 17 vendor bot UAs (consolidated via `@dataProvider`) + 3 real-browser guards
- `tests/browscap-bot-safety-net-test.php` — updated TEST 6 for the new gate, added TEST 11 asserting all 15 new vendor tokens are present in `BOT_GENERIC_REGEX`

## Test plan

- [ ] Merge, update staging to this branch
- [ ] Run Playwright MCP regression on staging with mobile Googlebot UA + fresh browser context → verify NOT tracked
- [ ] Verify real Chrome desktop/Android still tracked
- [ ] Reply to Bob with the fix shipped in the next release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bot/crawler detection by expanding patterns to cover additional vendor and AI-related agents (Google, Yandex, Bing, WhatsApp, Skype, Anthropic/Cohere, etc.).
  * Made bot safety checks apply more consistently across device types so detected bots are handled reliably.

* **Tests**
  * Added and extended tests to validate vendor bot detection and ensure real browsers are not misclassified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->