### PR TITLE
security: narrow vendored Symfony Console dev-dep range to exclude vulnerable symfony/process

### DIFF
--- a/src/Dependencies/Symfony/Component/Console/composer.json
+++ b/src/Dependencies/Symfony/Component/Console/composer.json
@@ -29,7 +29,7 @@
         "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
         "symfony/dependency-injection": "^4.4|^5.0|^6.0",
         "symfony/lock": "^4.4|^5.0|^6.0",
-        "symfony/process": "^4.4|^5.0|^6.0",
+        "symfony/process": "^5.4.51|^6.0",
         "symfony/var-dumper": "^4.4|^5.0|^6.0",
         "psr/log": "^1|^2"
     },


### PR DESCRIPTION
## Summary

GitHub Dependabot flagged two CVEs against the vendored Symfony Console's `composer.json` constraint for `symfony/process`:

- **[GHSA-qq5c-677p-737q](https://github.com/advisories/GHSA-qq5c-677p-737q)** (HIGH) — command-execution hijack on Windows, fixed in 5.4.46
- **[GHSA-r39x-jcww-82v6](https://github.com/advisories/GHSA-r39x-jcww-82v6)** (MEDIUM) — incorrect argument escaping under MSYS2 / Git Bash on Windows, fixed in 5.4.51

## Impact analysis (no runtime risk)

The vulnerable component (`symfony/process`) is in the bundled Console's `require-dev` block — **it is NOT installed in the production bundle**. There is no `src/Dependencies/Symfony/Component/Process/` directory; only `Console`, `BrowscapPHP`, etc. The vulnerability is unreachable at runtime.

Dependabot scans manifest text and matched the unbounded `^4.4|^5.0|^6.0` constraint against the vulnerable ranges. Narrow the constraint to `^5.4.51|^6.0`:

- excludes 4.4.x (EOL, never received the fix)
- excludes 5.0.x – 5.4.50 (vulnerable)
- allows 5.4.51+ and 6.x (patched)

Closes both alerts.

## Test plan

- [ ] Confirm CI still passes (no behavioural change)
- [ ] After merge to `development` → `master`, the two Dependabot alerts auto-close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency constraints to refine version compatibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->