### PR TITLE
style(tests): batch PR #307 CodeRabbit nits (GPL + Yoda + PHPDoc + assertion message)

### DIFF
--- a/tests/Unit/Admin/EnqueueScriptsCompatTest.php
+++ b/tests/Unit/Admin/EnqueueScriptsCompatTest.php
@@ -17,6 +17,11 @@ use WpSlimstat\Tests\Unit\WpSlimstatTestCase;
  */
 class EnqueueScriptsCompatTest extends WpSlimstatTestCase
 {
+    /**
+     * Data provider for the screen-id gate at admin/index.php:891.
+     *
+     * @return array<string,array{0:mixed,1:bool}> Map of label → [screen_id, expected match].
+     */
     public static function screenIdProvider(): array
     {
         return [
@@ -28,15 +33,29 @@ class EnqueueScriptsCompatTest extends WpSlimstatTestCase
         ];
     }
 
-    /** @dataProvider screenIdProvider */
+    /**
+     * Verifies the screen-id gate at admin/index.php:891 matches str_contains semantics.
+     *
+     * @dataProvider screenIdProvider
+     *
+     * @param mixed $screen_id      The simulated WP_Screen->id value (string|null).
+     * @param bool  $expected_match Whether the post-fix conditional must evaluate true.
+     *
+     * @return void
+     */
     public function test_screen_gate_matches_str_contains_semantics($screen_id, bool $expected_match): void
     {
-        $current_screen = $screen_id !== null ? (object) ['id' => $screen_id] : null;
+        $current_screen = null !== $screen_id ? (object) ['id' => $screen_id] : null;
         $matched = $current_screen && false !== strpos((string) ($current_screen->id ?? ''), 'slim');
 
-        $this->assertSame($expected_match, $matched, "Screen gate mismatch for screen_id=" . var_export($screen_id, true));
+        $this->assertSame($expected_match, $matched, 'Screen gate mismatch for screen_id=' . var_export($screen_id, true));
     }
 
+    /**
+     * Data provider for the datepicker gate at admin/index.php:906.
+     *
+     * @return array<string,array{0:string,1:bool}> Map of label → [page query value, expected match].
+     */
     public static function pageQueryProvider(): array
     {
         return [
@@ -49,7 +68,16 @@ class EnqueueScriptsCompatTest extends WpSlimstatTestCase
         ];
     }
 
-    /** @dataProvider pageQueryProvider */
+    /**
+     * Verifies the datepicker gate at admin/index.php:906 matches the original semantics.
+     *
+     * @dataProvider pageQueryProvider
+     *
+     * @param string $page           The simulated $_GET['page'] value.
+     * @param bool   $expected_match Whether the post-fix conditional must evaluate true.
+     *
+     * @return void
+     */
     public function test_datepicker_gate_matches_str_contains_semantics(string $page, bool $expected_match): void
     {
         $matched = false !== strpos($page, 'slim') && false === strpos($page, 'setting');

--- a/tests/e2e/issue-php74-admin-load.spec.ts
+++ b/tests/e2e/issue-php74-admin-load.spec.ts
@@ -23,7 +23,7 @@ test.describe('Issue #303 follow-up — PHP 7.4 wp-admin loads (str_contains reg
 
   test.afterEach(() => {
     const log = readDebugLog();
-    expect(log, 'debug.log must not contain `Class "finfo" not found` nor `Call to undefined function str_contains`')
+    expect(log, 'debug.log must not contain `Call to undefined function str_contains`')
       .not.toMatch(/Call to undefined function str_contains/);
     expect(log, 'debug.log must not contain any PHP Fatal from wp-slimstat path')
       .not.toMatch(/PHP Fatal error[\s\S]{0,500}wp-slimstat/);

--- a/tests/php74-no-php80-functions-test.php
+++ b/tests/php74-no-php80-functions-test.php
@@ -1,5 +1,24 @@
 <?php
 /**
+ * SlimStat Analytics — PHP 7.4 source-level regression test.
+ *
+ * @package wp-slimstat
+ * @license GPL-2.0-or-later
+ *
+ * Copyright (C) 2026 VeronaLabs <info@veronalabs.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
  * Source-level regression: PHP 8.0+ functions must not appear in own code.
  *
  * Until v5.4.14, admin/index.php called str_contains() (PHP 8.0+) without
@@ -41,22 +60,22 @@ $paths = [
 $files = [];
 foreach ($paths as $path) {
     if (is_file($path)) {
-        if (substr($path, -4) === '.php') $files[] = $path;
+        if ('.php' === substr($path, -4)) $files[] = $path;
         continue;
     }
     if (!is_dir($path)) continue;
     // Prune src/Dependencies/ at descent — saves walking ~500 scoped vendor files.
     $directory = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS);
     $filtered  = new RecursiveCallbackFilterIterator($directory, function ($file) use ($deps_prefix) {
-        return strpos($file->getPathname(), $deps_prefix . DIRECTORY_SEPARATOR) !== 0;
+        return 0 !== strpos($file->getPathname(), $deps_prefix . DIRECTORY_SEPARATOR);
     });
     foreach (new RecursiveIteratorIterator($filtered) as $file) {
-        if (substr($file->getPathname(), -4) === '.php') $files[] = $file->getPathname();
+        if ('.php' === substr($file->getPathname(), -4)) $files[] = $file->getPathname();
     }
 }
 sort($files);
 
-if (count($files) === 0) {
+if (0 === count($files)) {
     fwrite(STDERR, "FAIL: scanner found zero own-code .php files\n");
     exit(1);
 }
@@ -64,7 +83,7 @@ if (count($files) === 0) {
 $violations = [];
 foreach ($files as $file) {
     $contents = file_get_contents($file);
-    if ($contents === false) continue;
+    if (false === $contents) continue;
     foreach ($forbidden_functions as $fn) {
         $pattern = '/(?<![>:$\\\\])\b' . preg_quote($fn, '/') . '\s*\(/';
         if (!preg_match_all($pattern, $contents, $matches, PREG_OFFSET_CAPTURE)) continue;
@@ -72,9 +91,9 @@ foreach ($files as $file) {
             $line_no = substr_count($contents, "\n", 0, $offset) + 1;
             $line    = strtok(substr($contents, $offset), "\n");
             $prev    = $line_no > 1 ? explode("\n", substr($contents, 0, $offset))[$line_no - 2] : '';
-            if (strpos($prev, $allow_marker) !== false) continue;
+            if (false !== strpos($prev, $allow_marker)) continue;
             $stripped = ltrim($line);
-            if (strpos($stripped, '//') === 0 || strpos($stripped, '*') === 0) continue;
+            if (0 === strpos($stripped, '//') || 0 === strpos($stripped, '*')) continue;
             $rel = substr($file, strlen($plugin_root) + 1);
             $violations[] = sprintf('%s:%d  → %s(...)  %s', $rel, $line_no, $fn, trim($line));
         }


### PR DESCRIPTION
Batches the 4 CodeRabbit findings from PR #307's review into a single sweep.

## What
| File | Fix |
|------|-----|
| `tests/php74-no-php80-functions-test.php` | + GPL-2.0+ license header (was the only test in the repo without one) |
| `tests/php74-no-php80-functions-test.php` | 7 Yoda conversions on lines 44, 51, 54, 59, 67, 75, 77 (literal-first per WPCS) |
| `tests/Unit/Admin/EnqueueScriptsCompatTest.php` | + PHPDoc on both data providers (@return) and both test methods (@dataProvider, @param, @return) |
| `tests/e2e/issue-php74-admin-load.spec.ts` | Trim misleading `Class "finfo" not found` mention from the afterEach assertion message (belongs to the separate fileinfo spec) |

## Verification
- `composer test:php74-compat` — scans 102 own-code files, clean (logic unchanged)
- `vendor/bin/phpunit tests/Unit/Admin/EnqueueScriptsCompatTest.php` — 11 tests, 11 assertions, green
- `php -l` clean on both touched PHP files

Surfaced by the post-merge review as Follow-up #3.