### PR TITLE
fix: Tracker::_dtr_pton initializes $unpacked (PHP 8.1+ regression) + re-promote 8.1 to Tier 1 fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # 8.1 stays in Tier 3 nightly only — promoting to fast surfaced an
-        # unrelated pre-existing test failure (TrackerTest::test_dtr_pton…
-        # `inet_pton` returns '00000000' on 8.1, not ''). Tracked separately.
-        php: ["7.4", "8.2"]
+        # 8.1 promoted so implicit-nullable E_DEPRECATED regressions surface
+        # during PR review, not 24h later in nightly.
+        php: ["7.4", "8.1", "8.2"]
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+= 5.4.16 - 2026-05-14 =
+
+**PHP 8.1 tracker IP binarization fix**
+
+- `Tracker::_dtr_pton()` returns `''` for invalid IPs on PHP 8.1+ as documented. Previously, the missing `$unpacked = false;` initialization let an invalid input fall through to `str_split(null)` which produces `['']` on PHP 8.1+ (a single empty-char element). `ord('') + decbin(0) + str_pad(8)` then yielded a phantom `'00000000'` — 8 fake zero bits being silently mixed into IP filter comparisons. The sibling `Utils::dtrPton()` already had the right initialization (`src/Tracker/Utils.php:219`); this fix copies the same one-line guard into `Tracker::_dtr_pton()`. Surfaced by the v5.4.15 CI matrix expansion (which initially promoted 8.1 to Tier 1 fast, then reverted when this test failed). With the fix, PHP 8.1 is re-promoted to Tier 1 fast in this release — implicit-nullable regressions now surface on PR review, not 24h later in nightly.
+
 = 5.4.15 - 2026-05-14 =
 
 **PHP 8.1+ deprecation cleanup**

--- a/composer.json
+++ b/composer.json
@@ -80,10 +80,12 @@
     "test:php74-compat": "php tests/php74-no-php80-functions-test.php",
     "test:implicit-nullable": "php tests/php-implicit-nullable-test.php",
     "test:ci-matrix-coverage": "php tests/ci-matrix-coverage-test.php",
+    "test:dtr-pton-init": "php tests/dtr-pton-init-test.php",
     "test:source-level": [
       "@test:php74-compat",
       "@test:implicit-nullable",
-      "@test:ci-matrix-coverage"
+      "@test:ci-matrix-coverage",
+      "@test:dtr-pton-init"
     ],
     "test:unit": "phpunit --configuration phpunit.xml.dist",
     "test:all": [

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 5.6
 Requires PHP: 7.4
 Recommended PHP extensions: fileinfo (required if the Browscap library is enabled)
 Tested up to: 6.9.4
-Stable tag: 5.4.15
+Stable tag: 5.4.16
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -76,6 +76,9 @@ An extensive knowledge base is available on our [website](https://www.wp-slimsta
 9. **Settings** - Plenty of options to customize the plugin's behavior
 
 == Changelog ==
+= 5.4.16 - 2026-05-14 =
+* Fix: Tracker IP binarization no longer emits 8 phantom zero bits when called with an invalid IP on PHP 8.1+. `Tracker::_dtr_pton()` was missing the initialization its `Utils::dtrPton()` sibling already had. PHP 8.1 is now re-promoted to the CI Tier 1 fast lane.
+
 = 5.4.15 - 2026-05-14 =
 * Fix: 6 implicit-nullable parameter signatures (`Type $x = null` → `?Type $x = null`) silenced — `LogException`, `Query::hasWhereClause`, `DateRangeHelper::format_date_range`, `ConditionTagEvaluator::checkConditions`, `CloudflareGeolocationProvider` closure, `Session::setTrackingCookie`. Stops PHP 8.1+ `debug.log` deprecation noise from own code and prepares for PHP 9.0 (where the deprecation becomes fatal). New `composer test:implicit-nullable` regression test catches future regressions.
 

--- a/src/Tracker/Tracker.php
+++ b/src/Tracker/Tracker.php
@@ -425,6 +425,13 @@ class Tracker
 
     public static function _dtr_pton($_ip)
     {
+        // Initialize before the conditional branches. Without this, an invalid
+        // IP leaves $unpacked undefined; on PHP 8.1+ the downstream
+        // `str_split($unpacked[1])` evaluates to `['']` (one empty char) which
+        // ord/decbin/str_pad converts to '00000000' — leaking 8 bogus zero
+        // bits instead of returning an empty string. Mirrors the explicit
+        // init at Utils.php:219.
+        $unpacked = false;
         if (filter_var($_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
             $unpacked = unpack('A4', inet_pton($_ip));
         } elseif (filter_var($_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) && defined('AF_INET6')) {

--- a/tests/Unit/Tracker/TrackerTest.php
+++ b/tests/Unit/Tracker/TrackerTest.php
@@ -162,11 +162,46 @@ class TrackerTest extends WpSlimstatTestCase
     /** @test */
     public function test_dtr_pton_returns_empty_string_for_invalid_ip(): void
     {
-        // The production code accesses $unpacked before it is assigned when
-        // neither IPv4 nor IPv6 branch fires.  Suppress the resulting PHP
-        // notice/warning so PHPUnit does not flag this test as warned.
-        $result = @\SlimStat\Tracker\Tracker::_dtr_pton('not-an-ip');
+        // Pre-fix: undefined $unpacked → null → on PHP 8.1+ str_split(null)
+        // returned [''] and ord('')+decbin(0)+str_pad yielded '00000000'.
+        // Post-fix: explicit init lets the condition short-circuit cleanly.
+        $result = \SlimStat\Tracker\Tracker::_dtr_pton('not-an-ip');
         $this->assertSame('', $result);
+    }
+
+    /** @test */
+    public function test_dtr_pton_returns_32_bit_binary_for_valid_ipv4(): void
+    {
+        $result = \SlimStat\Tracker\Tracker::_dtr_pton('192.168.1.1');
+        $this->assertSame(32, strlen($result), 'IPv4 must produce 32-bit binary string');
+        $this->assertMatchesRegularExpression('/^[01]+$/', $result);
+        $this->assertSame('11000000101010000000000100000001', $result);
+    }
+
+    /** @test */
+    public function test_dtr_pton_returns_128_bit_binary_for_valid_ipv6(): void
+    {
+        if (!defined('AF_INET6')) {
+            $this->markTestSkipped('AF_INET6 not available on this build');
+        }
+        $result = \SlimStat\Tracker\Tracker::_dtr_pton('::1');
+        $this->assertSame(128, strlen($result), 'IPv6 must produce 128-bit binary string');
+        $this->assertMatchesRegularExpression('/^[01]+$/', $result);
+        $this->assertSame(str_repeat('0', 127) . '1', $result, '::1 is 127 zero bits + 1');
+    }
+
+    /** @test */
+    public function test_dtr_pton_returns_empty_string_for_empty_input(): void
+    {
+        $result = \SlimStat\Tracker\Tracker::_dtr_pton('');
+        $this->assertSame('', $result, 'Empty input must produce empty result, not 8 phantom zero bits');
+    }
+
+    /** @test */
+    public function test_dtr_pton_returns_empty_string_for_null_input(): void
+    {
+        $result = \SlimStat\Tracker\Tracker::_dtr_pton(null);
+        $this->assertSame('', $result, 'Null input must produce empty result');
     }
 
     /** @test */

--- a/tests/dtr-pton-init-test.php
+++ b/tests/dtr-pton-init-test.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Source-level regression: dtr_pton-style IP binarization helpers must
+ * initialize $unpacked BEFORE the conditional IPv4/IPv6 branches.
+ *
+ * Without explicit init, an invalid IP leaves $unpacked undefined. On PHP
+ * 8.1+ the downstream `str_split($unpacked[1])` evaluates to `['']` (one
+ * empty char) and `ord('') + decbin(0) + str_pad(8)` yields a phantom
+ * '00000000' — 8 fake zero bits leaking into IP-filter comparisons.
+ *
+ * @see src/Tracker/Tracker.php:_dtr_pton (was missing init, fixed in 5.4.16)
+ * @see src/Tracker/Utils.php:dtrPton (already had `$unpacked = false;`)
+ */
+
+declare(strict_types=1);
+
+$plugin_root = dirname(__DIR__);
+
+$checks = [
+    [
+        'file'  => $plugin_root . '/src/Tracker/Tracker.php',
+        'fn'    => '_dtr_pton',
+        'label' => 'Tracker::_dtr_pton',
+    ],
+    [
+        'file'  => $plugin_root . '/src/Tracker/Utils.php',
+        'fn'    => 'dtrPton',
+        'label' => 'Utils::dtrPton',
+    ],
+];
+
+$violations = [];
+foreach ($checks as $c) {
+    $src = file_get_contents($c['file']);
+    if ($src === false) {
+        $violations[] = "{$c['label']}: cannot read {$c['file']}";
+        continue;
+    }
+    // Match the function body up to the first `if (...)` that uses unpack().
+    $pattern = '/function\s+' . preg_quote($c['fn'], '/')
+        . '\s*\([^)]*\)\s*(?::\s*\w+\s*)?\{([\s\S]*?)(?:if\s*\(\s*filter_var)/m';
+    if (!preg_match($pattern, $src, $m)) {
+        $violations[] = "{$c['label']}: could not parse function body";
+        continue;
+    }
+    $pre_branch = $m[1];
+    if (!preg_match('/\$unpacked\s*=\s*(false|null|\[\])\s*;/', $pre_branch)) {
+        $violations[] = "{$c['label']}: missing `\$unpacked = false;` initialization before filter_var branches in {$c['file']}";
+    }
+}
+
+if ($violations) {
+    fwrite(STDERR, "FAIL: dtr_pton helpers must initialize \$unpacked (PHP 8.1+ regression guard):\n");
+    foreach ($violations as $v) fwrite(STDERR, "  - {$v}\n");
+    fwrite(STDERR, "\nFix: add `\$unpacked = false;` between the function open-brace and the IPv4/IPv6 filter_var branches.\n");
+    exit(1);
+}
+
+echo "OK: dtr_pton-style helpers initialize \$unpacked (Tracker::_dtr_pton, Utils::dtrPton)\n";

--- a/tests/e2e/features/dtr-pton-php81-regression.feature
+++ b/tests/e2e/features/dtr-pton-php81-regression.feature
@@ -1,0 +1,40 @@
+Feature: Tracker IP binarization is correct on PHP 8.1+
+  The `_dtr_pton()` helper converts an IP string to its binary representation
+  for prefix-based IP-filter comparisons (`ignore_ip`, GDPR exclusions, etc.).
+  On PHP 8.1+ a missing `$unpacked` initialization let invalid inputs leak
+  8 phantom zero bits into filter comparisons — silently broken IP filters.
+
+  # Source enforcement: tests/dtr-pton-init-test.php
+  # PHPUnit:            tests/Unit/Tracker/TrackerTest.php (5 test_dtr_pton_* cases)
+  # Issue:              v5.4.15 CI Tier 1 8.1 lane test failure (resolved in 5.4.16)
+
+  Background:
+    Given WP Slimstat 5.4.16 or later is active
+    And the host is running PHP 8.1 or higher
+
+  Scenario: bdd-dtr-pton-invalid-ip-returns-empty-string
+    When Tracker::_dtr_pton is called with the string "not-an-ip"
+    Then the return value is the empty string ""
+    And the return value is NOT the phantom "00000000" (8 fake zero bits)
+
+  Scenario: bdd-dtr-pton-valid-ipv4-returns-32-bit-binary
+    When Tracker::_dtr_pton is called with "192.168.1.1"
+    Then the return value has length 32
+    And the return value contains only "0" and "1" characters
+    And the return value equals "11000000101010000000000100000001"
+
+  Scenario: bdd-dtr-pton-valid-ipv6-returns-128-bit-binary
+    Given the AF_INET6 constant is defined
+    When Tracker::_dtr_pton is called with "::1"
+    Then the return value has length 128
+    And the return value is 127 zero bits followed by "1"
+
+  Scenario: bdd-dtr-pton-empty-input-returns-empty-string
+    When Tracker::_dtr_pton is called with the empty string ""
+    Then the return value is the empty string ""
+
+  Scenario: bdd-ci-8-1-lane-re-promoted-to-fast
+    # Reverted in v5.4.15, re-promoted in v5.4.16 once the underlying bug was
+    # fixed. 8.1 in Tier 1 catches implicit-nullable E_DEPRECATED at PR time.
+    Given .github/workflows/ci.yml is at v5.4.16 or later
+    Then the Tier 1 fast matrix includes "8.1"

--- a/wp-slimstat.php
+++ b/wp-slimstat.php
@@ -3,7 +3,7 @@
  * Plugin Name: SlimStat Analytics
  * Plugin URI: https://wp-slimstat.com/
  * Description: The leading web analytics plugin for WordPress
- * Version: 5.4.15
+ * Version: 5.4.16
  * Author: Jason Crouse, VeronaLabs
  * Text Domain: wp-slimstat
  * Domain Path: /languages
@@ -20,7 +20,7 @@ if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
 }
 
 // Set the plugin version and directory
-define('SLIMSTAT_ANALYTICS_VERSION', '5.4.15');
+define('SLIMSTAT_ANALYTICS_VERSION', '5.4.16');
 define('SLIMSTAT_FILE', __FILE__);
 define('SLIMSTAT_DIR', __DIR__);
 define('SLIMSTAT_URL', plugins_url('', __FILE__));


### PR DESCRIPTION
## Summary

Follow-up to the PHP 7.4–8.5 compat wave (#307–309). v5.4.15's CI matrix expansion initially promoted PHP 8.1 to Tier 1 fast but reverted it after a pre-existing test failure surfaced:

```
WpSlimstat\Tests\Unit\Tracker\TrackerTest::test_dtr_pton_returns_empty_string_for_invalid_ip
Failed asserting that two strings are identical.
- ''
+ '00000000'
```

This PR fixes the underlying bug and re-promotes PHP 8.1 to Tier 1 fast.

## Root cause

`Tracker::_dtr_pton()` ([src/Tracker/Tracker.php:426](wp-slimstat/src/Tracker/Tracker.php#L426)) was missing the `$unpacked = false;` initialization that its sibling [`Utils::dtrPton()`](wp-slimstat/src/Tracker/Utils.php#L219) already had. The control flow:

1. Invalid IP (`'not-an-ip'`) — neither `filter_var(..., FILTER_FLAG_IPV4)` nor `FILTER_FLAG_IPV6` branch fires.
2. `$unpacked` is **undefined**. PHP 7.x/8.0: warning, treated as `null`. PHP 8.1+: same — but downstream behavior diverges.
3. The condition `[] !== $unpacked && false !== $unpacked` is `true && true` (both are `null`).
4. Inside: `str_split($unpacked[1])` — `null[1]` is `null`.
5. **PHP 8.1+**: `str_split(null)` returns `['']` (one element, empty string).
6. `foreach ([''])` iterates once with `$char = ''`. `ord('')` = `0`. `decbin(0)` = `'0'`. `str_pad('0', 8, '0', STR_PAD_LEFT)` = `'00000000'`.
7. Function returns `'00000000'` — 8 phantom zero bits — instead of the empty string its contract promises.

The function is used by IP-filter prefix matching (`ignore_ip`, GDPR exclusions). The 8 phantom bits silently corrupted comparisons for any code path that fell through with an invalid IP.

## Fix

One-line `$unpacked = false;` initialization before the conditional branches. Mirrors the existing `Utils::dtrPton()` pattern exactly.

```diff
 public static function _dtr_pton($_ip)
 {
+    $unpacked = false;
     if (filter_var($_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
         $unpacked = unpack('A4', inet_pton($_ip));
     } elseif (filter_var($_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) && defined('AF_INET6')) {
         $unpacked = unpack('A16', inet_pton($_ip));
     }
```

Now `false !== $unpacked` short-circuits the body cleanly, returns `''`. Works across PHP 7.4 → 8.5.

## CI: 8.1 re-promoted to Tier 1 fast

```diff
       matrix:
-        # 8.1 stays in Tier 3 nightly only — promoting to fast surfaced an
-        # unrelated pre-existing test failure (TrackerTest::test_dtr_pton…
-        # `inet_pton` returns '00000000' on 8.1, not ''). Tracked separately.
-        php: ["7.4", "8.2"]
+        # 8.1 promoted so implicit-nullable E_DEPRECATED regressions surface
+        # during PR review, not 24h later in nightly.
+        php: ["7.4", "8.1", "8.2"]
```

## Test pyramid

| Layer | What it covers |
|-------|----------------|
| **Unit (PHPUnit)** | 5 cases in `tests/Unit/Tracker/TrackerTest.php`: invalid IP returns `''` (no longer needs `@` suppression), valid IPv4 returns the 32-bit binary, valid IPv6 returns the 128-bit binary, empty input, null input |
| **Source-level** | `tests/dtr-pton-init-test.php` — vanilla PHP greps both `_dtr_pton` and `dtrPton` siblings for the `$unpacked = false;` init line. Wired into `composer test:source-level`. Runs on every push including PHP 7.4 lane. |
| **BDD Gherkin** | `tests/e2e/features/dtr-pton-php81-regression.feature` — 5 scenarios documenting the contract |

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/Tracker/TrackerTest.php --filter dtr_pton` — 5 tests, 9 assertions, all green on PHP 8.5
- [x] `composer test:source-level` — all 4 source-level tests pass (incl. new `test:dtr-pton-init`)
- [x] `composer test:php74-compat` and `composer test:implicit-nullable` — clean (no regressions in own code)
- [x] `php -l` clean on all touched PHP files
- [ ] CI will validate the same on PHP 7.4, 8.1, 8.2 in Tier 1 fast (8.1 lane was the smoking gun)

## Version

5.4.15 → 5.4.16

## Related

- v5.4.15 introduction of the issue: see CI Tier 1 fast comment that this PR removes
- Original audit: workflow `wf_6a843729-d77`
- Final post-merge review surfaced this as Follow-up #1
