### PR TITLE
fix(security): block SQLi via chart_data.where in slimstat_fetch_chart_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+= 5.4.13 - 2026-04-22 =
+
+**Security**
+
+- Authenticated SQL injection in the chart AJAX endpoint (`wp_ajax_slimstat_fetch_chart_data`) is now blocked. `chart_data.where` is validated against the registered report definitions before being inlined into the SQL query — only WHERE clauses declared by trusted reports (and by Pro addons that register reports via the `slimstat_reports_info` filter) are accepted. Reported via Patchstack (CVSS 8.5, High). The `data1` / `data2` allowlist introduced in PR #232 already covered the aggregate-expression vector; this release closes the parallel `where` vector.
+
 = 5.4.12 - 2026-04-18 =
 
 **Bot detection hardening**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
-= 5.4.13 - 2026-04-22 =
+= 5.4.12 - 2026-04-18 =
 
 **Security**
 
 - Authenticated SQL injection in the chart AJAX endpoint (`wp_ajax_slimstat_fetch_chart_data`) is now blocked. `chart_data.where` is validated against the registered report definitions before being inlined into the SQL query — only WHERE clauses declared by trusted reports (and by Pro addons that register reports via the `slimstat_reports_info` filter) are accepted. Reported via Patchstack (CVSS 8.5, High). The `data1` / `data2` allowlist introduced in PR #232 already covered the aggregate-expression vector; this release closes the parallel `where` vector.
-
-= 5.4.12 - 2026-04-18 =
 
 **Bot detection hardening**
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Text Domain: wp-slimstat
 Requires at least: 5.6
 Requires PHP: 7.4
 Tested up to: 6.9.4
-Stable tag: 5.4.12
+Stable tag: 5.4.13
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -75,6 +75,9 @@ An extensive knowledge base is available on our [website](https://www.wp-slimsta
 9. **Settings** - Plenty of options to customize the plugin's behavior
 
 == Changelog ==
+= 5.4.13 - 2026-04-22 =
+* Security: Authenticated SQL injection in the chart AJAX endpoint (slimstat_fetch_chart_data) is now blocked. The `chart_data.where` parameter is validated against the trusted report registry before reaching the query layer. Reported via Patchstack (CVSS 8.5, High).
+
 = 5.4.12 - 2026-04-18 =
 * Fix: Chrome-based mobile Googlebot and Bingbot now correctly blocked when Browscap classifies them as mobile devices (#14843)
 * Fix: Google-InspectionTool mobile is now detected as a crawler

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Text Domain: wp-slimstat
 Requires at least: 5.6
 Requires PHP: 7.4
 Tested up to: 6.9.4
-Stable tag: 5.4.13
+Stable tag: 5.4.12
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -75,10 +75,8 @@ An extensive knowledge base is available on our [website](https://www.wp-slimsta
 9. **Settings** - Plenty of options to customize the plugin's behavior
 
 == Changelog ==
-= 5.4.13 - 2026-04-22 =
-* Security: Authenticated SQL injection in the chart AJAX endpoint (slimstat_fetch_chart_data) is now blocked. The `chart_data.where` parameter is validated against the trusted report registry before reaching the query layer. Reported via Patchstack (CVSS 8.5, High).
-
 = 5.4.12 - 2026-04-18 =
+* Security: Authenticated SQL injection in the chart AJAX endpoint (slimstat_fetch_chart_data) is now blocked. The `chart_data.where` parameter is validated against the trusted report registry before reaching the query layer. Reported via Patchstack (CVSS 8.5, High).
 * Fix: Chrome-based mobile Googlebot and Bingbot now correctly blocked when Browscap classifies them as mobile devices (#14843)
 * Fix: Google-InspectionTool mobile is now detected as a crawler
 * Improvement: Bot detection regex extended with 15 new vendor tokens — Mediapartners-Google, Google-InspectionTool, Google-Site-Verification, Google Favicon, GoogleOther, GoogleAgent-Mariner, Google-Safety, DuplexWeb-Google, BingPreview, YandexDirect, YandexFavicons, WhatsApp preview, SkypeUriPreview, anthropic-ai, cohere-ai

--- a/src/Modules/Chart.php
+++ b/src/Modules/Chart.php
@@ -290,10 +290,20 @@ class Chart
         // Build WHERE clause from active filters (excluding time filters)
         $filterWhere = $this->buildFilterWhere();
 
-        // Add chart-specific WHERE clause if provided
+        // Add chart-specific WHERE clause if provided.
+        // SECURITY: $args['chart_data']['where'] arrives via $_POST in the AJAX
+        // path (ajaxFetchChartData) and is later inlined into raw SQL through
+        // Query::whereRaw() with no parameter binding. To prevent SQL injection
+        // (Patchstack disclosure, CVSS 8.5), require the supplied clause to
+        // match — after whitespace normalization — one of the WHERE strings
+        // declared by a report registered in wp_slimstat_reports::$reports.
         if (!empty($args['chart_data']['where'])) {
-            $chartWhere = $args['chart_data']['where'];
-            $filterWhere = !empty($filterWhere) ? $filterWhere . ' AND ' . $chartWhere : $chartWhere;
+            $normalized = self::normalizeSqlWhitespace((string) $args['chart_data']['where']);
+            $allowed    = self::getAllowedWhereClauses();
+            if (!isset($allowed[$normalized])) {
+                throw new \Exception(__('Invalid chart filter expression.', 'wp-slimstat'));
+            }
+            $filterWhere = !empty($filterWhere) ? $filterWhere . ' AND ' . $normalized : $normalized;
         }
 
         // Use UNIX_TIMESTAMP difference for broad MySQL 5.0.x compatibility.
@@ -505,6 +515,60 @@ class Chart
 
         // If none of the patterns match, reject the expression
         throw new \Exception(__('Invalid SQL expression in chart data. Only whitelisted aggregate functions on valid columns are allowed.', 'wp-slimstat'));
+    }
+
+    /**
+     * Allowlist of legitimate chart `where` clauses harvested from every report
+     * registered in wp_slimstat_reports::$reports (including those added by
+     * third-party Pro addons via the `slimstat_reports_info` filter).
+     *
+     * Rebuilt per request because dynamic clauses (home_url(), date_i18n(...))
+     * are evaluated at init() time.
+     *
+     * @return array<string,bool> normalized-clause => true
+     */
+    private static function getAllowedWhereClauses(): array
+    {
+        static $cache = null;
+        if ($cache !== null) {
+            return $cache;
+        }
+
+        if (!class_exists('\wp_slimstat_reports')) {
+            $reportsFile = SLIMSTAT_DIR . '/admin/view/wp-slimstat-reports.php';
+            if (file_exists($reportsFile)) {
+                include_once $reportsFile;
+            }
+        }
+        if (!class_exists('\wp_slimstat_reports')) {
+            // Don't cache the failure — let a later call retry once the file
+            // has had a chance to load (e.g. via a downstream filter).
+            return [];
+        }
+
+        \wp_slimstat_reports::init();
+
+        $cache = [];
+        foreach ((array) \wp_slimstat_reports::$reports as $report) {
+            if (empty($report['callback_args']['chart_data']['where'])) {
+                continue;
+            }
+            $normalized = self::normalizeSqlWhitespace($report['callback_args']['chart_data']['where']);
+            if ($normalized !== '') {
+                $cache[$normalized] = true;
+            }
+        }
+
+        return $cache;
+    }
+
+    /**
+     * Both sides of the `where` allowlist comparison must run through the
+     * same whitespace normalization for the equality check to be sound.
+     */
+    private static function normalizeSqlWhitespace(string $sql): string
+    {
+        return trim(preg_replace('/\s+/', ' ', $sql));
     }
 
     private function processResults(array $rows, array $totals, array $params, int $start, int $end, int $prevStart, int $prevEnd): array

--- a/src/Modules/Chart.php
+++ b/src/Modules/Chart.php
@@ -298,7 +298,15 @@ class Chart
         // match — after whitespace normalization — one of the WHERE strings
         // declared by a report registered in wp_slimstat_reports::$reports.
         if (!empty($args['chart_data']['where'])) {
-            $normalized = self::normalizeSqlWhitespace((string) $args['chart_data']['where']);
+            // Reject non-string input before normalization. Chart.php does not
+            // declare(strict_types=1), so casting an array (E_WARNING) or an
+            // object without __toString (fatal Error → 500) would otherwise
+            // produce noisy logs or crash the AJAX handler instead of the
+            // generic security rejection below.
+            if (!is_string($args['chart_data']['where'])) {
+                throw new \Exception(__('Invalid chart filter expression.', 'wp-slimstat'));
+            }
+            $normalized = self::normalizeSqlWhitespace($args['chart_data']['where']);
             $allowed    = self::getAllowedWhereClauses();
             if (!isset($allowed[$normalized])) {
                 throw new \Exception(__('Invalid chart filter expression.', 'wp-slimstat'));

--- a/src/Modules/Chart.php
+++ b/src/Modules/Chart.php
@@ -530,7 +530,7 @@ class Chart
     private static function getAllowedWhereClauses(): array
     {
         static $cache = null;
-        if ($cache !== null) {
+        if (null !== $cache) {
             return $cache;
         }
 
@@ -550,11 +550,15 @@ class Chart
 
         $cache = [];
         foreach ((array) \wp_slimstat_reports::$reports as $report) {
-            if (empty($report['callback_args']['chart_data']['where'])) {
+            $where = $report['callback_args']['chart_data']['where'] ?? null;
+            // Skip non-string values defensively — a third-party report could
+            // register an array/object/null; normalizeSqlWhitespace is typed
+            // for string and Chart.php does not declare(strict_types=1).
+            if (!is_string($where) || '' === $where) {
                 continue;
             }
-            $normalized = self::normalizeSqlWhitespace($report['callback_args']['chart_data']['where']);
-            if ($normalized !== '') {
+            $normalized = self::normalizeSqlWhitespace($where);
+            if ('' !== $normalized) {
                 $cache[$normalized] = true;
             }
         }

--- a/src/Modules/Chart.php
+++ b/src/Modules/Chart.php
@@ -311,9 +311,10 @@ class Chart
             if (!isset($allowed[$normalized])) {
                 throw new \Exception(__('Invalid chart filter expression.', 'wp-slimstat'));
             }
-            // Wrap: allowlisted clauses may contain a top-level OR, which
-            // would otherwise rebind and drop the preceding AND filters.
-            $wrapped     = '(' . $normalized . ')';
+            $canonical   = $allowed[$normalized]; // splice trusted text, never the user-derived $normalized
+            // Wrap: allowlisted clauses may contain a top-level OR that would
+            // otherwise rebind and drop the preceding AND filters.
+            $wrapped     = '(' . $canonical . ')';
             $filterWhere = !empty($filterWhere) ? $filterWhere . ' AND ' . $wrapped : $wrapped;
         }
 
@@ -536,7 +537,7 @@ class Chart
      * Rebuilt per request because dynamic clauses (home_url(), date_i18n(...))
      * are evaluated at init() time.
      *
-     * @return array<string,bool> normalized-clause => true
+     * @return array<string,string> normalized-clause => canonical clause text
      */
     private static function getAllowedWhereClauses(): array
     {
@@ -570,7 +571,7 @@ class Chart
             }
             $normalized = self::normalizeSqlWhitespace($where);
             if ('' !== $normalized) {
-                $cache[$normalized] = true;
+                $cache[$normalized] = $where;
             }
         }
 

--- a/src/Modules/Chart.php
+++ b/src/Modules/Chart.php
@@ -311,7 +311,10 @@ class Chart
             if (!isset($allowed[$normalized])) {
                 throw new \Exception(__('Invalid chart filter expression.', 'wp-slimstat'));
             }
-            $filterWhere = !empty($filterWhere) ? $filterWhere . ' AND ' . $normalized : $normalized;
+            // Wrap: allowlisted clauses may contain a top-level OR, which
+            // would otherwise rebind and drop the preceding AND filters.
+            $wrapped     = '(' . $normalized . ')';
+            $filterWhere = !empty($filterWhere) ? $filterWhere . ' AND ' . $wrapped : $wrapped;
         }
 
         // Use UNIX_TIMESTAMP difference for broad MySQL 5.0.x compatibility.

--- a/tests/e2e/chart-sql-expression-validation.spec.ts
+++ b/tests/e2e/chart-sql-expression-validation.spec.ts
@@ -25,29 +25,12 @@ import {
   uninstallMuPluginByName,
 } from './helpers/setup';
 import { BASE_URL } from './helpers/env';
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/**
- * Obtain the chart nonce via the nonce-helper AJAX endpoint.
- * More reliable than page-scraping slimstat_chart_vars.nonce.
- */
-async function getChartNonce(page: import('@playwright/test').Page): Promise<string> {
-  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
-    form: { action: 'test_create_nonce', nonce_action: 'slimstat_chart_nonce' },
-  });
-  if (!res.ok()) throw new Error(`test_create_nonce failed: HTTP ${res.status()}`);
-  const body = await res.json();
-  if (!body?.success || !body?.data?.nonce) {
-    throw new Error(`test_create_nonce returned unexpected body: ${JSON.stringify(body)}`);
-  }
-  return body.data.nonce;
-}
+import { CHART_TEST_RANGE, getChartNonce } from './helpers/chart';
 
 /**
  * Call slimstat_fetch_chart_data AJAX with a custom data1 expression.
- * Uses a fixed past range (2026-02-01 → 2026-03-31) — no DB rows needed
- * because validateSqlExpression() runs before the SQL query.
+ * Uses a fixed past range — no DB rows needed because
+ * validateSqlExpression() runs before the SQL query.
  */
 async function callChartWithExpression(
   page: import('@playwright/test').Page,
@@ -55,8 +38,7 @@ async function callChartWithExpression(
   data1Expression: string
 ): Promise<{ status: number; body: any }> {
   const args = JSON.stringify({
-    start: 1738368000, // 2026-02-01 00:00 UTC
-    end:   1743379199, // 2026-03-31 23:59 UTC
+    ...CHART_TEST_RANGE,
     chart_data: {
       data1: data1Expression,
       data2: 'COUNT( DISTINCT ip )',

--- a/tests/e2e/chart-where-allowlist-validation.spec.ts
+++ b/tests/e2e/chart-where-allowlist-validation.spec.ts
@@ -15,7 +15,7 @@
  *   5. No `where` provided (slim_p1_01-style report)  → success: true
  *   6. Empty `where` string                           → success: true (early return)
  *
- * Source: Patchstack disclosure 2026-04 / fix shipped 5.4.13.
+ * Source: Patchstack disclosure 2026-04 / fix shipped 5.4.12.
  */
 import { test, expect } from '@playwright/test';
 import {

--- a/tests/e2e/chart-where-allowlist-validation.spec.ts
+++ b/tests/e2e/chart-where-allowlist-validation.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * E2E: chart_data.where allowlist validation — Patchstack SQLi (CVSS 8.5).
+ *
+ * Validates the registry-based allowlist in Chart::sqlFor() that compares the
+ * client-supplied `chart_data.where` (after whitespace normalization) against
+ * every WHERE clause registered in wp_slimstat_reports::$reports. Anything
+ * not in the allowlist throws \Exception, caught by ajaxFetchChartData() and
+ * returned as { success: false, data: { message } }.
+ *
+ * Tests:
+ *   1. Legit where (slim_p1_19_01 Search Terms clause) → success: true
+ *   2. Legit where with extra whitespace             → success: true (normalization)
+ *   3. Patchstack PoC: IF(1=1,SLEEP(2),0)            → success: false AND elapsed < 1500ms
+ *   4. Stacked-statement injection                    → success: false
+ *   5. No `where` provided (slim_p1_01-style report)  → success: true
+ *   6. Empty `where` string                           → success: true (early return)
+ *
+ * Source: Patchstack disclosure 2026-04 / fix shipped 5.4.13.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  closeDb,
+  installMuPluginByName,
+  uninstallMuPluginByName,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+import { CHART_TEST_RANGE, getChartNonce } from './helpers/chart';
+
+// Whitespace-equivalent of the registered slim_p1_19_01 (Search Terms) where clause.
+const LEGIT_WHERE = 'searchterms <> "_" AND searchterms IS NOT NULL AND searchterms <> ""';
+
+async function callChartWithWhere(
+  page: import('@playwright/test').Page,
+  nonce: string,
+  where: string | null
+): Promise<{ status: number; body: any; elapsedMs: number }> {
+  const chartData: Record<string, string> = {
+    data1: 'COUNT(id)',
+    data2: 'COUNT( DISTINCT ip )',
+  };
+  if (where !== null) {
+    chartData.where = where;
+  }
+
+  const args = JSON.stringify({
+    ...CHART_TEST_RANGE,
+    chart_data: chartData,
+  });
+
+  const t0 = Date.now();
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'slimstat_fetch_chart_data', nonce, args, granularity: 'monthly' },
+  });
+  const elapsedMs = Date.now() - t0;
+
+  return { status: res.status(), body: res.ok() ? await res.json() : null, elapsedMs };
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+test.describe('Chart where-clause allowlist — Patchstack SQLi regression', () => {
+  test.setTimeout(60_000);
+
+  let sharedNonce: string;
+
+  test.beforeAll(async ({ browser }) => {
+    installMuPluginByName('nonce-helper-mu-plugin.php');
+    const ctx  = await browser.newContext();
+    const page = await ctx.newPage();
+    sharedNonce = await getChartNonce(page);
+    await ctx.close();
+  });
+
+  test.afterAll(async () => {
+    uninstallMuPluginByName('nonce-helper-mu-plugin.php');
+    await closeDb();
+  });
+
+  test('legit where (slim_p1_19_01 Search Terms) is accepted', async ({ page }) => {
+    const { status, body } = await callChartWithWhere(page, sharedNonce, LEGIT_WHERE);
+
+    expect(status).toBe(200);
+    expect(body?.success, `Expected success:true, got: ${JSON.stringify(body?.data)}`).toBe(true);
+  });
+
+  test('legit where with extra whitespace is accepted (normalization)', async ({ page }) => {
+    const padded = '   searchterms   <>   "_"   AND  searchterms\tIS NOT NULL   AND searchterms <> ""   ';
+    const { status, body } = await callChartWithWhere(page, sharedNonce, padded);
+
+    expect(status).toBe(200);
+    expect(body?.success, `Expected success:true, got: ${JSON.stringify(body?.data)}`).toBe(true);
+  });
+
+  test('Patchstack PoC: IF(1=1,SLEEP(2),0) is rejected before SQL executes', async ({ page }) => {
+    const { status, body, elapsedMs } = await callChartWithWhere(page, sharedNonce, 'IF(1=1,SLEEP(2),0)');
+
+    expect(status).toBe(200);
+    expect(body?.success, 'SQLi payload must be rejected').toBe(false);
+    expect(typeof body?.data?.message).toBe('string');
+    // SLEEP(2) would push response well past 2000ms. Asserting < 1500ms proves
+    // the payload was rejected before the query layer.
+    expect(elapsedMs).toBeLessThan(1500);
+  });
+
+  test('stacked-statement injection is rejected', async ({ page }) => {
+    const { status, body } = await callChartWithWhere(page, sharedNonce, '1=1; DROP TABLE wp_slim_stats--');
+
+    expect(status).toBe(200);
+    expect(body?.success, 'Stacked-statement payload must be rejected').toBe(false);
+    expect(typeof body?.data?.message).toBe('string');
+  });
+
+  test('no `where` provided (slim_p1_01-style report) still succeeds', async ({ page }) => {
+    const { status, body } = await callChartWithWhere(page, sharedNonce, null);
+
+    expect(status).toBe(200);
+    expect(body?.success, `Expected success:true, got: ${JSON.stringify(body?.data)}`).toBe(true);
+  });
+
+  test('empty `where` string still succeeds (early-return guard)', async ({ page }) => {
+    const { status, body } = await callChartWithWhere(page, sharedNonce, '');
+
+    expect(status).toBe(200);
+    expect(body?.success, `Expected success:true, got: ${JSON.stringify(body?.data)}`).toBe(true);
+  });
+});

--- a/tests/e2e/helpers/chart.ts
+++ b/tests/e2e/helpers/chart.ts
@@ -8,7 +8,34 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getPool } from './setup';
-import { WP_ROOT } from './env';
+import { WP_ROOT, BASE_URL } from './env';
+
+// ─── HTTP-driven AJAX helpers (used by browser-context specs) ───────────────
+
+/**
+ * Fixed past UTC range used by chart AJAX specs. Picked so existing rows
+ * (or their absence) don't influence allowlist/validation outcomes.
+ *   start: 2026-02-01 00:00 UTC
+ *   end:   2026-03-31 23:59 UTC
+ */
+export const CHART_TEST_RANGE = { start: 1738368000, end: 1743379199 } as const;
+
+/**
+ * Obtain a `slimstat_chart_nonce` via the nonce-helper MU plugin.
+ * Caller must have installed `nonce-helper-mu-plugin.php` in beforeAll.
+ * Auth context is the test runner's WP session (admin, per harness).
+ */
+export async function getChartNonce(page: import('@playwright/test').Page): Promise<string> {
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'test_create_nonce', nonce_action: 'slimstat_chart_nonce' },
+  });
+  if (!res.ok()) throw new Error(`test_create_nonce failed: HTTP ${res.status()}`);
+  const body = await res.json();
+  if (!body?.success || !body?.data?.nonce) {
+    throw new Error(`test_create_nonce returned unexpected body: ${JSON.stringify(body)}`);
+  }
+  return body.data.nonce;
+}
 
 // ─── WP-CLI chart AJAX simulation ───────────────────────────────────────────
 

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -3,7 +3,7 @@
  * Plugin Name: SlimStat Analytics
  * Plugin URI: https://wp-slimstat.com/
  * Description: The leading web analytics plugin for WordPress
- * Version: 5.4.12
+ * Version: 5.4.13
  * Author: Jason Crouse, VeronaLabs
  * Text Domain: wp-slimstat
  * Domain Path: /languages
@@ -20,7 +20,7 @@ if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
 }
 
 // Set the plugin version and directory
-define('SLIMSTAT_ANALYTICS_VERSION', '5.4.12');
+define('SLIMSTAT_ANALYTICS_VERSION', '5.4.13');
 define('SLIMSTAT_FILE', __FILE__);
 define('SLIMSTAT_DIR', __DIR__);
 define('SLIMSTAT_URL', plugins_url('', __FILE__));

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -3,7 +3,7 @@
  * Plugin Name: SlimStat Analytics
  * Plugin URI: https://wp-slimstat.com/
  * Description: The leading web analytics plugin for WordPress
- * Version: 5.4.13
+ * Version: 5.4.12
  * Author: Jason Crouse, VeronaLabs
  * Text Domain: wp-slimstat
  * Domain Path: /languages
@@ -20,7 +20,7 @@ if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
 }
 
 // Set the plugin version and directory
-define('SLIMSTAT_ANALYTICS_VERSION', '5.4.13');
+define('SLIMSTAT_ANALYTICS_VERSION', '5.4.12');
 define('SLIMSTAT_FILE', __FILE__);
 define('SLIMSTAT_DIR', __DIR__);
 define('SLIMSTAT_URL', plugins_url('', __FILE__));


### PR DESCRIPTION
## Summary

Patches a Patchstack-disclosed authenticated SQL Injection (CVSS 8.5, High) in the `slimstat_fetch_chart_data` AJAX endpoint. The `chart_data.where` JSON parameter was concatenated directly into the SQL query passed to `Query::whereRaw()` with no parameter binding. Any logged-in **Subscriber** who could obtain the chart nonce — exposed on any frontend page that renders a Slimstat chart shortcode like `[slimstat f="widget" w="slim_p1_01"]` — could execute time-based blind SQL injection via a payload that wraps `SLEEP()` in a conditional `IF(...)`.

The `data1` / `data2` allowlist introduced in PR #232 already covered the aggregate-expression vector; this PR closes the parallel `where` vector.

**Patchstack disclosure date:** 18 May 2026. This needs to ride 5.4.12.

## Approach

Validate the supplied `where` clause against an allowlist built at request time from `wp_slimstat_reports::$reports`. Every WHERE clause declared by a registered report — including any added by Pro addons via the `slimstat_reports_info` filter — is harvested, whitespace-normalized, and compared for equality. Anything not in the allowlist throws `\Exception`, which the handler already catches and returns as `wp_send_json_error()` (same shape as the existing `validateSqlExpression()` failures).

Why allowlist over server-side `report_id` resolution: the chart JS ships the entire `args` blob and has no awareness of the report ID it belongs to. A registry-based allowlist auto-handles third-party reports (their clauses join the allowlist after the filter fires) and dynamic clauses like `slim_p3_01` (interpolates `home_url()`) and `slim_p7_02` (interpolates `date_i18n('U') - 300`) since the allowlist rebuilds per request.

Capability check intentionally stays at `'read'`. Tightening would break the legitimate Subscriber-views-shortcode-on-frontend-page flow that the threat model itself depends on.

## What changed

- **`src/Modules/Chart.php`** — new `getAllowedWhereClauses()` and `normalizeSqlWhitespace()`; vulnerable concat at `sqlFor()` replaced with allowlist check.
- **`tests/e2e/chart-where-allowlist-validation.spec.ts`** — 6-case regression test, including the Patchstack PoC with a sub-1500ms timing assertion that proves the SLEEP payload was rejected before reaching the query layer.
- **`tests/e2e/helpers/chart.ts`** — extracted `getChartNonce()` and `CHART_TEST_RANGE` so both chart specs share them. Existing `chart-sql-expression-validation.spec.ts` refactored to use them.
- **`CHANGELOG.md` / `readme.txt`** — Security entry added to the existing 5.4.12 changelog block. No version bump (5.4.12 is still pending release).

## Test plan

- [ ] `composer test:all` (PHP unit suite — no impact expected)
- [ ] `npx playwright test tests/e2e/chart-where-allowlist-validation.spec.ts` — all 6 cases green, including the timing assertion on the SLEEP payload
- [ ] `npx playwright test tests/e2e/chart-sql-expression-validation.spec.ts` — existing 4 cases still green after helper extraction
- [ ] Manual repro of the Patchstack PoC against the patched build — Subscriber + extracted nonce + crafted POST returns `{"success":false}` in well under the SLEEP delay
- [ ] Smoke-test admin dashboard charts that DO use a registered `where` (Audience → Search Terms `slim_p1_19_01`, Site Analysis → Human Visits `slim_p2_01`) — granularity changes still re-render
- [ ] Smoke-test as Subscriber against a public page with `[slimstat f="widget" w="slim_p2_01"]` — chart still renders/redraws (regression-risk scenario for the allowlist)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Chart data reporting now validates user-supplied WHERE filters against a trusted allowlist of report-declared clauses; changelog and readme updated.

* **Tests**
  * Added end-to-end tests that exercise allowed WHERE clauses, reject SQLi-like payloads, include shared test helpers, and use a stable chart time range for reliable E2E runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->