### PR TITLE
security: fix CVE-2026-7634 stored XSS via User-Agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 = 5.4.12 - 2026-04-18 =
 
+**Security**
+
+- Patched unauthenticated stored XSS via the `User-Agent` header ([CVE-2026-7634](https://nvd.nist.gov/vuln/detail/CVE-2026-7634), CVSS 7.2). `Storage::updateRow()` now mirrors `insertRow()`'s `sanitize_text_field()`/`sanitize_url()` loop so a redirect (`Processor::updateContentType`) or AJAX follow-up (`Ajax::process` navigation/outbound/event branches) can no longer overwrite the inserted row with raw HTML. The User-Agent header is also sanitized on capture in `Browscap::_get_user_agent()`, and `wp_slimstat_reports::inline_help()` defangs unsafe HTML via `wp_kses_post()` before rendering — defense in depth across capture, storage, and output. Reported by Supakiad S. (m3ez) — E-CQURITY (Thailand) via Wordfence. Required `show_complete_user_agent_tooltip` to be enabled (off by default) for the stored payload to render in the admin Browsers report.
+
 **Bot detection hardening**
 
 - Chrome-based mobile Googlebot and Bingbot are now correctly blocked when Browscap classifies them as mobile devices ([#14843](https://wp-slimstat.com/), [#291](https://github.com/wp-slimstat/wp-slimstat/issues/291)). The bot-detection safety net previously only re-checked desktop-classified UAs (`browser_type === 0`); it now re-checks every non-crawler type (desktop, mobile, touch) so Android/Chrome-suffixed crawler UAs no longer slip through.

--- a/admin/view/wp-slimstat-reports.php
+++ b/admin/view/wp-slimstat-reports.php
@@ -2096,7 +2096,9 @@ class wp_slimstat_reports
     public static function inline_help($_text = '', $_echo = true)
     {
         if (is_admin() && !empty($_text)) {
-            $wrapped_text = sprintf("<span class='dashicons dashicons-editor-help slimstat-tooltip-trigger corner'><span class='slimstat-tooltip-content'>%s</span></span>", $_text);
+            // CVE-2026-7634: defang attacker-controlled $_text. wp_kses_post preserves
+            // the formatting tags existing tooltips rely on.
+            $wrapped_text = sprintf("<span class='dashicons dashicons-editor-help slimstat-tooltip-trigger corner'><span class='slimstat-tooltip-content'>%s</span></span>", wp_kses_post($_text));
         } else {
             $wrapped_text = '';
         }

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
     "test:browscap-filesystem": "php tests/browscap-wp-filesystem-test.php",
     "test:dnt-gdpr": "php tests/dnt-gdpr-independence-test.php",
     "test:browscap-bot-safety": "php tests/browscap-bot-safety-net-test.php",
+    "test:storage-update-sanitize": "php tests/storage-update-sanitization-test.php",
     "test:unit": "phpunit --configuration phpunit.xml.dist",
     "test:all": [
       "@test:unit",
@@ -98,7 +99,8 @@
       "@test:browscap-isolation",
       "@test:browscap-filesystem",
       "@test:dnt-gdpr",
-      "@test:browscap-bot-safety"
+      "@test:browscap-bot-safety",
+      "@test:storage-update-sanitize"
     ]
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,7 @@ An extensive knowledge base is available on our [website](https://www.wp-slimsta
 
 == Changelog ==
 = 5.4.12 - 2026-04-18 =
+* Security: Patch unauthenticated stored XSS via the User-Agent header (CVE-2026-7634). Storage::updateRow() now mirrors insertRow()'s sanitization, the User-Agent is sanitized at capture in Browscap, and admin tooltips are escaped via wp_kses_post(). Reported by Supakiad S. (m3ez) — E-CQURITY (Thailand) via Wordfence.
 * Fix: Chrome-based mobile Googlebot and Bingbot now correctly blocked when Browscap classifies them as mobile devices (#14843)
 * Fix: Google-InspectionTool mobile is now detected as a crawler
 * Improvement: Bot detection regex extended with 15 new vendor tokens — Mediapartners-Google, Google-InspectionTool, Google-Site-Verification, Google Favicon, GoogleOther, GoogleAgent-Mariner, Google-Safety, DuplexWeb-Google, BingPreview, YandexDirect, YandexFavicons, WhatsApp preview, SkypeUriPreview, anthropic-ai, cohere-ai

--- a/src/Services/Browscap.php
+++ b/src/Services/Browscap.php
@@ -266,17 +266,23 @@ class Browscap
 
     protected static function _get_user_agent()
     {
-
-        $user_agent = (empty($_SERVER['HTTP_USER_AGENT']) ? '' : trim($_SERVER['HTTP_USER_AGENT']));
+        // CVE-2026-7634: sanitize at the source so a malicious UA cannot reach
+        // storage or render layers as raw HTML. Mirrors the pattern used in
+        // Session.php and IPHashProvider.php. Bot/crawler regex matching downstream
+        // (UADetector::BOT_GENERIC_REGEX, BrowscapPHP) operates on alphanumerics
+        // and punctuation that sanitize_text_field preserves.
+        $user_agent = empty($_SERVER['HTTP_USER_AGENT'])
+            ? ''
+            : trim(sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])));
         $real_user_agent = '';
         if (!empty($_SERVER['HTTP_X_DEVICE_USER_AGENT'])) {
-            $real_user_agent = trim($_SERVER['HTTP_X_DEVICE_USER_AGENT']);
+            $real_user_agent = trim(sanitize_text_field(wp_unslash($_SERVER['HTTP_X_DEVICE_USER_AGENT'])));
         } elseif (!empty($_SERVER['HTTP_X_ORIGINAL_USER_AGENT'])) {
-            $real_user_agent = trim($_SERVER['HTTP_X_ORIGINAL_USER_AGENT']);
+            $real_user_agent = trim(sanitize_text_field(wp_unslash($_SERVER['HTTP_X_ORIGINAL_USER_AGENT'])));
         } elseif (!empty($_SERVER['HTTP_X_MOBILE_UA'])) {
-            $real_user_agent = trim($_SERVER['HTTP_X_MOBILE_UA']);
+            $real_user_agent = trim(sanitize_text_field(wp_unslash($_SERVER['HTTP_X_MOBILE_UA'])));
         } elseif (!empty($_SERVER['HTTP_X_OPERAMINI_PHONE_UA'])) {
-            $real_user_agent = trim($_SERVER['HTTP_X_OPERAMINI_PHONE_UA']);
+            $real_user_agent = trim(sanitize_text_field(wp_unslash($_SERVER['HTTP_X_OPERAMINI_PHONE_UA'])));
         }
 
         if ('' !== $real_user_agent && '0' !== $real_user_agent && (strlen($real_user_agent) >= 5 || ('' === $user_agent || '0' === $user_agent))) {

--- a/src/Tracker/Storage.php
+++ b/src/Tracker/Storage.php
@@ -31,6 +31,19 @@ class Storage
 		$id = abs(intval($data['id']));
 		unset($data['id']);
 
+		// CVE-2026-7634: mirror insertRow()'s sanitization so an UPDATE cannot
+		// overwrite the row with raw HTML. Run before array_filter so values that
+		// sanitize to '' get dropped along with originals.
+		foreach ($data as $key => $value) {
+			if (is_array($value)) {
+				$data[$key] = array_map('sanitize_text_field', $value);
+			} elseif ('resource' === $key || 'outbound_resource' === $key) {
+				$data[$key] = sanitize_url($value);
+			} else {
+				$data[$key] = sanitize_text_field($value);
+			}
+		}
+
 		$data = array_filter($data);
 
 		$table_name = $GLOBALS['wpdb']->prefix . 'slim_stats';

--- a/src/Tracker/Storage.php
+++ b/src/Tracker/Storage.php
@@ -48,11 +48,13 @@ class Storage
 
 		$table_name = $GLOBALS['wpdb']->prefix . 'slim_stats';
 		$query = Query::update($table_name)->ignore()->where('id', '=', $id);
+		$hasUpdates = false;
 
 		if (!empty($data['notes']) && is_array($data['notes'])) {
 			$notes_to_append = '[' . implode('][', $data['notes']) . ']';
 			$query->setRaw('notes', "CONCAT(IFNULL(notes, ''), %s)", [$notes_to_append]);
 			unset($data['notes']);
+			$hasUpdates = true;
 		}
 
 		if (!empty($data['outbound_resource'])) {
@@ -63,10 +65,18 @@ class Storage
 				[$url, $url, $url]
 			);
 			unset($data['outbound_resource']);
+			$hasUpdates = true;
 		}
 
 		if ($data !== []) {
 			$query->set($data);
+			$hasUpdates = true;
+		}
+
+		// If sanitization stripped every field there is nothing to write — skip
+		// the execute() to avoid emitting `UPDATE ... SET  WHERE id=X` (invalid SQL).
+		if (!$hasUpdates) {
+			return $id;
 		}
 
 		$query->execute();

--- a/tests/e2e/cve-2026-7634-user-agent-xss.spec.ts
+++ b/tests/e2e/cve-2026-7634-user-agent-xss.spec.ts
@@ -8,7 +8,7 @@
  * Reported by Supakiad S. (m3ez) - E-CQURITY (Thailand).
  */
 import { test, expect, Page } from '@playwright/test';
-import { BASE_URL } from './helpers/env';
+import { BASE_URL, ADMIN_USER, ADMIN_PASS } from './helpers/env';
 import {
   getPool,
   closeDb,
@@ -17,6 +17,18 @@ import {
   snapshotSlimstatOptions,
   restoreSlimstatOptions,
 } from './helpers/setup';
+
+declare global {
+  interface Window {
+    __xss_fired?: boolean;
+  }
+}
+
+interface UserAgentRow {
+  user_agent: string;
+}
+type StatsRow = Record<string, unknown> & { id: number; user_agent: string; browser_type?: number };
+type QueryResult<T> = [T[], unknown];
 
 const XSS_PAYLOAD =
   'Mozilla/5.0 (Windows NT 10.0) <img src=x onerror=alert(/XSS_94821/)>';
@@ -28,8 +40,8 @@ async function ensureLoggedIn(page: Page): Promise<void> {
     await page.goto(`${BASE_URL}/wp-login.php`);
   }
   if (page.url().includes('wp-login.php')) {
-    await page.fill('#user_login', 'parhumm');
-    await page.fill('#user_pass', 'testpass123');
+    await page.fill('#user_login', ADMIN_USER);
+    await page.fill('#user_pass', ADMIN_PASS);
     await page.click('#wp-submit');
     await page.waitForURL('**/wp-admin/**', { timeout: 30_000 });
   }
@@ -38,15 +50,33 @@ async function ensureLoggedIn(page: Page): Promise<void> {
 async function getLatestUserAgent(): Promise<string | null> {
   const [rows] = (await getPool().execute(
     'SELECT user_agent FROM wp_slim_stats ORDER BY id DESC LIMIT 1'
-  )) as any;
+  )) as QueryResult<UserAgentRow>;
   return rows.length > 0 ? rows[0].user_agent : null;
 }
 
-async function getLatestRow(): Promise<Record<string, any> | null> {
+async function getLatestRow(): Promise<StatsRow | null> {
   const [rows] = (await getPool().execute(
     'SELECT * FROM wp_slim_stats ORDER BY id DESC LIMIT 1'
-  )) as any;
+  )) as QueryResult<StatsRow>;
   return rows.length > 0 ? rows[0] : null;
+}
+
+/**
+ * Polls the supplied async getter until it returns a non-null value or the
+ * timeout elapses. Replaces fixed waitForTimeout sleeps after server-side
+ * tracking writes, where the DB write is async relative to the HTTP response.
+ */
+async function waitForStored<T>(
+  getter: () => Promise<T | null>,
+  timeoutMs = 3_000,
+): Promise<T | null> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const value = await getter();
+    if (value !== null) return value;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return null;
 }
 
 test.describe('CVE-2026-7634 — Stored XSS via User-Agent header', () => {
@@ -84,10 +114,8 @@ test.describe('CVE-2026-7634 — Stored XSS via User-Agent header', () => {
     });
     expect(response.status(), '301 redirect must fire to trigger updateContentType').toBe(301);
 
-    // Allow the wp_redirect_status filter chain to flush updateRow().
-    await page.waitForTimeout(1_500);
-
-    const stored = await getLatestUserAgent();
+    // Wait for wp_redirect_status → updateRow() to flush by polling the DB.
+    const stored = await waitForStored(getLatestUserAgent);
     expect(stored, 'A row must be stored on the redirect path').not.toBeNull();
     expect(stored, 'user_agent must not contain raw <img tag').not.toContain('<img');
     expect(stored, 'user_agent must not contain onerror handler').not.toContain('onerror');
@@ -110,8 +138,10 @@ test.describe('CVE-2026-7634 — Stored XSS via User-Agent header', () => {
     const helpIcon = page.locator('.slimstat-tooltip-trigger.corner').first();
     if (await helpIcon.count() > 0) {
       await helpIcon.hover().catch(() => {});
-      await page.waitForTimeout(2_500);
     }
+    // Any XSS would fire synchronously during DOM parsing or the hover handler;
+    // wait for network to settle so we know the page is fully resolved before asserting.
+    await page.waitForLoadState('networkidle').catch(() => {});
 
     expect(dialogTriggered, 'XSS must not execute in admin Browsers report').toBe(false);
 
@@ -127,16 +157,18 @@ test.describe('CVE-2026-7634 — Stored XSS via User-Agent header', () => {
       headers: { 'User-Agent': XSS_PAYLOAD },
     });
     expect(seed.status()).toBeLessThan(400);
-    await page.waitForTimeout(800);
 
-    const seeded = await getLatestRow();
+    // Poll for the seed row to land; bot-exclusion or other settings may suppress it.
+    const seeded = await waitForStored(getLatestRow);
     if (!seeded) {
       test.skip(true, 'Seed pageview did not land — server-side tracking may be disabled');
       return;
     }
 
     // Trigger an outbound link update — even if the AJAX flow rejects (no nonce, etc.)
-    // the storage assertion still catches any update that did persist.
+    // the storage assertion still catches any update that did persist. The POST
+    // resolves synchronously with the server response, so the row state is
+    // observable immediately after.
     await request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
       headers: { 'User-Agent': XSS_PAYLOAD },
       form: {
@@ -145,7 +177,6 @@ test.describe('CVE-2026-7634 — Stored XSS via User-Agent header', () => {
         res: Buffer.from('https://external.example.com/some-target').toString('base64url'),
       },
     });
-    await page.waitForTimeout(800);
 
     const after = await getLatestUserAgent();
     if (after === null) {
@@ -184,11 +215,13 @@ test.describe('CVE-2026-7634 — Stored XSS via User-Agent header', () => {
     await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`, {
       waitUntil: 'domcontentloaded',
     });
-    await page.waitForTimeout(2_500);
+    // Inline <script> in the DOM would have executed during DCL; wait for the
+    // network to settle so deferred scripts/dialogs also have a chance to fire.
+    await page.waitForLoadState('networkidle').catch(() => {});
 
     // Even if the script tag survived in the DB row, wp_kses_post() must strip it
     // before output, so the inline script must never execute.
-    const xssFired = await page.evaluate(() => (window as any).__xss_fired === true);
+    const xssFired = await page.evaluate(() => window.__xss_fired === true);
     expect(xssFired, 'inline <script> in stored UA must not execute').toBe(false);
     expect(dialogTriggered, 'no alert dialogs from rendered tooltips').toBe(false);
 
@@ -208,16 +241,17 @@ test.describe('CVE-2026-7634 — Stored XSS via User-Agent header', () => {
       'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
 
     await request.get(`${BASE_URL}/`, { headers: { 'User-Agent': botUA } });
-    await page.waitForTimeout(1_000);
 
-    const row = await getLatestRow();
+    // Bot exclusion may suppress storage; poll briefly and skip cleanly if so.
+    const row = await waitForStored(getLatestRow);
     if (!row) {
       test.skip(true, 'No row stored — server-side tracking may exclude bots by setting');
+      return;
     }
-    expect(row?.user_agent, 'bot UA preserved through sanitization').toContain('Googlebot');
+    expect(row.user_agent, 'bot UA preserved through sanitization').toContain('Googlebot');
     // browser_type=1 means crawler. UADetector regex catches "Googlebot" keyword
     // — sanitize_text_field doesn't strip alphanumerics, so detection survives.
-    expect([1, 0]).toContain(row?.browser_type as number);
+    expect([0, 1]).toContain(row.browser_type as number);
   });
 
   // ─── Test 5: Regression — legitimate HTML in tooltips still renders ──
@@ -229,7 +263,7 @@ test.describe('CVE-2026-7634 — Stored XSS via User-Agent header', () => {
     await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`, {
       waitUntil: 'domcontentloaded',
     });
-    await page.waitForTimeout(1_500);
+    await page.waitForLoadState('networkidle').catch(() => {});
 
     const html = await page.content();
     // The Visitors / Activity report tooltip at line 111 contains <strong> and

--- a/tests/e2e/cve-2026-7634-user-agent-xss.spec.ts
+++ b/tests/e2e/cve-2026-7634-user-agent-xss.spec.ts
@@ -1,0 +1,242 @@
+/**
+ * E2E roundtrip test for CVE-2026-7634 — Stored XSS via User-Agent header.
+ *
+ * Reproduces the published Wordfence PoC plus the three additional
+ * Storage::updateRow() callers in Ajax.php (navigation, outbound, event)
+ * to prove the storage-layer fix closes every reachable path.
+ *
+ * Reported by Supakiad S. (m3ez) - E-CQURITY (Thailand).
+ */
+import { test, expect, Page } from '@playwright/test';
+import { BASE_URL } from './helpers/env';
+import {
+  getPool,
+  closeDb,
+  clearStatsTable,
+  setSlimstatOptions,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+} from './helpers/setup';
+
+const XSS_PAYLOAD =
+  'Mozilla/5.0 (Windows NT 10.0) <img src=x onerror=alert(/XSS_94821/)>';
+const XSS_MARKER = 'onerror=alert';
+
+async function ensureLoggedIn(page: Page): Promise<void> {
+  const url = page.url();
+  if (url === 'about:blank' || !url.includes('wp-login.php')) {
+    await page.goto(`${BASE_URL}/wp-login.php`);
+  }
+  if (page.url().includes('wp-login.php')) {
+    await page.fill('#user_login', 'parhumm');
+    await page.fill('#user_pass', 'testpass123');
+    await page.click('#wp-submit');
+    await page.waitForURL('**/wp-admin/**', { timeout: 30_000 });
+  }
+}
+
+async function getLatestUserAgent(): Promise<string | null> {
+  const [rows] = (await getPool().execute(
+    'SELECT user_agent FROM wp_slim_stats ORDER BY id DESC LIMIT 1'
+  )) as any;
+  return rows.length > 0 ? rows[0].user_agent : null;
+}
+
+async function getLatestRow(): Promise<Record<string, any> | null> {
+  const [rows] = (await getPool().execute(
+    'SELECT * FROM wp_slim_stats ORDER BY id DESC LIMIT 1'
+  )) as any;
+  return rows.length > 0 ? rows[0] : null;
+}
+
+test.describe('CVE-2026-7634 — Stored XSS via User-Agent header', () => {
+  test.setTimeout(90_000);
+
+  test.beforeAll(async ({}, _testInfo) => {
+    await snapshotSlimstatOptions();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await clearStatsTable();
+    // Enable the vulnerable rendering path and force server-side tracking.
+    await setSlimstatOptions(page, {
+      show_complete_user_agent_tooltip: 'on',
+      javascript_mode: 'off',
+      enable_browscap: 'no',
+    });
+  });
+
+  test.afterAll(async () => {
+    await restoreSlimstatOptions();
+    await closeDb();
+  });
+
+  // ─── Test 1: Reproduce the published PoC verbatim ───────────────────
+
+  test('redirect path (Processor::updateContentType) sanitizes user_agent', async ({
+    page,
+    request,
+  }) => {
+    // The advisory uses /sample-page (no trailing slash) which triggers a 301.
+    const response = await request.get(`${BASE_URL}/sample-page`, {
+      headers: { 'User-Agent': XSS_PAYLOAD },
+      maxRedirects: 0,
+    });
+    expect(response.status(), '301 redirect must fire to trigger updateContentType').toBe(301);
+
+    // Allow the wp_redirect_status filter chain to flush updateRow().
+    await page.waitForTimeout(1_500);
+
+    const stored = await getLatestUserAgent();
+    expect(stored, 'A row must be stored on the redirect path').not.toBeNull();
+    expect(stored, 'user_agent must not contain raw <img tag').not.toContain('<img');
+    expect(stored, 'user_agent must not contain onerror handler').not.toContain('onerror');
+    expect(stored, 'sanitized UA still contains the benign prefix').toContain('Mozilla/5.0');
+
+    // Render the admin Browsers report and confirm no dialog fires.
+    let dialogTriggered = false;
+    page.on('dialog', async (d) => {
+      dialogTriggered = true;
+      await d.dismiss();
+    });
+
+    await ensureLoggedIn(page);
+    const adminResp = await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(adminResp?.status(), 'Browsers report must load').toBeLessThan(500);
+
+    // Hover the help icon to trigger the tooltip rendering as the advisory describes.
+    const helpIcon = page.locator('.slimstat-tooltip-trigger.corner').first();
+    if (await helpIcon.count() > 0) {
+      await helpIcon.hover().catch(() => {});
+      await page.waitForTimeout(2_500);
+    }
+
+    expect(dialogTriggered, 'XSS must not execute in admin Browsers report').toBe(false);
+
+    const html = await page.content();
+    expect(html, 'rendered HTML must not contain onerror=').not.toContain(XSS_MARKER);
+  });
+
+  // ─── Test 2: Outbound link path (Ajax.php:377) ──────────────────────
+
+  test('outbound link tracking path sanitizes user_agent on update', async ({ request, page }) => {
+    // Seed a row first so the outbound update has something to attach to.
+    const seed = await request.get(`${BASE_URL}/`, {
+      headers: { 'User-Agent': XSS_PAYLOAD },
+    });
+    expect(seed.status()).toBeLessThan(400);
+    await page.waitForTimeout(800);
+
+    const seeded = await getLatestRow();
+    if (!seeded) {
+      test.skip(true, 'Seed pageview did not land — server-side tracking may be disabled');
+      return;
+    }
+
+    // Trigger an outbound link update — even if the AJAX flow rejects (no nonce, etc.)
+    // the storage assertion still catches any update that did persist.
+    await request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+      headers: { 'User-Agent': XSS_PAYLOAD },
+      form: {
+        action: 'slimtrack',
+        id: String(seeded.id),
+        res: Buffer.from('https://external.example.com/some-target').toString('base64url'),
+      },
+    });
+    await page.waitForTimeout(800);
+
+    const after = await getLatestUserAgent();
+    if (after === null) {
+      test.skip(true, 'outbound AJAX request was rejected before reaching storage — not a fix regression but cannot exercise the path');
+      return;
+    }
+    expect(after, 'outbound update must not store raw <img tag').not.toContain('<img');
+    expect(after, 'outbound update must not store onerror handler').not.toContain('onerror');
+  });
+
+  // ─── Test 3: Direct DB seed → admin render is safe (rendering layer) ─
+
+  test('admin renders existing malicious row safely (output layer defense)', async ({ page }) => {
+    // Pre-fix data could already exist in the wild. Defense-in-depth means
+    // wp_kses_post() must defang it at render time even if storage was bypassed.
+    await getPool().execute(
+      'INSERT INTO wp_slim_stats (ip, resource, dt, user_agent, browser, browser_version, visit_id) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [
+        '127.0.0.1',
+        '/e2e-cve-2026-7634/',
+        Math.floor(Date.now() / 1000),
+        '<script>window.__xss_fired = true;</script>Mozilla/5.0',
+        'Chrome',
+        '120',
+        Date.now(),
+      ]
+    );
+
+    let dialogTriggered = false;
+    page.on('dialog', async (d) => {
+      dialogTriggered = true;
+      await d.dismiss();
+    });
+
+    await ensureLoggedIn(page);
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview3`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.waitForTimeout(2_500);
+
+    // Even if the script tag survived in the DB row, wp_kses_post() must strip it
+    // before output, so the inline script must never execute.
+    const xssFired = await page.evaluate(() => (window as any).__xss_fired === true);
+    expect(xssFired, 'inline <script> in stored UA must not execute').toBe(false);
+    expect(dialogTriggered, 'no alert dialogs from rendered tooltips').toBe(false);
+
+    const html = await page.content();
+    expect(html, 'rendered HTML must not contain a working <script> from the UA').not.toContain(
+      '<script>window.__xss_fired'
+    );
+  });
+
+  // ─── Test 4: Regression — bot detection still works after sanitization ─
+
+  test('Googlebot UA is still classified as a bot after sanitize_text_field', async ({
+    request,
+    page,
+  }) => {
+    const botUA =
+      'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+
+    await request.get(`${BASE_URL}/`, { headers: { 'User-Agent': botUA } });
+    await page.waitForTimeout(1_000);
+
+    const row = await getLatestRow();
+    if (!row) {
+      test.skip(true, 'No row stored — server-side tracking may exclude bots by setting');
+    }
+    expect(row?.user_agent, 'bot UA preserved through sanitization').toContain('Googlebot');
+    // browser_type=1 means crawler. UADetector regex catches "Googlebot" keyword
+    // — sanitize_text_field doesn't strip alphanumerics, so detection survives.
+    expect([1, 0]).toContain(row?.browser_type as number);
+  });
+
+  // ─── Test 5: Regression — legitimate HTML in tooltips still renders ──
+
+  test('admin tooltips with legitimate HTML still render formatted (wp_kses_post)', async ({
+    page,
+  }) => {
+    await ensureLoggedIn(page);
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.waitForTimeout(1_500);
+
+    const html = await page.content();
+    // The Visitors / Activity report tooltip at line 111 contains <strong> and
+    // <span class="little-color-box">. After wp_kses_post we must still see at
+    // least one of those tags rendered (not escaped to literal text).
+    const hasFormattedTooltip = /<span class="little-color-box[^"]*">/.test(html) ||
+      /slimstat-tooltip-content[^>]*>[^<]*<strong>/.test(html);
+    expect(hasFormattedTooltip, 'tooltip HTML must survive wp_kses_post').toBe(true);
+  });
+});

--- a/tests/reports-output-escaping-test.php
+++ b/tests/reports-output-escaping-test.php
@@ -287,4 +287,64 @@ assert_contains('&lt;b&gt;bold&lt;/b&gt;', $html, 'Notes must be HTML-escaped');
 $html = render_column('fingerprint', "test\x00<script>xss</script>");
 assert_not_contains('<script>xss</script>', $html, 'Null byte must not bypass escaping');
 
+// ─── CVE-2026-7634: Browsers report user_agent tooltip XSS ──────────
+
+function render_browser_row(string $user_agent, string $tooltip_setting): string
+{
+    wp_slimstat::$settings['show_complete_user_agent_tooltip'] = $tooltip_setting;
+
+    $test_data = [
+        [
+            'browser'         => 'Chrome',
+            'browser_version' => '120',
+            'user_agent'      => $user_agent,
+            'counthits'       => 1,
+        ],
+    ];
+
+    ob_start();
+    wp_slimstat_reports::raw_results_to_html([
+        'columns'   => 'browser',
+        'type'      => 'top',
+        'raw'       => make_data_callback($test_data),
+        'where'     => '',
+        'filter_op' => 'equals',
+    ]);
+    return ob_get_clean();
+}
+
+// Test 14: Malicious user_agent rendered with tooltip ON has script-like markup defanged.
+$html = render_browser_row('Mozilla/5.0 <img src=x onerror=alert(/XSS_94821/)>', 'on');
+assert_not_contains('onerror=', $html, 'onerror attribute must be stripped from rendered tooltip');
+assert_contains('Mozilla/5.0', $html, 'Benign UA prefix still rendered');
+
+// Test 15: <script> in user_agent is removed from rendered tooltip (wp_kses_post strips script).
+$html = render_browser_row('<script>alert(1)</script>UA', 'on');
+assert_not_contains('<script>alert(1)</script>', $html, 'script tag must be stripped from tooltip');
+
+// Test 16: Tooltip-OFF baseline — no tooltip span emitted, gating still works.
+$html = render_browser_row('Mozilla/5.0', 'off');
+assert_not_contains('slimstat-tooltip-content', $html, 'No tooltip span when setting is off');
+
+// Test 17: inline_help() preserves legitimate HTML used in existing tooltips (regression guard).
+$rendered = wp_slimstat_reports::inline_help('<strong>Tip:</strong> read the <a href="/docs">docs</a>', false);
+assert_contains('<strong>', $rendered, 'wp_kses_post preserves <strong> in tooltip text');
+assert_contains('</strong>', $rendered, 'wp_kses_post preserves </strong>');
+assert_contains('<a href="/docs">', $rendered, 'wp_kses_post preserves safe <a href> tags');
+
+// Test 18: inline_help() strips event-handler attributes.
+$rendered = wp_slimstat_reports::inline_help('<img src=x onerror=alert(1)>', false);
+assert_not_contains('onerror', $rendered, 'wp_kses_post strips onerror handler');
+
+// Test 19: inline_help() strips <script> tags entirely.
+$rendered = wp_slimstat_reports::inline_help('<script>alert(1)</script>after', false);
+assert_not_contains('<script', $rendered, 'wp_kses_post strips <script> tags');
+
+// Test 20: inline_help() preserves common formatting tags used in report tooltips (<em>, <br>, <p>, <span class>).
+$rendered = wp_slimstat_reports::inline_help('<em>note</em><br><p><span class="x">hi</span></p>', false);
+assert_contains('<em>', $rendered, 'wp_kses_post preserves <em>');
+assert_contains('<br', $rendered, 'wp_kses_post preserves <br>');
+assert_contains('<p>', $rendered, 'wp_kses_post preserves <p>');
+assert_contains('<span class="x">', $rendered, 'wp_kses_post preserves <span class>');
+
 echo "All {$assertions} assertions passed in reports-output-escaping-test.php\n";

--- a/tests/storage-update-sanitization-test.php
+++ b/tests/storage-update-sanitization-test.php
@@ -1,0 +1,305 @@
+<?php
+
+/**
+ * Tests for Storage::updateRow() sanitization parity with Storage::insertRow().
+ *
+ * Covers: CVE-2026-7634 — Storage::updateRow() lacked the sanitize_text_field()
+ * loop that Storage::insertRow() applies, allowing raw HTML/JS in user_agent
+ * (and other columns) to overwrite the sanitized row when a request triggered
+ * a redirect (Processor::updateContentType) or AJAX update (Ajax::process).
+ *
+ * Run: php tests/storage-update-sanitization-test.php
+ */
+
+declare(strict_types=1);
+
+// ─── Fake Query / wpdb that captures the SQL payload ───────────────
+
+namespace SlimStat\Utils {
+
+    class FakeQueryRecorder
+    {
+        public static array $setClauses = [];
+        public static array $setRawClauses = [];
+        public static array $setRawParams = [];
+        public static ?int $where_id = null;
+        public static int $executeCalls = 0;
+
+        public static function reset(): void
+        {
+            self::$setClauses     = [];
+            self::$setRawClauses  = [];
+            self::$setRawParams   = [];
+            self::$where_id       = null;
+            self::$executeCalls   = 0;
+        }
+    }
+
+    class Query
+    {
+        public static function update($table)
+        {
+            return new self();
+        }
+
+        public function ignore($flag = true)
+        {
+            return $this;
+        }
+
+        public function where($field, $operator, $value)
+        {
+            if ('id' === $field) {
+                FakeQueryRecorder::$where_id = (int) $value;
+            }
+            return $this;
+        }
+
+        public function set($values)
+        {
+            FakeQueryRecorder::$setClauses = $values;
+            return $this;
+        }
+
+        public function setRaw($column, $expression, $params = [])
+        {
+            FakeQueryRecorder::$setRawClauses[$column] = $expression;
+            FakeQueryRecorder::$setRawParams[$column]  = $params;
+            return $this;
+        }
+
+        public function execute()
+        {
+            FakeQueryRecorder::$executeCalls++;
+            return 1;
+        }
+    }
+}
+
+namespace {
+
+    $assertions = 0;
+
+    function assert_same($expected, $actual, string $message): void
+    {
+        global $assertions;
+        $assertions++;
+
+        if ($expected !== $actual) {
+            fwrite(STDERR, "FAIL: {$message} (expected " . var_export($expected, true) . ', got ' . var_export($actual, true) . ")\n");
+            exit(1);
+        }
+    }
+
+    function assert_true($actual, string $message): void
+    {
+        global $assertions;
+        $assertions++;
+
+        if ($actual !== true) {
+            fwrite(STDERR, "FAIL: {$message} (expected true, got " . var_export($actual, true) . ")\n");
+            exit(1);
+        }
+    }
+
+    function assert_false($actual, string $message): void
+    {
+        global $assertions;
+        $assertions++;
+
+        if ($actual !== false) {
+            fwrite(STDERR, "FAIL: {$message} (expected false, got " . var_export($actual, true) . ")\n");
+            exit(1);
+        }
+    }
+
+    function assert_not_contains(string $needle, string $haystack, string $message): void
+    {
+        global $assertions;
+        $assertions++;
+
+        if (strpos($haystack, $needle) !== false) {
+            fwrite(STDERR, "FAIL: {$message}\n  Expected NOT to contain: '{$needle}'\n  In: '{$haystack}'\n");
+            exit(1);
+        }
+    }
+
+    function assert_contains(string $needle, string $haystack, string $message): void
+    {
+        global $assertions;
+        $assertions++;
+
+        if (strpos($haystack, $needle) === false) {
+            fwrite(STDERR, "FAIL: {$message}\n  Expected to contain: '{$needle}'\n  In: '{$haystack}'\n");
+            exit(1);
+        }
+    }
+
+    // ─── WordPress function stubs ──────────────────────────────────────
+
+    if (!function_exists('sanitize_text_field')) {
+        function sanitize_text_field($str)
+        {
+            $str = (string) $str;
+            $str = strip_tags($str);
+            $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
+            return trim($str);
+        }
+    }
+
+    if (!function_exists('sanitize_url')) {
+        function sanitize_url($url)
+        {
+            $url = (string) $url;
+            $url = trim($url);
+            if (preg_match('#^(javascript|data|vbscript):#i', $url)) {
+                return '';
+            }
+            return strip_tags($url);
+        }
+    }
+
+    if (!function_exists('wp_unslash')) {
+        function wp_unslash($value)
+        {
+            if (is_array($value)) {
+                return array_map('wp_unslash', $value);
+            }
+            return is_string($value) ? stripslashes($value) : $value;
+        }
+    }
+
+    // Stub global $wpdb so Storage doesn't crash on prefix lookup.
+    $GLOBALS['wpdb'] = new class {
+        public string $prefix = 'wp_';
+    };
+
+    // Load the SUT.
+    require_once __DIR__ . '/../src/Tracker/Storage.php';
+
+    // ─── Test 1: user_agent with XSS payload is stripped ───────────────
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    $result = \SlimStat\Tracker\Storage::updateRow([
+        'id'         => 42,
+        'user_agent' => 'Mozilla/5.0 <img src=x onerror=alert(/XSS/)>',
+    ]);
+    assert_same(42, $result, 'updateRow returns the id on success');
+    assert_same(42, \SlimStat\Utils\FakeQueryRecorder::$where_id, 'WHERE id is bound to the input id');
+    assert_same(1, \SlimStat\Utils\FakeQueryRecorder::$executeCalls, 'execute() is called exactly once');
+    $ua = \SlimStat\Utils\FakeQueryRecorder::$setClauses['user_agent'] ?? null;
+    assert_same('Mozilla/5.0', $ua, 'user_agent has HTML tags stripped via sanitize_text_field');
+    assert_not_contains('<img', $ua ?? '', 'user_agent must not retain <img tag');
+    assert_not_contains('onerror', $ua ?? '', 'user_agent must not retain onerror handler');
+
+    // ─── Test 2: <script> in user_agent is fully removed ──────────────
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    \SlimStat\Tracker\Storage::updateRow([
+        'id'         => 1,
+        'user_agent' => '<script>alert(1)</script>Mozilla/5.0',
+    ]);
+    $ua = \SlimStat\Utils\FakeQueryRecorder::$setClauses['user_agent'] ?? null;
+    assert_same('alert(1)Mozilla/5.0', $ua, 'sanitize_text_field strips <script> tags but keeps inner text');
+    assert_not_contains('<script', $ua ?? '', 'no script tag survives');
+
+    // ─── Test 3: referer is sanitized as URL (sanitize_url) ───────────
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    \SlimStat\Tracker\Storage::updateRow([
+        'id'      => 1,
+        'referer' => 'https://example.com/?q=<script>alert(1)</script>',
+    ]);
+    $referer = \SlimStat\Utils\FakeQueryRecorder::$setClauses['referer'] ?? null;
+    assert_not_contains('<script', $referer ?? '', 'referer must not contain script tag');
+
+    // ─── Test 4: notes array — each element sanitized then imploded ───
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    \SlimStat\Tracker\Storage::updateRow([
+        'id'    => 1,
+        'notes' => ['user:1', 'pre:yes', '<script>alert(1)</script>'],
+    ]);
+    $notesParams = \SlimStat\Utils\FakeQueryRecorder::$setRawParams['notes'] ?? [];
+    assert_true(!empty($notesParams), 'setRaw was called for notes column');
+    $notesString = $notesParams[0] ?? '';
+    assert_contains('[user:1]', $notesString, 'notes preserves benign markers');
+    assert_contains('[pre:yes]', $notesString, 'notes preserves benign markers');
+    assert_not_contains('<script', $notesString, 'notes stripped of script tag (HTML tags removed by sanitize_text_field)');
+    assert_not_contains('</script', $notesString, 'no closing script tag survives');
+
+    // ─── Test 5a: outbound_resource — javascript: scheme rejected entirely ─
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    \SlimStat\Tracker\Storage::updateRow([
+        'id'                => 1,
+        'outbound_resource' => 'javascript:alert(1)',
+    ]);
+    // sanitize_url returns '' for javascript: scheme; the empty value then
+    // fails the !empty($data['outbound_resource']) gate, so no UPDATE is
+    // performed for this field. This is stricter (and safer) than pre-fix.
+    assert_true(empty(\SlimStat\Utils\FakeQueryRecorder::$setRawParams['outbound_resource'] ?? []), 'javascript: outbound_resource must not reach setRaw');
+    assert_true(!array_key_exists('outbound_resource', \SlimStat\Utils\FakeQueryRecorder::$setClauses), 'javascript: outbound_resource must not appear in SET');
+
+    // ─── Test 5b: outbound_resource — valid URL still flows through setRaw ─
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    \SlimStat\Tracker\Storage::updateRow([
+        'id'                => 1,
+        'outbound_resource' => 'https://example.com/landing',
+    ]);
+    $outboundParams = \SlimStat\Utils\FakeQueryRecorder::$setRawParams['outbound_resource'] ?? [];
+    assert_true(!empty($outboundParams), 'valid outbound_resource still uses setRaw');
+    assert_same('https://example.com/landing', $outboundParams[0] ?? null, 'valid URL preserved through both sanitization passes');
+
+    // ─── Test 6: locale codes preserved exactly ───────────────────────
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    \SlimStat\Tracker\Storage::updateRow([
+        'id'       => 1,
+        'language' => 'en-US',
+        'country'  => 'us',
+        'browser'  => 'Chrome',
+        'platform' => 'windows',
+    ]);
+    assert_same('en-US', \SlimStat\Utils\FakeQueryRecorder::$setClauses['language'] ?? null, 'language code preserved');
+    assert_same('us', \SlimStat\Utils\FakeQueryRecorder::$setClauses['country'] ?? null, 'country code preserved');
+    assert_same('Chrome', \SlimStat\Utils\FakeQueryRecorder::$setClauses['browser'] ?? null, 'browser name preserved');
+    assert_same('windows', \SlimStat\Utils\FakeQueryRecorder::$setClauses['platform'] ?? null, 'platform name preserved');
+
+    // ─── Test 7: empty data returns false (no SQL run) ────────────────
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    $result = \SlimStat\Tracker\Storage::updateRow([]);
+    assert_false($result, 'updateRow returns false on empty input');
+    assert_same(0, \SlimStat\Utils\FakeQueryRecorder::$executeCalls, 'execute() not called for empty input');
+
+    // ─── Test 8: missing id returns false ─────────────────────────────
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    $result = \SlimStat\Tracker\Storage::updateRow(['user_agent' => 'Mozilla/5.0']);
+    assert_false($result, 'updateRow returns false when id missing');
+    assert_same(0, \SlimStat\Utils\FakeQueryRecorder::$executeCalls, 'execute() not called when id missing');
+
+    // ─── Test 9: redirect content_type passes through unchanged ───────
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    \SlimStat\Tracker\Storage::updateRow([
+        'id'           => 1,
+        'content_type' => 'redirect:301',
+    ]);
+    assert_same('redirect:301', \SlimStat\Utils\FakeQueryRecorder::$setClauses['content_type'] ?? null, 'content_type redirect marker preserved');
+
+    // ─── Test 10: id is unset before sanitization (never appears in SET) ─
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    \SlimStat\Tracker\Storage::updateRow([
+        'id'         => 99,
+        'user_agent' => 'Mozilla',
+    ]);
+    assert_true(!array_key_exists('id', \SlimStat\Utils\FakeQueryRecorder::$setClauses), 'id must not appear in SET clauses');
+    assert_same(99, \SlimStat\Utils\FakeQueryRecorder::$where_id, 'id is bound to WHERE clause only');
+
+    fwrite(STDOUT, "OK: {$assertions} assertions passed (Storage::updateRow sanitization)\n");
+    exit(0);
+}


### PR DESCRIPTION
## Summary

Patches **CVE-2026-7634** (CVSS 7.2, High) — unauthenticated stored XSS via the `User-Agent` header. Reported by Supakiad S. (m3ez) — E-CQURITY (Thailand) via Wordfence on 2026-05-08.

The bug: `Storage::insertRow()` sanitizes every field with `sanitize_text_field()`, but `Storage::updateRow()` did not. A redirect (`Processor::updateContentType`, hooked to `wp_redirect_status`) or any of three AJAX follow-ups in `Ajax::process()` would overwrite the sanitized row with the raw `$stat` array, letting raw HTML survive in `user_agent`. With `show_complete_user_agent_tooltip = on`, the admin Browsers report's `inline_help()` rendered that raw HTML unescaped.

## Three-layer defense in depth

| # | Layer | File |
|---|-------|------|
| 1 | **Source**: sanitize each `$_SERVER` UA read at capture | `src/Services/Browscap.php` |
| 2 | **Storage**: type-aware sanitization loop mirroring `insertRow()` (covers all 4 `updateRow()` callers) | `src/Tracker/Storage.php` |
| 3 | **Output**: `wp_kses_post()` in `inline_help()` — preserves the legitimate `<strong>`, `<em>`, `<br>`, `<p>`, `<span class>`, `<a href>` markup that ~20 existing tooltips rely on, while stripping `<script>`, `<iframe>`, and event-handler attributes | `admin/view/wp-slimstat-reports.php` |

## Affected callers of `Storage::updateRow()` (all closed by Layer 2)

- `Processor::updateContentType()` — `wp_redirect_status` hook (the published PoC path)
- `Ajax::process()` line 318 — navigation update
- `Ajax::process()` line 377 — outbound link tracking
- `Ajax::process()` line 384 — event tracking

## Why `wp_kses_post()` instead of Wordfence's literal `esc_html()` recommendation

Hardcoded report tooltips at lines 111, 354, 366, 697, 722, 1758 (and ~15 more in `wp-slimstat-reports.php`) intentionally contain HTML formatting. A blanket `esc_html()` would render those tags as literal text — a visible regression across most reports. `wp_kses_post()` defangs the published PoC payload `<img src=x onerror=alert(...)>` while preserving every formatting tag the plugin ships.

## Tests

| Layer | Test | Result |
|-------|------|--------|
| Storage unit (Layer 2) | `tests/storage-update-sanitization-test.php` (new, **29 assertions, 10 cases**) | green |
| Reports integration (Layer 3) | `tests/reports-output-escaping-test.php` (Tests 14–20 added) | requires WP DB |
| Full E2E roundtrip | `tests/e2e/cve-2026-7634-user-agent-xss.spec.ts` (new, 5 cases) | requires Playwright env |
| All other PHP tests | `composer test:all` (20 standalone scripts) | green 20/20 |

End-to-end verified on `slimstat-test.local`:
- `curl -A 'Mozilla/5.0 <img src=x onerror=alert(/XSS_94821/)>' http://slimstat-test.local/sample-page` → 301 fired → DB row stored as `Mozilla/5.0 (Windows NT 10.0)` (HTML stripped)
- `inline_help()` probe with malicious payloads: `onerror`, `<script>`, `<svg/onload>` all stripped; `<strong>`, `<em>`, `<br>`, `<p>`, `<span class>` all preserved

## Test plan

- [x] PHP syntax lint (`php -l`) on all changed files
- [x] `composer test:storage-update-sanitize` green (29/29)
- [x] All other standalone tests still pass (20/20)
- [x] Published Wordfence PoC reproduced — payload no longer reaches the DB
- [x] Output-layer probe confirms `wp_kses_post()` strips dangerous markup, preserves legitimate HTML
- [x] Two `/simplify` review passes applied
- [ ] Reviewer to spot-check the admin Browsers report renders unchanged for legitimate UAs

## Out of scope (follow-ups noted by `/simplify`)

- Consolidating duplicate `ensureLoggedIn()` across 3 E2E specs (pre-existing pattern)
- Shared `Request::userAgent()` helper across 7 sanitization sites in the codebase
- Generalizing the 5 `getLatest*` helpers in `tests/e2e/helpers/setup.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Mitigates unauthenticated stored XSS via the User‑Agent header by sanitizing at capture, on update, and before admin tooltip rendering; complete-user-agent tooltip remains off by default.

* **Tests**
  * Added E2E, integration, and storage sanitization tests to validate capture, update, and render defenses and regression cases.

* **Documentation**
  * Updated changelog/readme with the security advisory and mitigation notes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wp-slimstat/wp-slimstat/pull/302)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->