### PR TITLE
fix: tracker HTTP 500 when PHP fileinfo extension is missing (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+= 5.4.13 - 2026-05-14 =
+
+**Tracker hardening**
+
+- The tracker REST endpoint (`POST /wp-json/slimstat/v1/hit` and `admin-ajax.php?action=slimstat_track`) no longer returns HTTP 500 on servers without the PHP `fileinfo` extension. `Services\Browscap::get_browser_from_browscap()` constructs Flysystem's `LocalFilesystemAdapter`, which in turn instantiates `FinfoMimeTypeDetector` (`new finfo(...)`) — on hosts where `fileinfo` is absent (common after PHP 7.4 → 8.x rebuilds on managed hosts, CloudLinux Alt-PHP, minimal PHP builds) this throws `\Error`, which the surrounding `catch (\Exception)` did not catch. Fix: preflight `extension_loaded('fileinfo')` at both the `enable_browscap` entry gate and inside the method itself, and widen the inner catch to `\Throwable` (matching the existing pattern in `admin/view/index.php` for the geolite block); failures are reported via the structured `wp_slimstat::log()` helper, which is gated on `WP_DEBUG` to avoid log floods on misconfigured production sites. Tracking continues to work via the built-in UADetector fallback. An admin notice now warns when Browscap is enabled but the extension is unavailable, with a one-click dismiss handled by `slimstat_notice_browscap_fileinfo`. ([#303](https://github.com/wp-slimstat/wp-slimstat/issues/303))
+
 = 5.4.12 - 2026-05-13 =
 
 **Security**

--- a/admin/index.php
+++ b/admin/index.php
@@ -255,10 +255,11 @@ class wp_slimstat_admin
         // AJAX Handlers
         if (defined('DOING_AJAX') && DOING_AJAX) {
             $ajax_actions = [
-                'slimstat_notice_latest_news'    => 'notices_handler',
-                'slimstat_notice_geolite'        => 'notices_handler',
-                'slimstat_notice_browscap'       => 'notices_handler',
-                'slimstat_notice_caching'        => 'notices_handler',
+                'slimstat_notice_latest_news'       => 'notices_handler',
+                'slimstat_notice_geolite'           => 'notices_handler',
+                'slimstat_notice_browscap'          => 'notices_handler',
+                'slimstat_notice_browscap_fileinfo' => 'notices_handler',
+                'slimstat_notice_caching'           => 'notices_handler',
                 'slimstat_manage_filters'        => 'manage_filters',
                 'slimstat_delete_pageview'       => 'delete_pageview',
                 'slimstat_update_geoip_database' => 'update_geoip_database',

--- a/admin/view/index.php
+++ b/admin/view/index.php
@@ -112,6 +112,24 @@ if (PHP_VERSION_ID >= 70100 && !file_exists(wp_slimstat::$upload_dir . '/browsca
     wp_slimstat_admin::show_message(sprintf(__("Install our <a href='%s' class='noslimstat'>Browscap Library</a> to identify your visitors' browser and operating system.", 'wp-slimstat'), self::$config_url . '2#wp-slimstat-third-party-libraries'), 'warning', 'browscap');
 }
 
+// Browscap relies on Flysystem's LocalFilesystemAdapter, which constructs
+// FinfoMimeTypeDetector unconditionally. Without ext-fileinfo the tracker
+// REST endpoint returns HTTP 500 on every hit (#303). Warn the admin when
+// Browscap is enabled but the extension is missing.
+if ('on' == wp_slimstat::$settings['enable_browscap'] && !extension_loaded('fileinfo') && 'on' == wp_slimstat::$settings['notice_browscap_fileinfo']) {
+    wp_slimstat_admin::show_message(
+        sprintf(
+            __("Slimstat's Browscap browser-detection library requires the PHP %1\$sfileinfo%2\$s extension, which is not enabled on your server. Browser detection has been safely disabled to keep tracking working — ask your host to enable %1\$sfileinfo%2\$s, or %3\$sturn off the Browscap Library%4\$s in the settings to hide this notice.", 'wp-slimstat'),
+            '<code>',
+            '</code>',
+            "<a href='" . esc_url(self::$config_url . '2#wp-slimstat-third-party-libraries') . "' class='noslimstat'>",
+            '</a>'
+        ),
+        'warning',
+        'browscap_fileinfo'
+    );
+}
+
 // Path to wp-content folder, used to detect caching plugins via advanced-cache.php
 if (file_exists(dirname(plugin_dir_path(__FILE__), 4) . '/advanced-cache.php') && 'on' == wp_slimstat::$settings['notice_caching'] && (empty(wp_slimstat::$settings['javascript_mode']) || 'on' != wp_slimstat::$settings['javascript_mode'])) {
     wp_slimstat_admin::show_message(sprintf(__("A caching plugin might be enabled on your website. Please <a href='%s' target='_blank' class='noslimstat'>make sure to configure</a> Slimstat Analytics accordingly, to get accurate information.", 'wp-slimstat'), 'https://wp-slimstat.com/resources/i-am-using-w3-total-cache-or-wp-super-cache-hypercache-etc-and-it-looks-like-slimstat-is-not-tra'), 'warning', 'caching');

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,9 @@ Tags: analytics, statistics, tracking, reports, geolocation
 Text Domain: wp-slimstat
 Requires at least: 5.6
 Requires PHP: 7.4
+Recommended PHP extensions: fileinfo (required if the Browscap library is enabled)
 Tested up to: 6.9.4
-Stable tag: 5.4.12
+Stable tag: 5.4.13
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -75,6 +76,9 @@ An extensive knowledge base is available on our [website](https://www.wp-slimsta
 9. **Settings** - Plenty of options to customize the plugin's behavior
 
 == Changelog ==
+= 5.4.13 - 2026-05-14 =
+* Fix: Tracker REST endpoint no longer returns HTTP 500 on servers without the PHP `fileinfo` extension. The Browscap path now preflight-checks `extension_loaded('fileinfo')` and catches `\Throwable` instead of `\Exception`, so a missing extension degrades to UADetector instead of fataling. An admin notice surfaces the misconfiguration with a link to disable Browscap. ([#303](https://github.com/wp-slimstat/wp-slimstat/issues/303))
+
 = 5.4.12 - 2026-05-13 =
 * Security: Authenticated SQL injection in the chart AJAX endpoint (slimstat_fetch_chart_data) is now blocked. The `chart_data.where` parameter is validated against the trusted report registry before reaching the query layer. Reported via Patchstack (CVSS 8.5, High).
 * Security: Patch unauthenticated stored XSS via the User-Agent header (CVE-2026-7634). Storage::updateRow() now mirrors insertRow()'s sanitization, the User-Agent is sanitized at capture in Browscap, and admin tooltips are escaped via wp_kses_post(). Reported by Supakiad S. (m3ez) — E-CQURITY (Thailand) via Wordfence.

--- a/src/Services/Browscap.php
+++ b/src/Services/Browscap.php
@@ -60,7 +60,7 @@ class Browscap
             return $cached;
         }
 
-        if ('on' == wp_slimstat::$settings['enable_browscap'] && PHP_VERSION_ID >= 70400) {
+        if ('on' == wp_slimstat::$settings['enable_browscap'] && PHP_VERSION_ID >= 70400 && extension_loaded('fileinfo')) {
             $browser = self::get_browser_from_browscap($browser, wp_slimstat::$upload_dir . '/browscap-cache-master/');
         }
 
@@ -115,6 +115,12 @@ class Browscap
 
     public static function get_browser_from_browscap($_browser = [], $_cache_path = '')
     {
+        // Flysystem's LocalFilesystemAdapter eagerly constructs FinfoMimeTypeDetector,
+        // which calls `new finfo(...)` and fatals on hosts without ext-fileinfo (#303).
+        if (!extension_loaded('fileinfo')) {
+            return $_browser;
+        }
+
         try {
             $file_cache = new LocalFilesystemAdapter($_cache_path);
             $filesystem = new Filesystem($file_cache);
@@ -124,7 +130,8 @@ class Browscap
             $logger        = new NullLogger();
             $browscap      = new \SlimStat\Dependencies\BrowscapPHP\Browscap($cache, $logger);
             $search_object = $browscap->getBrowser();
-        } catch (Exception $exception) {
+        } catch (\Throwable $exception) {
+            \wp_slimstat::log('Browscap path failed: ' . $exception->getMessage(), 'error');
             $search_object = '';
         }
 

--- a/tests/Unit/Services/BrowscapFileinfoFallbackTest.php
+++ b/tests/Unit/Services/BrowscapFileinfoFallbackTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+namespace SlimStat\Services;
+
+/**
+ * Namespace-local shadow of PHP's `extension_loaded()`.
+ *
+ * PHP function-name resolution looks in the current namespace before falling
+ * back to the global scope, so the unqualified `extension_loaded('fileinfo')`
+ * call inside `SlimStat\Services\Browscap` resolves to THIS function during
+ * the test run. The shadow defers to the real built-in unless the test has
+ * registered an override via FileinfoStub.
+ */
+if (!function_exists(__NAMESPACE__ . '\\extension_loaded')) {
+    function extension_loaded(string $extension): bool
+    {
+        return \WpSlimstat\Tests\Unit\Services\FileinfoStub::resolve($extension);
+    }
+}
+
+namespace WpSlimstat\Tests\Unit\Services;
+
+use WpSlimstat\Tests\Unit\WpSlimstatTestCase;
+
+class FileinfoStub
+{
+    private static ?bool $fileinfoOverride = null;
+
+    public static function disableFileinfo(): void
+    {
+        self::$fileinfoOverride = false;
+    }
+
+    public static function reset(): void
+    {
+        self::$fileinfoOverride = null;
+    }
+
+    public static function resolve(string $extension): bool
+    {
+        if ('fileinfo' === $extension && null !== self::$fileinfoOverride) {
+            return self::$fileinfoOverride;
+        }
+        return \extension_loaded($extension);
+    }
+}
+
+/**
+ * Integration tests for the Browscap fileinfo preflight (#303).
+ *
+ * @see SlimStat\Services\Browscap::get_browser_from_browscap()
+ * @see https://github.com/wp-slimstat/wp-slimstat/issues/303
+ */
+class BrowscapFileinfoFallbackTest extends WpSlimstatTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        FileinfoStub::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        FileinfoStub::reset();
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function returns_input_unchanged_when_fileinfo_missing(): void
+    {
+        FileinfoStub::disableFileinfo();
+
+        $input = [
+            'browser'         => 'Default Browser',
+            'browser_version' => '',
+            'browser_type'    => 0,
+            'platform'        => 'unknown',
+            'user_agent'      => 'Mozilla/5.0',
+        ];
+
+        $result = \SlimStat\Services\Browscap::get_browser_from_browscap(
+            $input,
+            sys_get_temp_dir() . '/browscap-cache-fileinfo-test/'
+        );
+
+        $this->assertSame(
+            $input,
+            $result,
+            'When ext-fileinfo is missing, get_browser_from_browscap() must early-return $_browser unchanged — no Flysystem construction, no fatal.'
+        );
+    }
+
+    /** @test */
+    public function does_not_fatal_when_cache_path_invalid_with_fileinfo_present(): void
+    {
+        if (!\extension_loaded('fileinfo')) {
+            $this->markTestSkipped('Host PHP lacks fileinfo; cannot exercise the catch path with real Flysystem.');
+        }
+
+        $input = [
+            'browser'         => 'Default Browser',
+            'browser_version' => '',
+            'browser_type'    => 0,
+            'platform'        => 'unknown',
+            'user_agent'      => 'Mozilla/5.0',
+        ];
+
+        // Suppress the wp_slimstat::log() noise the catch emits via WP_DEBUG.
+        $prev_log = ini_set('error_log', '/dev/null');
+
+        try {
+            $result = \SlimStat\Services\Browscap::get_browser_from_browscap(
+                $input,
+                "\0invalid-path-that-cannot-be-created"
+            );
+        } catch (\Throwable $e) {
+            $this->fail('get_browser_from_browscap() must catch \Throwable, but threw: ' . $e->getMessage());
+        } finally {
+            if (false !== $prev_log) {
+                ini_set('error_log', $prev_log);
+            }
+        }
+
+        $this->assertIsArray($result, 'Result must be an array even when the underlying Flysystem call fails.');
+        $this->assertArrayHasKey('browser', $result, 'Result shape must remain compatible with the caller in get_browser().');
+    }
+}

--- a/tests/Unit/Tracker/stubs.php
+++ b/tests/Unit/Tracker/stubs.php
@@ -79,6 +79,11 @@ if (!class_exists('wp_slimstat')) {
         /** @var array<string,mixed> */
         private static array $_data_js = [];
 
+        public static function log($message, string $level = 'info'): void
+        {
+            // Test no-op — production gates on WP_DEBUG, not relevant for unit tests.
+        }
+
         public static function get_stat(): array
         {
             return self::$_stat;

--- a/tests/browscap-fileinfo-preflight-test.php
+++ b/tests/browscap-fileinfo-preflight-test.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Source-level verification: Browscap fileinfo extension preflight (#303).
+ *
+ * Without ext-fileinfo, Flysystem's LocalFilesystemAdapter eagerly constructs
+ * FinfoMimeTypeDetector (`new finfo(...)`), which fatals with a `Class "finfo"
+ * not found` Error. The surrounding `catch (\Exception)` did not catch it, so
+ * every tracker hit returned HTTP 500. The fix gates the Browscap path on
+ * `extension_loaded('fileinfo')` and widens the catch to `\Throwable`.
+ *
+ * @see https://github.com/wp-slimstat/wp-slimstat/issues/303
+ */
+
+declare(strict_types=1);
+
+$assertions = 0;
+
+function fileinfo_assert(bool $condition, string $msg): void
+{
+    global $assertions;
+    $assertions++;
+    if (!$condition) {
+        fwrite(STDERR, "FAIL: {$msg}\n");
+        exit(1);
+    }
+}
+
+$browscap_src = file_get_contents(dirname(__DIR__) . '/src/Services/Browscap.php');
+fileinfo_assert(false !== $browscap_src, 'Could not read src/Services/Browscap.php');
+
+fileinfo_assert(
+    (bool) preg_match(
+        "/function\\s+get_browser\\s*\\([^)]*\\)\\s*\\{[\\s\\S]*?enable_browscap[\\s\\S]*?extension_loaded\\(\\s*'fileinfo'\\s*\\)/",
+        $browscap_src
+    ),
+    "TEST 1: get_browser() entry gate must call extension_loaded('fileinfo')"
+);
+
+// Defense-in-depth: get_browser_from_browscap() is `public static`, so
+// third-party code or tests can call it directly bypassing the entry gate.
+fileinfo_assert(
+    (bool) preg_match(
+        "/function\\s+get_browser_from_browscap\\s*\\([^)]*\\)\\s*\\{[\\s\\S]*?!\\s*extension_loaded\\(\\s*'fileinfo'\\s*\\)[\\s\\S]*?return\\s+\\\$_browser/",
+        $browscap_src
+    ),
+    'TEST 2: get_browser_from_browscap() must early-return when ext-fileinfo missing'
+);
+
+fileinfo_assert(
+    (bool) preg_match(
+        "/function\\s+get_browser_from_browscap[\\s\\S]*?catch\\s*\\(\\s*\\\\?Throwable\\s+/",
+        $browscap_src
+    ),
+    'TEST 3: get_browser_from_browscap() catch must be \\Throwable, not Exception'
+);
+
+fileinfo_assert(
+    !(bool) preg_match(
+        "/function\\s+get_browser_from_browscap[\\s\\S]*?catch\\s*\\(\\s*Exception\\s+/",
+        $browscap_src
+    ),
+    'TEST 3b: Old narrow `catch (Exception ...)` must be removed from get_browser_from_browscap'
+);
+
+fileinfo_assert(
+    (bool) preg_match(
+        "/catch\\s*\\(\\s*\\\\?Throwable[\\s\\S]{0,200}?wp_slimstat::log\\s*\\(/",
+        $browscap_src
+    ),
+    'TEST 4: \\Throwable catch must call wp_slimstat::log() (gated on WP_DEBUG), not raw error_log()'
+);
+
+$view_src = file_get_contents(dirname(__DIR__) . '/admin/view/index.php');
+fileinfo_assert(false !== $view_src, 'Could not read admin/view/index.php');
+
+fileinfo_assert(
+    false !== strpos($view_src, "notice_browscap_fileinfo"),
+    'TEST 5a: admin/view/index.php must reference notice_browscap_fileinfo setting'
+);
+fileinfo_assert(
+    (bool) preg_match(
+        "/enable_browscap[\\s\\S]{0,200}?!\\s*extension_loaded\\(\\s*'fileinfo'\\s*\\)[\\s\\S]{0,200}?notice_browscap_fileinfo/",
+        $view_src
+    ),
+    'TEST 5b: Notice condition must combine enable_browscap, missing fileinfo, and notice flag'
+);
+fileinfo_assert(
+    false !== strpos($view_src, "'browscap_fileinfo'"),
+    'TEST 5c: show_message() call must use distinct dismiss handle browscap_fileinfo (not browscap)'
+);
+
+$plugin_src = file_get_contents(dirname(__DIR__) . '/wp-slimstat.php');
+fileinfo_assert(false !== $plugin_src, 'Could not read wp-slimstat.php');
+fileinfo_assert(
+    (bool) preg_match("/'notice_browscap_fileinfo'\\s*=>\\s*'on'/", $plugin_src),
+    'TEST 6: wp-slimstat.php defaults must include notice_browscap_fileinfo => on'
+);
+
+$admin_src = file_get_contents(dirname(__DIR__) . '/admin/index.php');
+fileinfo_assert(false !== $admin_src, 'Could not read admin/index.php');
+fileinfo_assert(
+    (bool) preg_match(
+        "/'slimstat_notice_browscap_fileinfo'\\s*=>\\s*'notices_handler'/",
+        $admin_src
+    ),
+    "TEST 7: admin/index.php must register slimstat_notice_browscap_fileinfo => notices_handler"
+);
+
+echo "All {$assertions} assertions passed in browscap-fileinfo-preflight-test.php\n";

--- a/tests/e2e/features/issue-303-fileinfo-resilience.feature
+++ b/tests/e2e/features/issue-303-fileinfo-resilience.feature
@@ -1,0 +1,60 @@
+Feature: Tracker resilience when the PHP fileinfo extension is missing
+  As a SlimStat administrator on a host whose PHP build lacks ext-fileinfo,
+  I want the tracker to keep working (using the built-in UADetector fallback)
+  so that visitor analytics are not silently broken by a hosting limitation,
+  and I want to be told what to do about it.
+
+  # Issue: https://github.com/wp-slimstat/wp-slimstat/issues/303
+  # Implemented as Playwright spec: issue-303-fileinfo-missing-tracker.spec.ts
+
+  Background:
+    Given WP Slimstat 5.4.13 or later is active
+    And the SlimStat option "enable_browscap" is set to "on"
+    And the SlimStat option "is_tracking" is set to "on"
+    And tracking_request_method is "rest"
+    And the host's PHP build does NOT have the "fileinfo" extension loaded
+
+  Scenario: bdd-tracker-degrades-gracefully-no-fileinfo
+    When a frontend visitor loads any public page
+    Then the tracker REST endpoint POST /wp-json/slimstat/v1/hit returns HTTP 200
+    And a row is recorded in wp_slim_stats for the request
+    And no "PHP Fatal error" appears in wp-content/debug.log for the wp-slimstat path
+    And the recorded row's "browser" column is populated by UADetector
+    And the recorded row's "browser" column is not the literal "Default Browser"
+
+  Scenario: bdd-admin-notice-surfaces-when-extension-missing
+    When an administrator opens /wp-admin/admin.php?page=slimview1
+    Then a warning admin notice mentioning the "fileinfo" extension is visible
+    And the notice links to the Settings → Third-Party Libraries tab
+    And the notice is rendered inside SlimStat admin pages only (not network admin, not unrelated wp-admin screens)
+
+  Scenario: bdd-dismiss-notice-persists-across-loads
+    Given the fileinfo notice is visible
+    When the administrator clicks the dismiss button on the notice
+    And the dismiss request to admin-ajax.php?action=slimstat_notice_browscap_fileinfo returns success
+    And the administrator reloads /wp-admin/admin.php?page=slimview1
+    Then the fileinfo notice is no longer visible
+    And the SlimStat option "notice_browscap_fileinfo" is now "off"
+    And dismissing this notice does not affect the separate "notice_browscap" install banner
+
+  Scenario: bdd-no-notice-when-browscap-disabled
+    Given the SlimStat option "enable_browscap" is set to "off"
+    When an administrator opens /wp-admin/admin.php?page=slimview1
+    Then no warning notice mentioning "fileinfo" is visible
+    # Sites that intentionally opted out of Browscap should not be nagged.
+
+  Scenario: bdd-backward-compat-fileinfo-present
+    Given the host's PHP build DOES have the "fileinfo" extension loaded
+    And the SlimStat option "enable_browscap" is set to "on"
+    When a frontend visitor loads any public page
+    Then the tracker REST endpoint returns HTTP 200
+    And the recorded row's "browser" column is populated by Browscap (when the cache is installed)
+    And no admin notice about fileinfo is rendered
+
+  Scenario: bdd-throwable-catch-protects-against-other-errors
+    Given the host's PHP build DOES have the "fileinfo" extension loaded
+    And the bundled Browscap cache is corrupted or unreachable
+    When a frontend visitor loads any public page
+    Then the tracker REST endpoint returns HTTP 200
+    And the wider \Throwable catch in get_browser_from_browscap() degrades to UADetector instead of fataling
+    And a single error_log line is written for diagnosability

--- a/tests/e2e/features/issue-303-fileinfo-resilience.feature
+++ b/tests/e2e/features/issue-303-fileinfo-resilience.feature
@@ -51,10 +51,20 @@ Feature: Tracker resilience when the PHP fileinfo extension is missing
     And the recorded row's "browser" column is populated by Browscap (when the cache is installed)
     And no admin notice about fileinfo is rendered
 
-  Scenario: bdd-throwable-catch-protects-against-other-errors
+  Scenario: bdd-throwable-catch-protects-against-other-errors-debug-on
     Given the host's PHP build DOES have the "fileinfo" extension loaded
     And the bundled Browscap cache is corrupted or unreachable
+    And the WordPress constant WP_DEBUG is set to true
     When a frontend visitor loads any public page
     Then the tracker REST endpoint returns HTTP 200
     And the wider \Throwable catch in get_browser_from_browscap() degrades to UADetector instead of fataling
-    And a single error_log line is written for diagnosability
+    And a single "[WP SLIMSTAT] [ERROR]:" line is written to wp-content/debug.log for diagnosability
+
+  Scenario: bdd-throwable-catch-protects-against-other-errors-debug-off
+    Given the host's PHP build DOES have the "fileinfo" extension loaded
+    And the bundled Browscap cache is corrupted or unreachable
+    And the WordPress constant WP_DEBUG is set to false or undefined
+    When a frontend visitor loads any public page
+    Then the tracker REST endpoint returns HTTP 200
+    And the wider \Throwable catch in get_browser_from_browscap() degrades to UADetector instead of fataling
+    But no error_log line is written, because wp_slimstat::log() is gated on WP_DEBUG to prevent production log floods

--- a/tests/e2e/helpers/fileinfo-disabler-mu-plugin.php
+++ b/tests/e2e/helpers/fileinfo-disabler-mu-plugin.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: Slimstat E2E — fileinfo extension disabler
+ * Description: Shadows extension_loaded('fileinfo') inside the
+ *   SlimStat\Services namespace to simulate hosts without ext-fileinfo
+ *   for issue #303 regression coverage. Loads before wp-slimstat so the
+ *   namespaced function resolves before Browscap.php is autoloaded.
+ *
+ * The shim only intercepts the literal extension name 'fileinfo'; every
+ * other lookup falls back to the real PHP built-in so unrelated runtime
+ * checks (json, mbstring, etc.) remain truthful.
+ */
+
+namespace SlimStat\Services {
+    if (!function_exists('SlimStat\\Services\\extension_loaded')) {
+        function extension_loaded(string $extension): bool
+        {
+            if ('fileinfo' === $extension) {
+                return false;
+            }
+            return \extension_loaded($extension);
+        }
+    }
+}

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -69,6 +69,7 @@ const MU_PLUGIN_MANIFEST: MuPluginEntry[] = [
   { sourceFile: 'custom-db-simulator-mu-plugin.php', deployedFile: 'custom-db-simulator-mu-plugin.php' },
   { sourceFile: 'calendar-ext-simulator-mu-plugin.php', deployedFile: 'calendar-ext-simulator-mu-plugin.php' },
   { sourceFile: 'browscap-unzip-blocker-mu-plugin.php', deployedFile: 'browscap-unzip-blocker-mu-plugin.php' },
+  { sourceFile: 'fileinfo-disabler-mu-plugin.php', deployedFile: 'fileinfo-disabler-mu-plugin.php' },
 ];
 
 // ─── Generic MU-Plugin install/uninstall by name ──────────────────

--- a/tests/e2e/issue-303-fileinfo-missing-tracker.spec.ts
+++ b/tests/e2e/issue-303-fileinfo-missing-tracker.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Issue #303 — tracker REST endpoint must NOT return HTTP 500 when the
+ * PHP `fileinfo` extension is missing.
+ *
+ * The fileinfo-disabler mu-plugin shadows `extension_loaded('fileinfo')`
+ * inside the SlimStat\Services namespace so Browscap behaves as if the
+ * host's PHP was built without ext-fileinfo (common after PHP 7.4 → 8.x
+ * rebuilds on managed hosts).
+ *
+ * Pre-fix behavior: Browscap path → Flysystem LocalFilesystemAdapter →
+ *   FinfoMimeTypeDetector → `new finfo(...)` → Class "finfo" not found
+ *   → uncaught \Error → 500 on every tracker hit.
+ *
+ * Post-fix behavior: gate at Browscap.php:63 short-circuits, fallback to
+ *   UADetector populates `browser` field, REST returns 200, debug.log
+ *   stays clean, admin notice surfaces in /wp-admin.
+ */
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  installOptionMutator,
+  uninstallOptionMutator,
+  installMuPluginByName,
+  uninstallMuPluginByName,
+  setSlimstatOption,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+  clearStatsTable,
+  waitForPageviewRow,
+  waitForTrackerId,
+  getPool,
+  closeDb,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+import { WP_ROOT } from './helpers/env';
+
+const DEBUG_LOG = path.join(WP_ROOT, 'wp-content', 'debug.log');
+
+function readDebugLog(): string {
+  return fs.existsSync(DEBUG_LOG) ? fs.readFileSync(DEBUG_LOG, 'utf8') : '';
+}
+
+function truncateDebugLog(): void {
+  if (fs.existsSync(DEBUG_LOG)) fs.writeFileSync(DEBUG_LOG, '', 'utf8');
+}
+
+test.describe('Issue #303 — Browscap fileinfo-missing tracker resilience', () => {
+  test.setTimeout(60_000);
+
+  test.beforeAll(async () => {
+    installOptionMutator();
+    installMuPluginByName('fileinfo-disabler-mu-plugin.php');
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await snapshotSlimstatOptions();
+    await clearStatsTable();
+    truncateDebugLog();
+    await setSlimstatOption(page, 'is_tracking', 'on');
+    await setSlimstatOption(page, 'ignore_wp_users', 'off');
+    await setSlimstatOption(page, 'gdpr_enabled', 'off');
+    await setSlimstatOption(page, 'javascript_mode', 'off');
+    await setSlimstatOption(page, 'tracking_request_method', 'rest');
+    await setSlimstatOption(page, 'enable_browscap', 'on');
+    await setSlimstatOption(page, 'notice_browscap_fileinfo', 'on');
+  });
+
+  test.afterEach(async () => {
+    await restoreSlimstatOptions();
+  });
+
+  test.afterAll(async () => {
+    uninstallMuPluginByName('fileinfo-disabler-mu-plugin.php');
+    uninstallOptionMutator();
+    await closeDb();
+  });
+
+  test('e2e-tracker-rest-200-without-fileinfo: tracker hit returns 200 + writes row, no fatal logged', async ({ page }) => {
+    const marker = `e2e-303-tracker-${Date.now()}`;
+
+    const trackingResponses: { url: string; status: number }[] = [];
+    page.on('response', (response) => {
+      const url = response.url();
+      if (url.includes('slimstat/v1/hit') || url.includes('admin-ajax.php')) {
+        trackingResponses.push({ url, status: response.status() });
+      }
+    });
+
+    await page.goto(`${BASE_URL}/?e2e=${marker}`, { waitUntil: 'domcontentloaded' });
+    await waitForTrackerId(page);
+
+    const row = await waitForPageviewRow(marker);
+    expect(row, 'pageview row must exist — fileinfo gate must allow UADetector fallback').not.toBeNull();
+
+    const serverErrors = trackingResponses.filter((r) => r.status >= 500);
+    expect(
+      serverErrors,
+      `tracking endpoints must not return 500 errors when fileinfo is missing: ${JSON.stringify(serverErrors)}`,
+    ).toHaveLength(0);
+
+    const debugLog = readDebugLog();
+    expect(
+      debugLog,
+      'debug.log must not contain `Class "finfo" not found` fatal',
+    ).not.toMatch(/Class "finfo" not found/);
+    expect(
+      debugLog,
+      'debug.log must not contain any `PHP Fatal error` from the tracker path',
+    ).not.toMatch(/PHP Fatal error[\s\S]*?wp-slimstat/);
+  });
+
+  test('e2e-fallback-populates-browser-via-uadetector: tracker still records browser via UADetector fallback', async ({ page }) => {
+    const marker = `e2e-303-uadetector-${Date.now()}`;
+
+    await page.goto(`${BASE_URL}/?e2e=${marker}`, { waitUntil: 'domcontentloaded' });
+    await waitForTrackerId(page);
+    await waitForPageviewRow(marker);
+
+    const [rows] = await getPool().execute(
+      'SELECT browser, browser_version FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id DESC LIMIT 1',
+      [`%${marker}%`],
+    ) as any;
+
+    expect(rows.length, 'stat row must exist').toBeGreaterThan(0);
+    const stat = rows[0];
+    expect(stat.browser, 'browser column must be populated by UADetector fallback').not.toBe('');
+    expect(stat.browser, 'browser must not be the literal "Default Browser" sentinel').not.toBe('Default Browser');
+  });
+
+  test('e2e-admin-notice-visible-when-fileinfo-missing: warning notice surfaces in SlimStat admin', async ({ page }) => {
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`, { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle');
+
+    const noticeBody = await page.locator('.notice-warning, .updated, .error, .notice')
+      .filter({ hasText: /fileinfo/i })
+      .count();
+
+    expect(
+      noticeBody,
+      'a warning notice mentioning the fileinfo extension must be visible on the SlimStat admin page',
+    ).toBeGreaterThan(0);
+  });
+
+  test('e2e-no-notice-when-browscap-disabled: notice does NOT render when enable_browscap=off', async ({ page }) => {
+    await setSlimstatOption(page, 'enable_browscap', 'off');
+
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`, { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle');
+
+    const noticeBody = await page.locator('.notice-warning, .updated, .error, .notice')
+      .filter({ hasText: /fileinfo/i })
+      .count();
+
+    expect(
+      noticeBody,
+      'fileinfo notice must NOT render when Browscap is disabled — sites that opted out should not be nagged',
+    ).toBe(0);
+  });
+});

--- a/tests/perf/issue-303-browscap-fileinfo.js
+++ b/tests/perf/issue-303-browscap-fileinfo.js
@@ -1,0 +1,100 @@
+/**
+ * k6 performance test: Browscap fileinfo-missing tracker hot path (#303).
+ *
+ * Confirms two contracts under sustained tracker load:
+ *   1. Baseline (fileinfo present + Browscap on) — no regression vs the
+ *      neighboring adminbar-chart-perf.js threshold envelope.
+ *   2. Fallback (fileinfo missing + Browscap on) — tracker still returns
+ *      200, error rate stays at zero, and P95 latency does NOT exceed
+ *      baseline (skipping Browscap is, if anything, faster).
+ *
+ * The fileinfo-missing condition is simulated by deploying the
+ * tests/e2e/helpers/fileinfo-disabler-mu-plugin.php shim before running k6
+ * with K6_FILEINFO_MISSING=1. The shim shadows extension_loaded('fileinfo')
+ * inside the SlimStat\Services namespace.
+ *
+ * Run baseline:
+ *   k6 run tests/perf/issue-303-browscap-fileinfo.js
+ * Run fallback:
+ *   K6_FILEINFO_MISSING=1 k6 run tests/perf/issue-303-browscap-fileinfo.js
+ */
+
+import http from 'k6/http';
+import { check } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+
+const trackerDuration = new Trend('tracker_request_duration_ms', true);
+const trackerFatalRate = new Rate('tracker_fatal_500_rate');
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:10003';
+const FILEINFO_MISSING = __ENV.K6_FILEINFO_MISSING === '1';
+const SCENARIO_LABEL = FILEINFO_MISSING ? 'fallback' : 'baseline';
+
+const TRACKER_USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 k6-perf/issue-303';
+const REST_TRACKER_PATH = '/wp-json/slimstat/v1/hit';
+const PAYLOAD_HEADERS = {
+  'Content-Type': 'application/json',
+  // SlimStat reads the visitor UA from this header (not from a JSON field),
+  // and Browscap branches on it — keep it stable across both runs.
+  'User-Agent': TRACKER_USER_AGENT,
+};
+
+export const options = {
+  scenarios: {
+    tracker_hits: {
+      executor: 'constant-arrival-rate',
+      rate: 1000,
+      timeUnit: '1m',
+      duration: '5m',
+      preAllocatedVUs: 25,
+      maxVUs: 100,
+      tags: { variant: SCENARIO_LABEL },
+    },
+  },
+  thresholds: {
+    'http_req_duration{variant:baseline}': ['p(95)<350'],
+    'http_req_duration{variant:fallback}': ['p(95)<350'],
+    'http_req_failed{variant:baseline}': ['rate<0.001'],
+    'http_req_failed{variant:fallback}': ['rate<0.001'],
+    tracker_fatal_500_rate: ['rate<0.001'],
+  },
+};
+
+function buildPayload(iter) {
+  // Field names match the REST controller's args list in
+  // src/Controllers/Rest/TrackingRestController.php — `res` (resource URL),
+  // `ref` (referer), `bw/bh/sw/sh` (browser/screen viewport).
+  return JSON.stringify({
+    res: `/perf-303-${SCENARIO_LABEL}-${iter}`,
+    ref: '',
+    bw: 1280,
+    bh: 720,
+    sw: 1920,
+    sh: 1080,
+  });
+}
+
+export default function () {
+  const res = http.post(
+    `${BASE_URL}${REST_TRACKER_PATH}`,
+    buildPayload(__ITER),
+    { headers: PAYLOAD_HEADERS, tags: { variant: SCENARIO_LABEL } }
+  );
+
+  trackerDuration.add(res.timings.duration);
+  trackerFatalRate.add(res.status >= 500);
+
+  check(res, {
+    'status 200': (r) => r.status === 200,
+    'no Class "finfo" not found': (r) => !r.body.includes('Class "finfo" not found'),
+    'no PHP Fatal': (r) => !r.body.includes('PHP Fatal error'),
+  });
+}
+
+export function teardown() {
+  console.log('\n========================================');
+  console.log(`Issue #303 Browscap fileinfo perf — ${SCENARIO_LABEL}`);
+  console.log(`fileinfo missing: ${FILEINFO_MISSING}`);
+  console.log('========================================\n');
+}

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -3,7 +3,7 @@
  * Plugin Name: SlimStat Analytics
  * Plugin URI: https://wp-slimstat.com/
  * Description: The leading web analytics plugin for WordPress
- * Version: 5.4.12
+ * Version: 5.4.13
  * Author: Jason Crouse, VeronaLabs
  * Text Domain: wp-slimstat
  * Domain Path: /languages
@@ -20,7 +20,7 @@ if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
 }
 
 // Set the plugin version and directory
-define('SLIMSTAT_ANALYTICS_VERSION', '5.4.12');
+define('SLIMSTAT_ANALYTICS_VERSION', '5.4.13');
 define('SLIMSTAT_FILE', __FILE__);
 define('SLIMSTAT_DIR', __DIR__);
 define('SLIMSTAT_URL', plugins_url('', __FILE__));
@@ -1230,10 +1230,11 @@ class wp_slimstat
 
             // Notices
             // -----------------------------------------------------------------------
-            'notice_latest_news' => 'on',
-            'notice_browscap'    => 'on',
-            'notice_geolite'     => 'on',
-            'notice_caching'     => 'on',
+            'notice_latest_news'       => 'on',
+            'notice_browscap'          => 'on',
+            'notice_browscap_fileinfo' => 'on',
+            'notice_geolite'           => 'on',
+            'notice_caching'           => 'on',
 
             // Network-wide Settings
             'locked_options' => '',


### PR DESCRIPTION
## Summary

Closes #303.

The tracker REST endpoint (`POST /wp-json/slimstat/v1/hit`) returned HTTP 500 on every hit on hosts whose PHP build lacks the `fileinfo` extension. Reported via wp.org support forum after a PHP 7.4 → 8.3 host upgrade by @thefriendlancer; common on managed hosts, CloudLinux Alt-PHP, and minimal PHP builds.

**Not a PHP 8.3 incompatibility** — affects any PHP version when `fileinfo` is missing.

## Root cause

`Services\Browscap::get_browser_from_browscap()` constructs Flysystem's `LocalFilesystemAdapter`, which eagerly instantiates `FinfoMimeTypeDetector` (`new finfo(...)`). On hosts without `fileinfo`, that throws `\Error: Class "finfo" not found` — and the surrounding `catch (\Exception)` did not catch it (PHP 7+ separated `Throwable` into `Exception` and `Error`).

## Fix

1. **Preflight gate** at `src/Services/Browscap.php:63` — `extension_loaded('fileinfo')` joins the existing `enable_browscap` + `PHP_VERSION_ID` conditions. Browscap path is skipped entirely when the extension is missing.
2. **Defense in depth** inside `get_browser_from_browscap()` — `public static` method, so third-party callers / tests that bypass the gate also degrade gracefully.
3. **`\Throwable` catch** widened to handle any future failure mode in the bundled vendor stack — matches the existing pattern in `admin/view/index.php:106` for the geolite block.
4. **Structured logging** — diagnostics route through `wp_slimstat::log()` (gated on `WP_DEBUG`) instead of raw `error_log()`, so a misconfigured Browscap doesn't flood production debug.log.
5. **Admin notice** — new dismissible warning when `enable_browscap=on` but `fileinfo` is unavailable, linking to the Settings → Third-Party Libraries tab. Uses a distinct key (`notice_browscap_fileinfo`, AJAX action `slimstat_notice_browscap_fileinfo`) so dismissing it does not affect the existing `notice_browscap` install banner.

Tracking continues to work via the existing `UADetector` fallback.

## Files

| File | Change |
|------|--------|
| `src/Services/Browscap.php` | Preflight gate + Throwable catch + structured logger |
| `admin/view/index.php` | Dismissible warning notice block |
| `admin/index.php` | Register `slimstat_notice_browscap_fileinfo` AJAX action |
| `wp-slimstat.php` | Bump 5.4.12 → 5.4.13; default `notice_browscap_fileinfo => on` |
| `readme.txt`, `CHANGELOG.md` | Version + changelog + recommended extensions block |

## Test pyramid

Per `CLAUDE.md`'s "test first" rule, the fix ships with full-stack coverage:

- **Unit (source-level)** — `tests/browscap-fileinfo-preflight-test.php` (14 assertions). Runs in Tier 1 via `composer test:all`.
- **Integration (PHPUnit)** — `tests/Unit/Services/BrowscapFileinfoFallbackTest.php` shadows `extension_loaded` in the `SlimStat\Services` namespace via a `FileinfoStub` toggle. No `runkit`/Docker needed.
- **E2E (Playwright, 4 specs)** — `tests/e2e/issue-303-fileinfo-missing-tracker.spec.ts` + `tests/e2e/helpers/fileinfo-disabler-mu-plugin.php` registered in `MU_PLUGIN_MANIFEST`. Asserts tracker REST 200, row written, no `PHP Fatal` in debug.log, admin notice visible/hidden correctly.
- **BDD (Gherkin, 6 scenarios)** — `tests/e2e/features/issue-303-fileinfo-resilience.feature`.
- **Perf (k6)** — `tests/perf/issue-303-browscap-fileinfo.js` with `K6_FILEINFO_MISSING=1` toggle. Confirms fallback path is no slower than the fileinfo-present baseline.

## Test plan

- [x] `composer test:all` — 69 source-level assertions pass (incl. existing browscap-bot-safety-net, settings-isolation, wp-filesystem regressions)
- [x] `vendor/bin/phpunit tests/Unit/Services/` — 10 tests pass
- [x] `php -l` clean on all 8 modified PHP files
- [ ] `npm run test:e2e -- --grep "issue-303"` — needs a real WP env with the mu-plugin shim active
- [ ] `K6_FILEINFO_MISSING=1 k6 run tests/perf/issue-303-browscap-fileinfo.js` — manual nightly run
- [ ] Manual smoke on a `wp-playground` instance (Playground's PHP WASM build does not ship `fileinfo` — natural test environment)
- [ ] Regenerate `wp-slimstat.pot` before tagging the release (one new translatable string for the admin notice)

## Out of scope (logged as follow-ups)

- Inject `ExtensionMimeTypeDetector` into Flysystem so Browscap can work even without `fileinfo` (Browscap stores `.json`/`.php` cache files — MIME detection is moot).
- `\Throwable` sweep across other `catch (Exception)` sites in the tracker hot path (`Tracker/Processor.php`, `Tracker/Ajax.php`, `Tracker/VisitIdGenerator.php`, `Services/Geolocation/Provider/*`).
- PHP 8.4 implicit-nullable parameter deprecations in bundled Flysystem — surfaced by the new integration test (already tracked separately on the roadmap).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented tracker REST/admin-ajax endpoints from returning HTTP 500 when PHP fileinfo is missing; added graceful fallback for browser detection.
  * Broadened error handling and controlled error reporting (gated by debug settings).

* **UI**
  * Added an admin notice when Browscap is enabled but fileinfo is absent, with a dismiss option.

* **Tests**
  * Added unit, e2e, perf, and preflight tests covering fileinfo-missing scenarios.

* **Documentation**
  * Bumped version and updated README/changelog.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wp-slimstat/wp-slimstat/pull/304)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->