### PR TITLE
fix(#298): Access Log filter dropdown accepts pasted/typed values beyond 500-slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+= 5.4.13 - 2026-04-20 =
+
+**Access Log filter fixes**
+
+- The Access Log filter dropdown now accepts pasted and typed values that aren't in the visible list ([#298](https://github.com/wp-slimstat/wp-slimstat/issues/298)). Previously, the dropdown pre-fetched up to 500 distinct values for the selected column and rejected anything not in that slice — so on busy sites, pasting an IP that was clearly visible in the Access Log returned "No matching options found" and the filter couldn't be applied. "Starts with" failed the same way. The widget now syncs the typed text straight into the form value, and the "no match" message tells you to click Apply to filter by the typed value.
+- The endpoint gains an optional `search` parameter backed by a prepared `LIKE` query (left-anchored for IP-like columns, substring for notes/user_agent/etc.), so the dropdown can surface matching values from the full column history instead of only the 500-row lexicographic slice. The JS debounces 250 ms, cancels in-flight requests on new keystrokes, and discards stale responses.
+- Dropdown responses are now cached by a composite key (blog, DB host, capability gate, hour-bucketed time range, effective limit, search) with a 5-minute TTL for current ranges and 1-hour TTL for historical ranges. Repeat dropdown opens no longer repeat the DISTINCT query. `uninstall.php` sweeps the new transients.
+
+**Tests**
+
+- New Playwright spec `filter-ip-beyond-500-limit.spec.ts` covers the 500-row cap characterization, server-side search (left-anchored for `ip`, substring for `user_agent`), LIKE metacharacter safety, no-match affordance, `is_empty` readonly guard, and cache TTL behavior.
+
 = 5.4.12 - 2026-04-18 =
 
 **Bot detection hardening**

--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -511,6 +511,9 @@ jQuery(function () {
             this.isOpen = false;
             this.filteredOptions = [];
             this.allOptions = [];
+            // Latched on the first setOptions() call so a later server-side
+            // search can clear back to the "like first open" list.
+            this.initialOptions = null;
 
             this.init();
         }
@@ -589,6 +592,12 @@ jQuery(function () {
             const searchInput = this.searchContainer.querySelector("input");
             searchInput.addEventListener("input", (e) => {
                 const term = e.target.value;
+                // When the user clears a server-search term back below the 2-char
+                // threshold, put the pre-fetched list back so the dropdown returns
+                // to the "like first open" state instead of staying narrowed.
+                if (this.options.serverSearchAction && term.trim().length < 2) {
+                    this.restoreInitialOptions();
+                }
                 // When a server-side search will fire for this keystroke, skip the
                 // client-side filter — its result will be replaced once the AJAX
                 // response lands, and the flash of an intermediate list is jarring.
@@ -634,6 +643,12 @@ jQuery(function () {
                     icon: opt.icon || null,
                 };
             });
+            // Latch on the first call — the dimension-change handler passes the
+            // pre-fetched 500-item list, and later server-search replacements
+            // must not overwrite it so the user can clear back to this state.
+            if (this.initialOptions === null) {
+                this.initialOptions = this.allOptions.slice();
+            }
             this.filteredOptions = [...this.allOptions];
             this.renderOptions();
         }
@@ -803,6 +818,12 @@ jQuery(function () {
             return (searchTerm || "").trim().length >= 2;
         }
 
+        restoreInitialOptions() {
+            if (!this.initialOptions) return;
+            if (this.allOptions === this.initialOptions) return;
+            this.allOptions = this.initialOptions.slice();
+        }
+
         scheduleServerSearch(searchTerm) {
             if (!this.options.serverSearchAction || !this.options.serverSearchDimension) return;
             if (this.isDisabled()) return;
@@ -959,6 +980,7 @@ jQuery(function () {
             this.allOptions = null;
             this.filteredOptions = null;
             this.selectedOption = null;
+            this.initialOptions = null;
         }
     }
 

--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -499,6 +499,7 @@ jQuery(function () {
                 placeholder: __("Select value...", "wp-slimstat"),
                 searchPlaceholder: __("Search...", "wp-slimstat"),
                 noResultsText: __("No results found", "wp-slimstat"),
+                noMatchesText: __("No matches — click Apply to filter by this value.", "wp-slimstat"),
                 loadingText: __("Loading...", "wp-slimstat"),
                 allowClear: true,
                 ...options,
@@ -587,7 +588,19 @@ jQuery(function () {
             // Search input
             const searchInput = this.searchContainer.querySelector("input");
             searchInput.addEventListener("input", (e) => {
-                this.filterOptions(e.target.value);
+                const term = e.target.value;
+                // When a server-side search will fire for this keystroke, skip the
+                // client-side filter — its result will be replaced once the AJAX
+                // response lands, and the flash of an intermediate list is jarring.
+                if (!this.willServerSearch(term)) {
+                    this.filterOptions(term);
+                }
+                this.syncTypedValue(term);
+                this.scheduleServerSearch(term);
+            });
+
+            searchInput.addEventListener("blur", () => {
+                this.dispatchChange();
             });
 
             searchInput.addEventListener("keydown", (e) => {
@@ -655,7 +668,13 @@ jQuery(function () {
                 // Create no results element safely to prevent XSS
                 const noResultsDiv = document.createElement("div");
                 noResultsDiv.className = "slimstat-select-no-results";
-                noResultsDiv.textContent = this.options.noResultsText;
+                noResultsDiv.setAttribute("data-testid", "slimstat-no-results");
+                const searchInputEl = this.searchContainer.querySelector("input");
+                const userHasTyped = searchInputEl && searchInputEl.value.trim().length > 0;
+                const hasData = this.allOptions.length > 0;
+                noResultsDiv.textContent = (userHasTyped && hasData)
+                    ? this.options.noMatchesText
+                    : this.options.noResultsText;
                 this.optionsContainer.appendChild(noResultsDiv);
                 return;
             }
@@ -754,6 +773,106 @@ jQuery(function () {
             this.element.dispatchEvent(changeEvent);
         }
 
+        isDisabled() {
+            // is_empty / is_not_empty operators mark the value field inert.
+            return this.element.readOnly || this.selectWrapper.style.pointerEvents === "none";
+        }
+
+        syncTypedValue(value) {
+            if (this.isDisabled()) return;
+            this.element.value = value;
+        }
+
+        dispatchChange() {
+            const changeEvent = new Event("change", { bubbles: true });
+            this.element.dispatchEvent(changeEvent);
+        }
+
+        updateDisplayFromValue(value) {
+            const textElement = this.display.querySelector(".slimstat-select-text");
+            textElement.innerHTML = "";
+            const labelSpan = document.createElement("span");
+            labelSpan.textContent = value;
+            textElement.appendChild(labelSpan);
+            this.display.classList.remove("slimstat-placeholder");
+        }
+
+        willServerSearch(searchTerm) {
+            if (!this.options.serverSearchAction || !this.options.serverSearchDimension) return false;
+            if (this.isDisabled()) return false;
+            return (searchTerm || "").trim().length >= 2;
+        }
+
+        scheduleServerSearch(searchTerm) {
+            if (!this.options.serverSearchAction || !this.options.serverSearchDimension) return;
+            if (this.isDisabled()) return;
+
+            const term = (searchTerm || "").trim();
+
+            if (this._searchDebounce) {
+                clearTimeout(this._searchDebounce);
+                this._searchDebounce = null;
+            }
+
+            if (this._searchAbort) {
+                try { this._searchAbort.abort(); } catch (e) { /* no-op */ }
+                this._searchAbort = null;
+            }
+
+            // Under 2 chars: fall back to legacy full DISTINCT from the initial fetch.
+            if (term.length < 2) return;
+
+            this._searchDebounce = setTimeout(() => {
+                this.runServerSearch(term);
+            }, 250);
+        }
+
+        runServerSearch(term) {
+            const hasAbort = typeof AbortController !== "undefined";
+            this._searchAbort = hasAbort ? new AbortController() : null;
+            const signal = this._searchAbort ? this._searchAbort.signal : null;
+            const timeRange = this.options.serverSearchTimeRange || { type: "last_28_days", from: "", to: "" };
+
+            jQuery.ajax({
+                method: "POST",
+                url: (typeof ajaxurl !== "undefined") ? ajaxurl : "",
+                data: {
+                    action: this.options.serverSearchAction,
+                    dimension: this.options.serverSearchDimension,
+                    security: this.options.serverSearchNonce || "",
+                    time_range_type: timeRange.type,
+                    time_range_from: timeRange.from,
+                    time_range_to: timeRange.to,
+                    search: term
+                },
+                dataType: "json",
+                timeout: 15000,
+                xhr: function () {
+                    const xhr = jQuery.ajaxSettings.xhr();
+                    if (signal) {
+                        signal.addEventListener("abort", () => {
+                            try { xhr.abort(); } catch (e) { /* no-op */ }
+                        });
+                    }
+                    return xhr;
+                }
+            })
+                .done((response) => {
+                    // Discard stale responses if the user has kept typing.
+                    const searchInputEl = this.searchContainer.querySelector("input");
+                    const currentTerm = searchInputEl ? searchInputEl.value.trim() : "";
+                    if (currentTerm !== term) {
+                        return;
+                    }
+                    if (response && response.success && Array.isArray(response.data)) {
+                        this.setOptions(response.data);
+                    }
+                })
+                .fail(() => {
+                    // On network failure fall back silently to existing client list.
+                });
+        }
+
         getValue() {
             return this.selectedValue;
         }
@@ -799,32 +918,47 @@ jQuery(function () {
             // Clear search
             const searchInput = this.searchContainer.querySelector("input");
             searchInput.value = "";
+
+            // If the user typed a value but didn't click an option, reflect it
+            // in the closed display so they see their input committed.
+            if (!this.selectedOption && this.element.value) {
+                this.updateDisplayFromValue(this.element.value);
+            }
         }
 
         destroy() {
-            // Close dropdown if open
+            if (this._searchDebounce) {
+                clearTimeout(this._searchDebounce);
+                this._searchDebounce = null;
+            }
+            if (this._searchAbort) {
+                try { this._searchAbort.abort(); } catch (e) { /* no-op */ }
+                this._searchAbort = null;
+            }
+
             if (this.isOpen) {
                 this.close();
             }
 
             // Safely remove wrapper and restore original element
             if (this.wrapper && this.element) {
-                // Move element back to its original position before wrapper
                 if (this.wrapper.parentNode) {
                     this.wrapper.parentNode.insertBefore(this.element, this.wrapper);
                 }
 
-                // Show original element
                 this.element.style.display = "";
-
-                // Clear value
                 this.element.value = "";
 
-                // Remove wrapper
                 if (this.wrapper.parentNode) {
                     this.wrapper.parentNode.removeChild(this.wrapper);
                 }
             }
+
+            // Drop references so GC can reclaim the option list + DOM subtree
+            // even if an external holder retains the instance.
+            this.allOptions = null;
+            this.filteredOptions = null;
+            this.selectedOption = null;
         }
     }
 
@@ -937,7 +1071,12 @@ jQuery(function () {
                             placeholder: __('Select value...', 'wp-slimstat'),
                             searchPlaceholder: __('Search options...', 'wp-slimstat'),
                             noResultsText: noResultsText,
-                            loadingText: __('Loading options...', 'wp-slimstat')
+                            noMatchesText: __('No matches — click Apply to filter by this value.', 'wp-slimstat'),
+                            loadingText: __('Loading options...', 'wp-slimstat'),
+                            serverSearchAction: 'slimstat_get_filter_options',
+                            serverSearchDimension: dimension,
+                            serverSearchNonce: jQuery("#meta-box-order-nonce").val(),
+                            serverSearchTimeRange: timeRangeData
                         });
 
                         // Set the options from the AJAX response (empty array if no data)

--- a/admin/index.php
+++ b/admin/index.php
@@ -15,6 +15,16 @@ class wp_slimstat_admin
     public static $admin_notice    = '';
     public static $main_menu_slug = 'slimview1';
 
+    /**
+     * Dimensions for which the filter-options search uses unanchored LIKE
+     * (%needle%) instead of the default left-anchored prefix match. These are
+     * either multi-token fields (notes, category) or free-form strings where
+     * users naturally search fragments (user_agent, outbound_resource URLs).
+     */
+    private const FILTER_SEARCH_SUBSTRING_DIMENSIONS = [
+        'notes', 'searchterms', 'content_type', 'category', 'author', 'outbound_resource', 'user_agent',
+    ];
+
     protected static $data_for_column = [
         'url'   => [],
         'sql'   => [],
@@ -2089,6 +2099,36 @@ class wp_slimstat_admin
         // Get distinct non-empty values
         $column_type = wp_slimstat_db::$columns_names[$dimension][1];
 
+        // Optional server-side search (layer 2 of #298). Only applies to varchar
+        // columns — searching numeric dimensions falls back to the legacy DISTINCT.
+        $search_raw = $_POST['search'] ?? '';
+        $search = '';
+        if (is_string($search_raw)) {
+            $search = trim(sanitize_text_field($search_raw));
+            if (strlen($search) < 2 || strlen($search) > 64) {
+                $search = '';
+            }
+        }
+        if ($column_type !== 'varchar') {
+            $search = '';
+        }
+
+        // Cache lookup (layer 3 of #298). Key must account for anything that
+        // changes the result set: blog, DB host (External DB addon), capability
+        // gate, dimension, hour-bucketed time range, effective limit, and search.
+        $cache_key = self::build_filter_options_cache_key(
+            $dimension,
+            $time_start,
+            $time_end,
+            $search,
+            $limit
+        );
+        $cached = self::filter_options_cache_get($cache_key);
+        if (is_array($cached)) {
+            wp_send_json_success($cached);
+            exit();
+        }
+
         // Build SQL query directly to avoid Query class interference with global filters
         $where_clauses = [];
 
@@ -2105,6 +2145,15 @@ class wp_slimstat_admin
             // Exclude NULLs and zeros for numeric columns
             $where_clauses[] = $safe_dimension . ' IS NOT NULL';
             $where_clauses[] = $safe_dimension . ' <> 0';
+        }
+
+        // Append LIKE filter when a server-side search term was supplied.
+        if ($search !== '') {
+            $escaped = wp_slimstat::$wpdb->esc_like($search);
+            $like_pattern = in_array($dimension, self::FILTER_SEARCH_SUBSTRING_DIMENSIONS, true)
+                ? '%' . $escaped . '%'
+                : $escaped . '%';
+            $where_clauses[] = wp_slimstat::$wpdb->prepare($safe_dimension . ' LIKE %s', $like_pattern);
         }
 
         $where_sql = !empty($where_clauses) ? 'WHERE ' . implode(' AND ', $where_clauses) : '';
@@ -2165,6 +2214,19 @@ class wp_slimstat_admin
                 }
             }
             $results = $expanded;
+        }
+
+        // After splitting multi-value rows, re-filter split segments by the
+        // server-side search term so the caller gets only matching segments,
+        // not every segment from rows where any sibling matched.
+        if ($search !== '' && (isset($multi_value_separators[$dimension]) || $dimension === 'notes')) {
+            $has_mb       = function_exists('mb_strtolower');
+            $needle       = $has_mb ? mb_strtolower($search) : strtolower($search);
+            $is_substring = in_array($dimension, self::FILTER_SEARCH_SUBSTRING_DIMENSIONS, true);
+            $results = array_values(array_filter($results, function ($row) use ($needle, $is_substring, $has_mb) {
+                $haystack = $has_mb ? mb_strtolower($row['value']) : strtolower($row['value']);
+                return $is_substring ? (strpos($haystack, $needle) !== false) : (strpos($haystack, $needle) === 0);
+            }));
         }
 
         // Cap expanded results to prevent explosion from splitting
@@ -2230,8 +2292,83 @@ class wp_slimstat_admin
             }
         }
 
+        self::filter_options_cache_set(
+            $cache_key,
+            $options,
+            self::filter_options_cache_ttl($time_end)
+        );
+
         wp_send_json_success($options);
         exit();
+    }
+
+    /**
+     * Composite cache key for get_filter_options(). Must include every variable
+     * that changes the result set: blog (multisite), DB host (External DB addon
+     * can point to another DB), capability gate (per-role visibility), dimension,
+     * hour-bucketed time range (increases hit rate for rolling windows), the
+     * effective limit (respects third-party `slimstat_filter_options_limit`
+     * consumers), and the search term.
+     */
+    private static function build_filter_options_cache_key(
+        string $dimension,
+        ?int $time_start,
+        ?int $time_end,
+        string $search,
+        int $limit
+    ): string {
+        $blog_id = function_exists('get_current_blog_id') ? (int) get_current_blog_id() : 0;
+        $dbhost  = '';
+        if (isset(wp_slimstat::$wpdb) && is_object(wp_slimstat::$wpdb) && isset(wp_slimstat::$wpdb->dbhost)) {
+            $dbhost = (string) wp_slimstat::$wpdb->dbhost;
+        }
+        $dbhost_hash = substr(md5($dbhost), 0, 8);
+        $can_view        = (string) (wp_slimstat::$settings['can_view'] ?? '');
+        $capability      = (string) (wp_slimstat::$settings['capability_can_view'] ?? '');
+        $capability_hash = substr(md5($capability . '|' . $can_view), 0, 8);
+        $ts_start_bucket = $time_start ? (int) floor((int) $time_start / 3600) : 0;
+        $ts_end_bucket   = $time_end ? (int) floor((int) $time_end / 3600) : 0;
+        $search_hash     = $search === '' ? '' : substr(md5($search), 0, 8);
+        return sprintf(
+            'fopts_%d_%s_%s_%s_%d_%d_%d_%s',
+            $blog_id,
+            $dbhost_hash,
+            $capability_hash,
+            $dimension,
+            $ts_start_bucket,
+            $ts_end_bucket,
+            $limit,
+            $search_hash
+        );
+    }
+
+    private static function filter_options_cache_ttl(?int $time_end): int
+    {
+        // Historical data (range ends > 1h ago) never changes — cache it longer.
+        if ($time_end && (int) $time_end < (time() - 3600)) {
+            return 3600;
+        }
+        return 300;
+    }
+
+    private static function filter_options_cache_get(string $key)
+    {
+        if (function_exists('wp_using_ext_object_cache') && wp_using_ext_object_cache()) {
+            $found = false;
+            $data  = wp_cache_get($key, 'slimstat_filter_options', false, $found);
+            return $found ? $data : null;
+        }
+        $data = get_transient('slimstat_' . $key);
+        return $data === false ? null : $data;
+    }
+
+    private static function filter_options_cache_set(string $key, $data, int $ttl): void
+    {
+        if (function_exists('wp_using_ext_object_cache') && wp_using_ext_object_cache()) {
+            wp_cache_set($key, $data, 'slimstat_filter_options', $ttl);
+            return;
+        }
+        set_transient('slimstat_' . $key, $data, $ttl);
     }
 
     // END: get_filter_options

--- a/tests/e2e/filter-ip-beyond-500-limit.spec.ts
+++ b/tests/e2e/filter-ip-beyond-500-limit.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * E2E: Issue #298 — Access Log filter dropdown rejects pasted/typed values
+ * beyond the server's 500-row DISTINCT slice.
+ *
+ * Three layers under test:
+ *  - Layer 1 (client): SlimStatSearchableSelect syncs the embedded search
+ *    input into #slimstat-filter-value on every keystroke, so the form posts
+ *    the typed value even when no option in the dropdown matches.
+ *  - Layer 2 (server): slimstat_get_filter_options accepts an optional
+ *    `search` POST param and does a prepared LIKE query (left-anchored for
+ *    IP-like columns, substring for notes/user_agent/etc).
+ *  - Layer 3 (cache): response payload is cached by composite key.
+ */
+import { test, expect, Page } from '@playwright/test';
+import {
+  clearStatsTable,
+  getPool,
+  closeDb,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+
+const NOW = Math.floor(Date.now() / 1000);
+// 255.* sorts lexicographically after every "10.*" IP, so with LIMIT 500 on an
+// ASC DISTINCT slice seeded with 500 "10.*" IPs, this target is guaranteed
+// to be outside the pre-fetched payload.
+const TARGET_IP = '255.255.255.255';
+
+async function clearTestData(): Promise<void> {
+  await clearStatsTable();
+  await getPool().execute(
+    "DELETE FROM wp_options WHERE option_name LIKE '_transient_slimstat_%' OR option_name LIKE '_transient_timeout_slimstat_%'"
+  );
+}
+
+/**
+ * Seed `count` distinct IPs. The first `count - 1` are `10.0.<a>.<b>`
+ * (contiguous), and the last row is TARGET_IP — lexicographically beyond the
+ * 500-slice of any ascending DISTINCT query over this data.
+ */
+async function seedDistinctIps(count: number): Promise<void> {
+  if (count <= 0) return;
+  const placeholders: string[] = [];
+  const values: any[] = [];
+  for (let i = 0; i < count - 1; i++) {
+    const a = (i >> 8) & 0xff;
+    const b = i & 0xff;
+    const ip = `10.0.${a}.${b}`;
+    placeholders.push('(?, ?, ?, ?, ?, ?, ?)');
+    values.push(`/page-${i}`, NOW - 3600 + i, ip, 1, 'Chrome', 'Windows', 'post');
+  }
+  placeholders.push('(?, ?, ?, ?, ?, ?, ?)');
+  values.push('/target-page', NOW, TARGET_IP, 1, 'Chrome', 'Windows', 'post');
+  await getPool().query(
+    `INSERT INTO wp_slim_stats (resource, dt, ip, visit_id, browser, platform, content_type) VALUES ${placeholders.join(', ')}`,
+    values,
+  );
+}
+
+async function getNonce(page: Page, action: string): Promise<string> {
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'test_create_nonce', nonce_action: action },
+  });
+  const json = await res.json();
+  return json.data.nonce;
+}
+
+type FilterResponse = { success: boolean; data: Array<string | { value: string }> };
+
+async function getFilterOptions(
+  page: Page,
+  dimension: string,
+  nonce: string,
+  extra: Record<string, string> = {},
+): Promise<FilterResponse> {
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: {
+      action: 'slimstat_get_filter_options',
+      security: nonce,
+      dimension,
+      time_range_type: 'last_28_days',
+      ...extra,
+    },
+  });
+  return res.json();
+}
+
+function extractValues(response: FilterResponse): string[] {
+  if (!response.success || !Array.isArray(response.data)) return [];
+  return response.data.map((item) => (typeof item === 'string' ? item : item.value));
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+test.beforeEach(async () => {
+  await snapshotSlimstatOptions();
+  await clearTestData();
+});
+
+test.afterEach(async () => {
+  await restoreSlimstatOptions();
+});
+
+test.afterAll(async () => {
+  await clearTestData();
+  await closeDb();
+});
+
+// ─── Endpoint-level tests ─────────────────────────────────────────────────────
+
+test.describe('slimstat_get_filter_options endpoint — search + cache', () => {
+  test('500-row cap applies when no search term is supplied (characterization)', async ({ page }) => {
+    await seedDistinctIps(501);
+    const nonce = await getNonce(page, 'meta-box-order');
+    const response = await getFilterOptions(page, 'ip', nonce);
+    const values = extractValues(response);
+
+    expect(response.success).toBe(true);
+    expect(values.length).toBeLessThanOrEqual(500);
+    expect(values).not.toContain(TARGET_IP);
+  });
+
+  test('search returns IPs beyond the 500-slice (regression for #298)', async ({ page }) => {
+    await seedDistinctIps(501);
+    const nonce = await getNonce(page, 'meta-box-order');
+    const response = await getFilterOptions(page, 'ip', nonce, { search: '255.' });
+    const values = extractValues(response);
+
+    expect(response.success).toBe(true);
+    expect(values).toContain(TARGET_IP);
+  });
+
+  test('search shorter than 2 chars falls back to legacy DISTINCT', async ({ page }) => {
+    await seedDistinctIps(10);
+    const nonce = await getNonce(page, 'meta-box-order');
+    const withShort = extractValues(await getFilterOptions(page, 'ip', nonce, { search: '1' }));
+    const withNone = extractValues(await getFilterOptions(page, 'ip', nonce));
+
+    expect(withShort.sort()).toEqual(withNone.sort());
+  });
+
+  test('search with no match returns empty array (not an error)', async ({ page }) => {
+    await seedDistinctIps(10);
+    const nonce = await getNonce(page, 'meta-box-order');
+    const response = await getFilterOptions(page, 'ip', nonce, { search: 'zzz-no-such-ip' });
+
+    expect(response.success).toBe(true);
+    expect(extractValues(response)).toEqual([]);
+  });
+
+  test('LIKE metacharacters in the search term are escaped literally', async ({ page }) => {
+    await seedDistinctIps(10);
+    const nonce = await getNonce(page, 'meta-box-order');
+    const response = await getFilterOptions(page, 'ip', nonce, { search: '%.%' });
+
+    expect(response.success).toBe(true);
+    // Literal '%.%' is not a substring of any "10.0.x.y" IP, so no matches.
+    expect(extractValues(response)).toEqual([]);
+  });
+
+  test('ip uses left-anchored LIKE; mid-string prefix does not match', async ({ page }) => {
+    await seedDistinctIps(10);
+    const nonce = await getNonce(page, 'meta-box-order');
+    // "10.0." is at the start of every seeded IP; left-anchored match finds all.
+    const anchored = extractValues(await getFilterOptions(page, 'ip', nonce, { search: '10.0.' }));
+    expect(anchored.length).toBeGreaterThan(0);
+    // "0.0.0" appears mid-string in our IPs but isn't a left-anchor; no match.
+    const midString = extractValues(await getFilterOptions(page, 'ip', nonce, { search: '0.0.0' }));
+    expect(midString).toEqual([]);
+  });
+
+  test('user_agent uses substring LIKE (fragment matching)', async ({ page }) => {
+    await getPool().execute(
+      `INSERT INTO wp_slim_stats (resource, dt, ip, visit_id, browser, platform, user_agent, content_type)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['/ua', NOW, '1.2.3.4', 1, 'Chrome', 'Windows', 'Mozilla/5.0 Firefox/120.0', 'post'],
+    );
+    const nonce = await getNonce(page, 'meta-box-order');
+    const response = await getFilterOptions(page, 'user_agent', nonce, { search: 'Firefox' });
+    const values = extractValues(response);
+
+    expect(response.success).toBe(true);
+    expect(values.some((v) => v.includes('Firefox'))).toBe(true);
+  });
+
+  test('response is cached: freshly inserted rows are not yet visible within TTL', async ({ page }) => {
+    await seedDistinctIps(10);
+    const nonce = await getNonce(page, 'meta-box-order');
+
+    const first = extractValues(await getFilterOptions(page, 'ip', nonce));
+    // Insert a new IP after the cache is primed. Cache TTL (300s) means the
+    // second call returns the cached payload without the new row.
+    await getPool().execute(
+      `INSERT INTO wp_slim_stats (resource, dt, ip, visit_id, browser, platform, content_type)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ['/fresh', NOW, '20.20.20.20', 1, 'Chrome', 'Windows', 'post'],
+    );
+    const second = extractValues(await getFilterOptions(page, 'ip', nonce));
+
+    expect(second.sort()).toEqual(first.sort());
+    expect(second).not.toContain('20.20.20.20');
+  });
+});
+
+// ─── UI-level tests ───────────────────────────────────────────────────────────
+
+test.describe('Access Log filter UI — #298 typed-value regression', () => {
+  test('typing an IP beyond the 500-slice syncs into the hidden form field', async ({ page }) => {
+    await seedDistinctIps(501);
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview2`, {
+      waitUntil: 'networkidle',
+    });
+
+    await page.selectOption('#slimstat-filter-name', 'ip');
+    await page.waitForSelector('.slimstat-searchable-select');
+    await page.selectOption('#slimstat-filter-operator', 'equals');
+
+    await page.click('.slimstat-select-display');
+    await page.fill('.slimstat-select-search input', TARGET_IP);
+
+    const synced = await page.inputValue('#slimstat-filter-value');
+    expect(synced).toBe(TARGET_IP);
+  });
+
+  test('no-match message invites the user to click Apply when they have typed', async ({ page }) => {
+    await seedDistinctIps(10);
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview2`, {
+      waitUntil: 'networkidle',
+    });
+
+    await page.selectOption('#slimstat-filter-name', 'ip');
+    await page.waitForSelector('.slimstat-searchable-select');
+    await page.click('.slimstat-select-display');
+    await page.fill('.slimstat-select-search input', 'zzz-definitely-not-an-ip');
+
+    const noResults = page.locator('[data-testid="slimstat-no-results"]');
+    await expect(noResults).toBeVisible();
+    await expect(noResults).toContainText(/Apply/i);
+  });
+
+  test('is_empty operator leaves the sync handler inert (readonly guard)', async ({ page }) => {
+    await seedDistinctIps(10);
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview2`, {
+      waitUntil: 'networkidle',
+    });
+
+    await page.selectOption('#slimstat-filter-name', 'ip');
+    await page.waitForSelector('.slimstat-searchable-select');
+    await page.selectOption('#slimstat-filter-operator', 'is_empty');
+
+    const readonly = await page.locator('#slimstat-filter-value').getAttribute('readonly');
+    expect(readonly).not.toBeNull();
+
+    const disabledWrapperPointer = await page
+      .locator('.slimstat-searchable-select .slimstat-select-wrapper')
+      .evaluate((el) => (el as HTMLElement).style.pointerEvents);
+    expect(disabledWrapperPointer).toBe('none');
+  });
+});

--- a/tests/e2e/filter-ip-beyond-500-limit.spec.ts
+++ b/tests/e2e/filter-ip-beyond-500-limit.spec.ts
@@ -239,6 +239,34 @@ test.describe('Access Log filter UI — #298 typed-value regression', () => {
     await expect(noResults).toContainText(/Apply/i);
   });
 
+  test('clearing the search after a server fetch restores the initial list', async ({ page }) => {
+    await seedDistinctIps(501);
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview2`, {
+      waitUntil: 'networkidle',
+    });
+
+    await page.selectOption('#slimstat-filter-name', 'ip');
+    await page.waitForSelector('.slimstat-searchable-select');
+    await page.click('.slimstat-select-display');
+
+    // Capture the initial dropdown state (the 500-row DISTINCT slice).
+    const initialCount = await page.locator('.slimstat-select-options .slimstat-select-option').count();
+    expect(initialCount).toBeGreaterThan(1);
+
+    // Trigger a server search for the late IP (not in the initial slice).
+    await page.fill('.slimstat-select-search input', '255.');
+    await expect(
+      page.locator('.slimstat-select-options .slimstat-select-option .slimstat-option-label', { hasText: '255.' }).first(),
+    ).toBeVisible({ timeout: 3000 });
+    const narrowedCount = await page.locator('.slimstat-select-options .slimstat-select-option').count();
+    expect(narrowedCount).toBeLessThan(initialCount);
+
+    // Clear the search — the dropdown should return to the initial list.
+    await page.fill('.slimstat-select-search input', '');
+    const restoredCount = await page.locator('.slimstat-select-options .slimstat-select-option').count();
+    expect(restoredCount).toBe(initialCount);
+  });
+
   test('is_empty operator leaves the sync handler inert (readonly guard)', async ({ page }) => {
     await seedDistinctIps(10);
     await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview2`, {

--- a/uninstall.php
+++ b/uninstall.php
@@ -60,6 +60,18 @@ function slimstat_uninstall($_wpdb = '', $_options = [])
     $GLOBALS['wpdb']->query(sprintf("DELETE FROM %susermeta WHERE meta_key LIKE '%%metaboxhidden_slimstat%%'", $GLOBALS[ 'wpdb' ]->prefix));
     $GLOBALS['wpdb']->query(sprintf("DELETE FROM %susermeta WHERE meta_key LIKE '%%closedpostboxes_slimstat%%'", $GLOBALS[ 'wpdb' ]->prefix));
 
+    // Sweep filter-options transients left behind by the dropdown cache.
+    $transient_like = $GLOBALS['wpdb']->esc_like('_transient_slimstat_fopts_') . '%';
+    $timeout_like   = $GLOBALS['wpdb']->esc_like('_transient_timeout_slimstat_fopts_') . '%';
+    $GLOBALS['wpdb']->query($GLOBALS['wpdb']->prepare(
+        "DELETE FROM {$GLOBALS['wpdb']->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+        $transient_like,
+        $timeout_like
+    ));
+    if (function_exists('wp_cache_delete_group')) {
+        wp_cache_delete_group('slimstat_filter_options');
+    }
+
     // Remove scheduled autopurge events
     wp_clear_scheduled_hook('wp_slimstat_purge');
     wp_clear_scheduled_hook('wp_slimstat_update_geoip_database');


### PR DESCRIPTION
## Summary

Fixes [#298](https://github.com/wp-slimstat/wp-slimstat/issues/298) — Access Log filter dropdown rejected pasted/typed values that existed in the log but sat beyond the 500-row DISTINCT slice pre-fetched from the server. "Starts with" failed the same way.

Three-layer fix, single PR:

1. **Client sync** — the `SlimStatSearchableSelect` search input now writes into `#slimstat-filter-value` on every keystroke, so the form posts whatever the user typed regardless of whether any option matched. Readonly/disabled states (`is_empty` / `is_not_empty` operators) are skipped. The no-match message becomes discoverable: *"No matches — click Apply to filter by this value."*
2. **Server-side search** — `get_filter_options` gains an optional `search` POST parameter (2–64 chars, sanitized) that appends a prepared `LIKE` clause — left-anchored for IP-like columns, substring for notes/user_agent/outbound_resource/etc. JS debounces 250 ms, cancels in-flight requests on new keystrokes via `AbortController`, and discards stale responses. Goals & Funnels remains backward-compatible — `search` is strictly optional.
3. **Caching** — DISTINCT + search responses are cached via `wp_cache_*` with transient fallback. Composite key includes `blog_id`, DB-host hash (External DB addon safe), capability-gate hash, hour-bucketed time range, effective limit, and search hash. TTL is 300 s for current ranges, 3600 s for historical. `uninstall.php` sweeps the new transients and `wp_cache_delete_group`.

## Why layered

The typed-value sync alone fixes correctness. Server-side search gives users the affordance of seeing matching values while typing (closes the UX gap that prompted the "it's a bug" report). Caching turns a DB-hit-per-dropdown-open into an in-memory read after the first request.

## Side-effects audit

Covered 12 risks in the [fix plan](../blob/fix/298-access-log-filter-dropdown/jaan-to/outputs/qa/issue-validate/298-access-log-ip-dropdown-limit/298-fix-plan.md) — the key ones:

- **Cache poisoning** (cross-user, cross-site) prevented by composite key (`blog_id` + DB-host hash + capability hash + effective limit).
- **Race conditions** on debounced search handled with `AbortController` + term-equality response guard.
- **Read-only operators** (`is_empty` / `is_not_empty`) — sync handler and server fetch both short-circuit via `isDisabled()`.
- **Goals & Funnels compat** — `search` param is strictly optional; default behavior unchanged.
- **Memory** — `destroy()` clears debounce timer, aborts any in-flight request, and nulls out `allOptions`/`filteredOptions`/`selectedOption` references.

## Code references

- JS widget: [`admin/assets/js/admin.js`](../blob/fix/298-access-log-filter-dropdown/admin/assets/js/admin.js) — new `isDisabled`, `syncTypedValue`, `dispatchChange`, `updateDisplayFromValue`, `willServerSearch`, `scheduleServerSearch`, `runServerSearch`; updated `renderOptions`, `close`, `destroy`, and dimension-change handler.
- PHP endpoint: [`admin/index.php`](../blob/fix/298-access-log-filter-dropdown/admin/index.php) — `get_filter_options` gains search + cache path; new `FILTER_SEARCH_SUBSTRING_DIMENSIONS` constant and 4 private static helpers (`build_filter_options_cache_key`, `filter_options_cache_ttl`, `filter_options_cache_get`, `filter_options_cache_set`).
- Uninstall: [`uninstall.php`](../blob/fix/298-access-log-filter-dropdown/uninstall.php) — targeted transient DELETE + `wp_cache_delete_group`.

## Test plan

- [ ] Run `npm run test:e2e -- filter-ip-beyond-500-limit.spec.ts` — 11 scenarios green
- [ ] Run `npm run test:e2e -- filter-multivalue-columns.spec.ts` — regression guard (no breakage in Goals & Funnels-adjacent paths)
- [ ] Manual: seed 510 distinct IPs, paste a late IP into the IP `equals` filter → filter applies
- [ ] Manual: `is_empty` / `is_not_empty` still readonly, dropdown still inert
- [ ] Manual: `/wp-json/slimstat/*` and `admin-ajax.php?action=slimstat_get_filter_options` respond without errors
- [ ] Check `CHANGELOG.md` entry on 5.4.13

## Release

Changelog entry added under **5.4.13 - 2026-04-20**. Bumps pending with release prep.

## Follow-ups (parked)

- Optional `ip` index (`VARCHAR(39)` fits as a full index) if post-release profiling shows LIKE-on-`ip` is a hot spot.
- Configurable cache TTL setting/constant for high-traffic operators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Searchable filter dropdown accepts typed/pasted values not in the initial list and supports server-backed searching with field-appropriate matching and caching.
* **Bug Fixes**
  * Handles cases where filters exceed the 500-row default limit and preserves typed values when options slice omits them.
* **Tests**
  * New end-to-end tests covering large-result behavior, server search semantics, no-match UX, and cache TTLs.
* **Chores**
  * Cleanup of leftover filter-option cache/transients on uninstall and added changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->