### PR TITLE
fix(v5.5.0): filter dropdown (#298), value-less filters (#305), android-app referers (#306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 = 5.5.0 - Unreleased =
 
+**Filters & traffic sources**
+
+- Fixed: Google Discover and other Android/iOS app traffic is recorded again. Since 5.4.0, referrers that start with `android-app://` (such as `com.google.android.googlequicksearchbox` from Google Discover) were silently dropped, so that traffic showed up as "direct" with no source. The tracker now preserves app-scheme referrers while still blocking unsafe ones. ([#306](https://github.com/wp-slimstat/wp-slimstat/issues/306))
+- Fixed: The "is empty" and "is not empty" report filters work again. Since 5.4.0 they were silently ignored — the filter chip appeared but every row was still shown — and the filter was lost when you paginated, refreshed, or changed the date range. They now apply on the first click and survive in-session navigation. ([#305](https://github.com/wp-slimstat/wp-slimstat/issues/305))
+- Fixed: The Access Log filter dropdown now accepts pasted or typed values that aren't in the visible list. Previously, on busy sites, a value clearly visible in the log (for example a specific IP) could return "No matching options found" and the filter couldn't be applied. The dropdown now searches the full column history and lets you apply the value you typed. ([#298](https://github.com/wp-slimstat/wp-slimstat/issues/298))
+
 **Compatibility & stability**
 
 - Fixed: WordPress admin no longer crashes on PHP 7.4 hosts. Some admin pages were calling a function that only exists in PHP 8.0 and newer, which broke wp-admin entirely. Replaced with a compatible alternative.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Compatibility & stability**
 
+- Removed: The admin "Feedback" widget (powered by feedbackbird.io) has been removed. It loaded a script from a third-party CDN and sent your email address, PHP version, and active-plugin list off-site with no opt-out. SlimStat no longer makes this external call.
 - Fixed: WordPress admin no longer crashes on PHP 7.4 hosts. Some admin pages were calling a function that only exists in PHP 8.0 and newer, which broke wp-admin entirely. Replaced with a compatible alternative.
 - Fixed: Visit tracking no longer fails with a 500 error on hosts that don't have the optional PHP `fileinfo` extension (common on managed and minimal PHP builds). When the extension is missing, the plugin now falls back to its built-in browser detector and shows a dismissible admin notice so you can ask your host to enable the extension or turn off the Browscap library.
 - Fixed: An IP-filter bug on PHP 8.1 silently added 8 extra binary bits when the tracker was handed an invalid IP, which could make rules like "ignore my IP" behave incorrectly. Filters now match correctly across all PHP versions.

--- a/admin/assets/css/header-modern.css
+++ b/admin/assets/css/header-modern.css
@@ -227,32 +227,7 @@
     letter-spacing: 0.01em;
 }
 
-#contextual-help-link-wrap,
-#feedbackbird-widget-button,
-#feedbackbird-widget-button-wrapper,
-.feedbackbird-widget-button,
-.feedbackbird-widget-button *,
-[data-feedbackbird-button],
-[data-feedbackbird-launch],
-[data-feedbackbird-launcher],
-[id*="feedbackbird"],
-.feedbackbird-floating-button,
-.feedbackbird-launcher,
-.feedbackbird-widget-app,
-[class*="feedbackbird"] button,
-[class*="feedbackbird"] a,
-[data-feedbackbird-open] {
-    display: none !important;
-}
-
-#wp-admin-bar-feedbackbird,
-#wp-admin-bar-feedbackbird * {
-    display: none !important;
-}
-
-iframe[src*="feedbackbird"],
-iframe[id*="feedbackbird"],
-[class*="feedbackbird"] iframe {
+#contextual-help-link-wrap {
     display: none !important;
 }
 

--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -511,6 +511,9 @@ jQuery(function () {
             this.isOpen = false;
             this.filteredOptions = [];
             this.allOptions = [];
+            // Latched on the first setOptions() call so a later server-side
+            // search can clear back to the "like first open" list.
+            this.initialOptions = null;
 
             this.init();
         }
@@ -589,6 +592,12 @@ jQuery(function () {
             const searchInput = this.searchContainer.querySelector("input");
             searchInput.addEventListener("input", (e) => {
                 const term = e.target.value;
+                // When the user clears a server-search term back below the 2-char
+                // threshold, put the pre-fetched list back so the dropdown returns
+                // to the "like first open" state instead of staying narrowed.
+                if (this.options.serverSearchAction && term.trim().length < 2) {
+                    this.restoreInitialOptions();
+                }
                 // When a server-side search will fire for this keystroke, skip the
                 // client-side filter — its result will be replaced once the AJAX
                 // response lands, and the flash of an intermediate list is jarring.
@@ -634,6 +643,12 @@ jQuery(function () {
                     icon: opt.icon || null,
                 };
             });
+            // Latch on the first call — the dimension-change handler passes the
+            // pre-fetched 500-item list, and later server-search replacements
+            // must not overwrite it so the user can clear back to this state.
+            if (this.initialOptions === null) {
+                this.initialOptions = this.allOptions.slice();
+            }
             this.filteredOptions = [...this.allOptions];
             this.renderOptions();
         }
@@ -803,6 +818,12 @@ jQuery(function () {
             return (searchTerm || "").trim().length >= 2;
         }
 
+        restoreInitialOptions() {
+            if (!this.initialOptions) return;
+            if (this.allOptions === this.initialOptions) return;
+            this.allOptions = this.initialOptions.slice();
+        }
+
         scheduleServerSearch(searchTerm) {
             if (!this.options.serverSearchAction || !this.options.serverSearchDimension) return;
             if (this.isDisabled()) return;
@@ -959,6 +980,7 @@ jQuery(function () {
             this.allOptions = null;
             this.filteredOptions = null;
             this.selectedOption = null;
+            this.initialOptions = null;
         }
     }
 

--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -499,6 +499,7 @@ jQuery(function () {
                 placeholder: __("Select value...", "wp-slimstat"),
                 searchPlaceholder: __("Search...", "wp-slimstat"),
                 noResultsText: __("No results found", "wp-slimstat"),
+                noMatchesText: __("No matches — click Apply to filter by this value.", "wp-slimstat"),
                 loadingText: __("Loading...", "wp-slimstat"),
                 allowClear: true,
                 ...options,
@@ -587,7 +588,19 @@ jQuery(function () {
             // Search input
             const searchInput = this.searchContainer.querySelector("input");
             searchInput.addEventListener("input", (e) => {
-                this.filterOptions(e.target.value);
+                const term = e.target.value;
+                // When a server-side search will fire for this keystroke, skip the
+                // client-side filter — its result will be replaced once the AJAX
+                // response lands, and the flash of an intermediate list is jarring.
+                if (!this.willServerSearch(term)) {
+                    this.filterOptions(term);
+                }
+                this.syncTypedValue(term);
+                this.scheduleServerSearch(term);
+            });
+
+            searchInput.addEventListener("blur", () => {
+                this.dispatchChange();
             });
 
             searchInput.addEventListener("keydown", (e) => {
@@ -655,7 +668,13 @@ jQuery(function () {
                 // Create no results element safely to prevent XSS
                 const noResultsDiv = document.createElement("div");
                 noResultsDiv.className = "slimstat-select-no-results";
-                noResultsDiv.textContent = this.options.noResultsText;
+                noResultsDiv.setAttribute("data-testid", "slimstat-no-results");
+                const searchInputEl = this.searchContainer.querySelector("input");
+                const userHasTyped = searchInputEl && searchInputEl.value.trim().length > 0;
+                const hasData = this.allOptions.length > 0;
+                noResultsDiv.textContent = (userHasTyped && hasData)
+                    ? this.options.noMatchesText
+                    : this.options.noResultsText;
                 this.optionsContainer.appendChild(noResultsDiv);
                 return;
             }
@@ -754,6 +773,106 @@ jQuery(function () {
             this.element.dispatchEvent(changeEvent);
         }
 
+        isDisabled() {
+            // is_empty / is_not_empty operators mark the value field inert.
+            return this.element.readOnly || this.selectWrapper.style.pointerEvents === "none";
+        }
+
+        syncTypedValue(value) {
+            if (this.isDisabled()) return;
+            this.element.value = value;
+        }
+
+        dispatchChange() {
+            const changeEvent = new Event("change", { bubbles: true });
+            this.element.dispatchEvent(changeEvent);
+        }
+
+        updateDisplayFromValue(value) {
+            const textElement = this.display.querySelector(".slimstat-select-text");
+            textElement.innerHTML = "";
+            const labelSpan = document.createElement("span");
+            labelSpan.textContent = value;
+            textElement.appendChild(labelSpan);
+            this.display.classList.remove("slimstat-placeholder");
+        }
+
+        willServerSearch(searchTerm) {
+            if (!this.options.serverSearchAction || !this.options.serverSearchDimension) return false;
+            if (this.isDisabled()) return false;
+            return (searchTerm || "").trim().length >= 2;
+        }
+
+        scheduleServerSearch(searchTerm) {
+            if (!this.options.serverSearchAction || !this.options.serverSearchDimension) return;
+            if (this.isDisabled()) return;
+
+            const term = (searchTerm || "").trim();
+
+            if (this._searchDebounce) {
+                clearTimeout(this._searchDebounce);
+                this._searchDebounce = null;
+            }
+
+            if (this._searchAbort) {
+                try { this._searchAbort.abort(); } catch (e) { /* no-op */ }
+                this._searchAbort = null;
+            }
+
+            // Under 2 chars: fall back to legacy full DISTINCT from the initial fetch.
+            if (term.length < 2) return;
+
+            this._searchDebounce = setTimeout(() => {
+                this.runServerSearch(term);
+            }, 250);
+        }
+
+        runServerSearch(term) {
+            const hasAbort = typeof AbortController !== "undefined";
+            this._searchAbort = hasAbort ? new AbortController() : null;
+            const signal = this._searchAbort ? this._searchAbort.signal : null;
+            const timeRange = this.options.serverSearchTimeRange || { type: "last_28_days", from: "", to: "" };
+
+            jQuery.ajax({
+                method: "POST",
+                url: (typeof ajaxurl !== "undefined") ? ajaxurl : "",
+                data: {
+                    action: this.options.serverSearchAction,
+                    dimension: this.options.serverSearchDimension,
+                    security: this.options.serverSearchNonce || "",
+                    time_range_type: timeRange.type,
+                    time_range_from: timeRange.from,
+                    time_range_to: timeRange.to,
+                    search: term
+                },
+                dataType: "json",
+                timeout: 15000,
+                xhr: function () {
+                    const xhr = jQuery.ajaxSettings.xhr();
+                    if (signal) {
+                        signal.addEventListener("abort", () => {
+                            try { xhr.abort(); } catch (e) { /* no-op */ }
+                        });
+                    }
+                    return xhr;
+                }
+            })
+                .done((response) => {
+                    // Discard stale responses if the user has kept typing.
+                    const searchInputEl = this.searchContainer.querySelector("input");
+                    const currentTerm = searchInputEl ? searchInputEl.value.trim() : "";
+                    if (currentTerm !== term) {
+                        return;
+                    }
+                    if (response && response.success && Array.isArray(response.data)) {
+                        this.setOptions(response.data);
+                    }
+                })
+                .fail(() => {
+                    // On network failure fall back silently to existing client list.
+                });
+        }
+
         getValue() {
             return this.selectedValue;
         }
@@ -799,32 +918,47 @@ jQuery(function () {
             // Clear search
             const searchInput = this.searchContainer.querySelector("input");
             searchInput.value = "";
+
+            // If the user typed a value but didn't click an option, reflect it
+            // in the closed display so they see their input committed.
+            if (!this.selectedOption && this.element.value) {
+                this.updateDisplayFromValue(this.element.value);
+            }
         }
 
         destroy() {
-            // Close dropdown if open
+            if (this._searchDebounce) {
+                clearTimeout(this._searchDebounce);
+                this._searchDebounce = null;
+            }
+            if (this._searchAbort) {
+                try { this._searchAbort.abort(); } catch (e) { /* no-op */ }
+                this._searchAbort = null;
+            }
+
             if (this.isOpen) {
                 this.close();
             }
 
             // Safely remove wrapper and restore original element
             if (this.wrapper && this.element) {
-                // Move element back to its original position before wrapper
                 if (this.wrapper.parentNode) {
                     this.wrapper.parentNode.insertBefore(this.element, this.wrapper);
                 }
 
-                // Show original element
                 this.element.style.display = "";
-
-                // Clear value
                 this.element.value = "";
 
-                // Remove wrapper
                 if (this.wrapper.parentNode) {
                     this.wrapper.parentNode.removeChild(this.wrapper);
                 }
             }
+
+            // Drop references so GC can reclaim the option list + DOM subtree
+            // even if an external holder retains the instance.
+            this.allOptions = null;
+            this.filteredOptions = null;
+            this.selectedOption = null;
         }
     }
 
@@ -937,7 +1071,12 @@ jQuery(function () {
                             placeholder: __('Select value...', 'wp-slimstat'),
                             searchPlaceholder: __('Search options...', 'wp-slimstat'),
                             noResultsText: noResultsText,
-                            loadingText: __('Loading options...', 'wp-slimstat')
+                            noMatchesText: __('No matches — click Apply to filter by this value.', 'wp-slimstat'),
+                            loadingText: __('Loading options...', 'wp-slimstat'),
+                            serverSearchAction: 'slimstat_get_filter_options',
+                            serverSearchDimension: dimension,
+                            serverSearchNonce: jQuery("#meta-box-order-nonce").val(),
+                            serverSearchTimeRange: timeRangeData
                         });
 
                         // Set the options from the AJAX response (empty array if no data)

--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -690,7 +690,12 @@ jQuery(function () {
                 const searchInputEl = this.searchContainer.querySelector("input");
                 const userHasTyped = searchInputEl && searchInputEl.value.trim().length > 0;
                 const hasData = this.allOptions.length > 0;
-                noResultsDiv.textContent = (userHasTyped && hasData)
+                // On server-search dropdowns the user can apply a value that isn't in
+                // the list, so keep inviting "click Apply" whenever they've typed — even
+                // after a server search returns no matches and empties allOptions
+                // (otherwise the hint silently reverts to the generic no-results text). See #298.
+                const acceptsTypedValue = !!this.options.serverSearchAction;
+                noResultsDiv.textContent = (userHasTyped && (hasData || acceptsTypedValue))
                     ? this.options.noMatchesText
                     : this.options.noResultsText;
                 this.optionsContainer.appendChild(noResultsDiv);

--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -618,12 +618,15 @@ jQuery(function () {
                 }
             });
 
-            // Click outside to close
-            document.addEventListener("click", (e) => {
+            // Click outside to close. Store the bound handler so destroy() can
+            // remove it — otherwise each dimension change leaks an instance whose
+            // closure pins the wrapper + option list (see destroy()).
+            this._onDocumentClick = (e) => {
                 if (!this.wrapper.contains(e.target)) {
                     this.close();
                 }
-            });
+            };
+            document.addEventListener("click", this._onDocumentClick);
 
             // Prevent dropdown from closing when clicking inside
             this.dropdown.addEventListener("click", (e) => {
@@ -795,6 +798,11 @@ jQuery(function () {
 
         syncTypedValue(value) {
             if (this.isDisabled()) return;
+            // Typing over a prior selection invalidates it, so close() reflects the
+            // typed value instead of the stale selected label.
+            if (this.selectedOption && this.selectedOption.value !== value) {
+                this.selectedOption = null;
+            }
             this.element.value = value;
         }
 
@@ -959,6 +967,13 @@ jQuery(function () {
 
             if (this.isOpen) {
                 this.close();
+            }
+
+            // Remove the document-level click listener so the instance (and the
+            // wrapper/option list its closure references) can be garbage-collected.
+            if (this._onDocumentClick) {
+                document.removeEventListener("click", this._onDocumentClick);
+                this._onDocumentClick = null;
             }
 
             // Safely remove wrapper and restore original element

--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -1126,8 +1126,11 @@ jQuery(function () {
         var operator = this.value;
         var $textInput = jQuery("#slimstat-filter-value");
 
-        if (operator == "is_empty" || operator == "is_not_empty") {
-            $textInput.attr("readonly", "readonly");
+        var valueless = SlimStatAdminParams.valueless_operators || ["is_empty", "is_not_empty"];
+        if (valueless.indexOf(operator) !== -1) {
+            // Clear any stale typed value so it cannot leak into the filter URL — the
+            // SQL builder ignores the value for these operators anyway. See #305.
+            $textInput.attr("readonly", "readonly").val("");
 
             // Disable searchable select if it exists
             if (searchableSelectInstance) {
@@ -2026,9 +2029,12 @@ var SlimStatAdmin = {
 
         // Manipulate the existing list of filters (hidden input fields), if we don't want to delete them
         if (typeof delete_existing_filters == "undefined" || !delete_existing_filters) {
+            var valueless = SlimStatAdminParams.valueless_operators || ["is_empty", "is_not_empty"];
             for (i in clean_filters) {
-                // If value is empty (length is 1, meaning that it just has the operator but no value), delete corresponding input field
-                if (clean_filters[i].trim().split(" ").length == 1) {
+                var parts = clean_filters[i].trim().split(" ");
+                // A single token means operator-only with no value. Drop it UNLESS the
+                // operator is value-less by design (is_empty/is_not_empty). See #305.
+                if (parts.length === 1 && valueless.indexOf(parts[0]) === -1) {
                     jQuery('input[name="' + i + '"]').remove();
                 } else if (jQuery('input[name="' + i + '"]').length > 0) {
                     jQuery('input[name="' + i + '"]').attr("value", clean_filters[i]);

--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -798,9 +798,13 @@ jQuery(function () {
 
         syncTypedValue(value) {
             if (this.isDisabled()) return;
-            // Typing over a prior selection invalidates it, so close() reflects the
-            // typed value instead of the stale selected label.
+            // Typing over a prior selection invalidates it. Clear the full selected
+            // state so close() reflects the typed value (not the stale label),
+            // getValue() returns the typed value, and the dropdown stops highlighting
+            // the old option.
             if (this.selectedOption && this.selectedOption.value !== value) {
+                this.selectedValue = "";
+                this.selectedText = "";
                 this.selectedOption = null;
             }
             this.element.value = value;

--- a/admin/index.php
+++ b/admin/index.php
@@ -2155,10 +2155,7 @@ class wp_slimstat_admin
 
         // Append LIKE filter when a server-side search term was supplied.
         if ($search !== '') {
-            $escaped = wp_slimstat::$wpdb->esc_like($search);
-            $like_pattern = in_array($dimension, self::FILTER_SEARCH_SUBSTRING_DIMENSIONS, true)
-                ? '%' . $escaped . '%'
-                : $escaped . '%';
+            $like_pattern    = self::build_filter_search_like($dimension, $search);
             $where_clauses[] = wp_slimstat::$wpdb->prepare($safe_dimension . ' LIKE %s', $like_pattern);
         }
 
@@ -2228,7 +2225,7 @@ class wp_slimstat_admin
         if ($search !== '' && (isset($multi_value_separators[$dimension]) || $dimension === 'notes')) {
             $has_mb       = function_exists('mb_strtolower');
             $needle       = $has_mb ? mb_strtolower($search) : strtolower($search);
-            $is_substring = in_array($dimension, self::FILTER_SEARCH_SUBSTRING_DIMENSIONS, true);
+            $is_substring = self::filter_search_is_substring($dimension);
             $results = array_values(array_filter($results, function ($row) use ($needle, $is_substring, $has_mb) {
                 $haystack = $has_mb ? mb_strtolower($row['value']) : strtolower($row['value']);
                 return $is_substring ? (strpos($haystack, $needle) !== false) : (strpos($haystack, $needle) === 0);
@@ -2306,6 +2303,28 @@ class wp_slimstat_admin
 
         wp_send_json_success($options);
         exit();
+    }
+
+    /**
+     * Whether the server-side filter search uses an unanchored (%needle%) LIKE for
+     * this dimension instead of the default left-anchored prefix (needle%). Single
+     * source of truth for the search-anchor decision (#298), shared by the SQL LIKE
+     * builder and the post-split segment re-filter.
+     */
+    private static function filter_search_is_substring(string $dimension): bool
+    {
+        return in_array($dimension, self::FILTER_SEARCH_SUBSTRING_DIMENSIONS, true);
+    }
+
+    /**
+     * Build the escaped, anchored LIKE pattern for a server-side filter search (#298).
+     * The needle is run through wpdb::esc_like so SQL LIKE metacharacters (% _) are
+     * matched literally; the caller still passes the result through wpdb::prepare.
+     */
+    private static function build_filter_search_like(string $dimension, string $search): string
+    {
+        $escaped = wp_slimstat::$wpdb->esc_like($search);
+        return self::filter_search_is_substring($dimension) ? '%' . $escaped . '%' : $escaped . '%';
     }
 
     /**

--- a/admin/index.php
+++ b/admin/index.php
@@ -970,6 +970,9 @@ class wp_slimstat_admin
             'refresh_interval'  => intval(wp_slimstat::$settings['refresh_interval']),
             'page_location'     => self::$page_location,
             'clear_cache_nonce' => wp_create_nonce('slimstat_clear_cache'),
+            // Shared with the filter form-builder so value-less operators (is_empty/
+            // is_not_empty) are never treated as a "remove filter" signal. See #305.
+            'valueless_operators' => wp_slimstat_db::$valueless_operators,
         ];
         wp_localize_script('slimstat_admin', 'SlimStatAdminParams', $params);
     }

--- a/admin/index.php
+++ b/admin/index.php
@@ -382,9 +382,6 @@ class wp_slimstat_admin
         // Add style to the admin menu
         add_action('admin_head', [self::class, 'styling_admin_menu']);
 
-        // Init feedback
-        self::initFeedback();
-
         // Add lock export button in report header
         add_filter('slimstat_report_header_buttons', fn ($_header_buttons, $_report_id) => self::add_lock_export_button($_header_buttons, $_report_id), 10, 2);
 
@@ -2566,55 +2563,6 @@ class wp_slimstat_admin
     }
 
     // END: _create_table
-
-    /**
-     * Init FeedbackBird widget a third-party service to get feedbacks from users
-     *
-     * @url https://feedbackbird.io
-     */
-    private static function initFeedback()
-    {
-        add_action('admin_enqueue_scripts', function () {
-            $screen = get_current_screen();
-
-            if (stristr($screen->id, 'slimview')) {
-                wp_register_script('feedbackbird-widget', 'https://cdn.jsdelivr.net/gh/feedbackbird/assets@master/wp/app.js?uid=01H5FBKA9Z5M2VJWQXZSX4Q7MS', [], null, true);
-                add_filter('script_loader_tag', function ($tag, $handle) {
-                    if ('feedbackbird-widget' === $handle) {
-                        $tag = str_replace('<script ', '<script defer ', $tag);
-                    }
-                    return $tag;
-                }, 10, 2);
-                wp_enqueue_script('feedbackbird-widget');
-                wp_add_inline_script('feedbackbird-widget', sprintf('var feedbackBirdObject = %s;', wp_json_encode([
-                    'user_email' => function_exists('wp_get_current_user') ? esc_attr(wp_get_current_user()->user_email) : '',
-                    'platform'   => 'wordpress-admin',
-                    'config'     => [
-                        'color'         => '#e8294c',
-                        'button'        => __('Feedback', 'wp-sms'),
-                        'subtitle'      => __('Feel free to share your thoughts!', 'wp-sms'),
-                        'opening_style' => 'modal',
-                    ],
-                    'meta' => [
-                        'php_version'    => PHP_VERSION,
-                        'active_plugins' => array_map(fn ($plugin, $pluginPath) => [
-                            'name'    => $plugin['Name'],
-                            'version' => $plugin['Version'],
-                            'status'  => is_plugin_active($pluginPath) ? 'active' : 'deactivate',
-                        ], get_plugins(), array_keys(get_plugins())),
-                    ],
-                ])));
-
-                add_filter('script_loader_tag', function ($tag, $handle, $src) {
-                    if ('feedbackbird-widget' === $handle) {
-                        return preg_replace('/^<script /i', '<script type="module" crossorigin="crossorigin" ', $tag);
-                    }
-
-                    return $tag;
-                }, 10, 3);
-            }
-        });
-    }
 
     public static function get_template($template, $args = [], $return = false)
     {

--- a/admin/index.php
+++ b/admin/index.php
@@ -15,6 +15,16 @@ class wp_slimstat_admin
     public static $admin_notice    = '';
     public static $main_menu_slug = 'slimview1';
 
+    /**
+     * Dimensions for which the filter-options search uses unanchored LIKE
+     * (%needle%) instead of the default left-anchored prefix match. These are
+     * either multi-token fields (notes, category) or free-form strings where
+     * users naturally search fragments (user_agent, outbound_resource URLs).
+     */
+    private const FILTER_SEARCH_SUBSTRING_DIMENSIONS = [
+        'notes', 'searchterms', 'content_type', 'category', 'author', 'outbound_resource', 'user_agent',
+    ];
+
     protected static $data_for_column = [
         'url'   => [],
         'sql'   => [],
@@ -2090,6 +2100,36 @@ class wp_slimstat_admin
         // Get distinct non-empty values
         $column_type = wp_slimstat_db::$columns_names[$dimension][1];
 
+        // Optional server-side search (layer 2 of #298). Only applies to varchar
+        // columns — searching numeric dimensions falls back to the legacy DISTINCT.
+        $search_raw = $_POST['search'] ?? '';
+        $search = '';
+        if (is_string($search_raw)) {
+            $search = trim(sanitize_text_field($search_raw));
+            if (strlen($search) < 2 || strlen($search) > 64) {
+                $search = '';
+            }
+        }
+        if ($column_type !== 'varchar') {
+            $search = '';
+        }
+
+        // Cache lookup (layer 3 of #298). Key must account for anything that
+        // changes the result set: blog, DB host (External DB addon), capability
+        // gate, dimension, hour-bucketed time range, effective limit, and search.
+        $cache_key = self::build_filter_options_cache_key(
+            $dimension,
+            $time_start,
+            $time_end,
+            $search,
+            $limit
+        );
+        $cached = self::filter_options_cache_get($cache_key);
+        if (is_array($cached)) {
+            wp_send_json_success($cached);
+            exit();
+        }
+
         // Build SQL query directly to avoid Query class interference with global filters
         $where_clauses = [];
 
@@ -2106,6 +2146,15 @@ class wp_slimstat_admin
             // Exclude NULLs and zeros for numeric columns
             $where_clauses[] = $safe_dimension . ' IS NOT NULL';
             $where_clauses[] = $safe_dimension . ' <> 0';
+        }
+
+        // Append LIKE filter when a server-side search term was supplied.
+        if ($search !== '') {
+            $escaped = wp_slimstat::$wpdb->esc_like($search);
+            $like_pattern = in_array($dimension, self::FILTER_SEARCH_SUBSTRING_DIMENSIONS, true)
+                ? '%' . $escaped . '%'
+                : $escaped . '%';
+            $where_clauses[] = wp_slimstat::$wpdb->prepare($safe_dimension . ' LIKE %s', $like_pattern);
         }
 
         $where_sql = !empty($where_clauses) ? 'WHERE ' . implode(' AND ', $where_clauses) : '';
@@ -2166,6 +2215,19 @@ class wp_slimstat_admin
                 }
             }
             $results = $expanded;
+        }
+
+        // After splitting multi-value rows, re-filter split segments by the
+        // server-side search term so the caller gets only matching segments,
+        // not every segment from rows where any sibling matched.
+        if ($search !== '' && (isset($multi_value_separators[$dimension]) || $dimension === 'notes')) {
+            $has_mb       = function_exists('mb_strtolower');
+            $needle       = $has_mb ? mb_strtolower($search) : strtolower($search);
+            $is_substring = in_array($dimension, self::FILTER_SEARCH_SUBSTRING_DIMENSIONS, true);
+            $results = array_values(array_filter($results, function ($row) use ($needle, $is_substring, $has_mb) {
+                $haystack = $has_mb ? mb_strtolower($row['value']) : strtolower($row['value']);
+                return $is_substring ? (strpos($haystack, $needle) !== false) : (strpos($haystack, $needle) === 0);
+            }));
         }
 
         // Cap expanded results to prevent explosion from splitting
@@ -2231,8 +2293,83 @@ class wp_slimstat_admin
             }
         }
 
+        self::filter_options_cache_set(
+            $cache_key,
+            $options,
+            self::filter_options_cache_ttl($time_end)
+        );
+
         wp_send_json_success($options);
         exit();
+    }
+
+    /**
+     * Composite cache key for get_filter_options(). Must include every variable
+     * that changes the result set: blog (multisite), DB host (External DB addon
+     * can point to another DB), capability gate (per-role visibility), dimension,
+     * hour-bucketed time range (increases hit rate for rolling windows), the
+     * effective limit (respects third-party `slimstat_filter_options_limit`
+     * consumers), and the search term.
+     */
+    private static function build_filter_options_cache_key(
+        string $dimension,
+        ?int $time_start,
+        ?int $time_end,
+        string $search,
+        int $limit
+    ): string {
+        $blog_id = function_exists('get_current_blog_id') ? (int) get_current_blog_id() : 0;
+        $dbhost  = '';
+        if (isset(wp_slimstat::$wpdb) && is_object(wp_slimstat::$wpdb) && isset(wp_slimstat::$wpdb->dbhost)) {
+            $dbhost = (string) wp_slimstat::$wpdb->dbhost;
+        }
+        $dbhost_hash = substr(md5($dbhost), 0, 8);
+        $can_view        = (string) (wp_slimstat::$settings['can_view'] ?? '');
+        $capability      = (string) (wp_slimstat::$settings['capability_can_view'] ?? '');
+        $capability_hash = substr(md5($capability . '|' . $can_view), 0, 8);
+        $ts_start_bucket = $time_start ? (int) floor((int) $time_start / 3600) : 0;
+        $ts_end_bucket   = $time_end ? (int) floor((int) $time_end / 3600) : 0;
+        $search_hash     = $search === '' ? '' : substr(md5($search), 0, 8);
+        return sprintf(
+            'fopts_%d_%s_%s_%s_%d_%d_%d_%s',
+            $blog_id,
+            $dbhost_hash,
+            $capability_hash,
+            $dimension,
+            $ts_start_bucket,
+            $ts_end_bucket,
+            $limit,
+            $search_hash
+        );
+    }
+
+    private static function filter_options_cache_ttl(?int $time_end): int
+    {
+        // Historical data (range ends > 1h ago) never changes — cache it longer.
+        if ($time_end && (int) $time_end < (time() - 3600)) {
+            return 3600;
+        }
+        return 300;
+    }
+
+    private static function filter_options_cache_get(string $key)
+    {
+        if (function_exists('wp_using_ext_object_cache') && wp_using_ext_object_cache()) {
+            $found = false;
+            $data  = wp_cache_get($key, 'slimstat_filter_options', false, $found);
+            return $found ? $data : null;
+        }
+        $data = get_transient('slimstat_' . $key);
+        return $data === false ? null : $data;
+    }
+
+    private static function filter_options_cache_set(string $key, $data, int $ttl): void
+    {
+        if (function_exists('wp_using_ext_object_cache') && wp_using_ext_object_cache()) {
+            wp_cache_set($key, $data, 'slimstat_filter_options', $ttl);
+            return;
+        }
+        set_transient('slimstat_' . $key, $data, $ttl);
     }
 
     // END: get_filter_options

--- a/admin/index.php
+++ b/admin/index.php
@@ -972,7 +972,9 @@ class wp_slimstat_admin
             'clear_cache_nonce' => wp_create_nonce('slimstat_clear_cache'),
             // Shared with the filter form-builder so value-less operators (is_empty/
             // is_not_empty) are never treated as a "remove filter" signal. See #305.
-            'valueless_operators' => wp_slimstat_db::$valueless_operators,
+            // Guarded: this method also runs on the Dashboard-widget path, where
+            // wp_slimstat_db may not be included — fall back to the literal list.
+            'valueless_operators' => class_exists('wp_slimstat_db') ? wp_slimstat_db::$valueless_operators : ['is_empty', 'is_not_empty'],
         ];
         wp_localize_script('slimstat_admin', 'SlimStatAdminParams', $params);
     }

--- a/admin/view/wp-slimstat-db.php
+++ b/admin/view/wp-slimstat-db.php
@@ -11,6 +11,11 @@ class wp_slimstat_db
 
     public static $operator_names = [];
 
+    // Operators that take no value by design (is_empty/is_not_empty). Shared with
+    // parse_filters(), fs_url(), and the JS layer (via SlimStatAdminParams) so the
+    // list never drifts between callsites. See #305.
+    public static $valueless_operators = ['is_empty', 'is_not_empty'];
+
     public static $filters_normalized = [];
 
     // Structure that maps filters to SQL information (table names, clauses, lookup tables, etc)
@@ -616,9 +621,19 @@ class wp_slimstat_db
             $matches = explode('&&&', $_filters_raw);
 
             foreach ($matches as $a_match) {
-                preg_match('/([^\s]+)\s([^\s]+)\s(.+)?/', urldecode($a_match), $a_filter);
+                // Third group AND its leading separator are optional so value-less
+                // operators survive a URL round-trip (sanitize_text_field() trims the
+                // trailing space the form-builder appends). See #305.
+                preg_match('/([^\s]+)\s([^\s]+)(?:\s(.+))?/', urldecode($a_match), $a_filter);
 
                 if ([] === $a_filter || ((!array_key_exists($a_filter[1], self::$all_columns_names) || false !== strpos($a_filter[1], 'no_filter')) && false === strpos($a_filter[1], 'addon_'))) {
+                    continue;
+                }
+
+                // Preserve "malformed (no value) → drop" semantics for value-bearing
+                // operators now that the regex no longer requires a value. Value-less
+                // operators (is_empty/is_not_empty) are explicitly allowed through. See #305.
+                if (!isset($a_filter[3]) && !in_array($a_filter[2], self::$valueless_operators, true)) {
                     continue;
                 }
 
@@ -697,10 +712,15 @@ class wp_slimstat_db
                         // no break here: if value IS numeric, go to the default parser here below
 
                     default:
+                        $filter_op    = $a_filter[2];
                         $filter_value = isset($a_filter[3]) ? str_replace('\\', '', htmlspecialchars_decode($a_filter[3])) : '';
-                        // Only add filter if value is not empty (ignore filters without values)
-                        if (trim($filter_value) !== '') {
-                            $filters_parsed['columns'][$a_filter[1]] = [$a_filter[2], $filter_value];
+                        if (in_array($filter_op, self::$valueless_operators, true)) {
+                            // Value-less by design — store an empty value, scrubbing any stale
+                            // UI value the SQL builder would ignore anyway. See #305.
+                            $filters_parsed['columns'][$a_filter[1]] = [$filter_op, ''];
+                        } elseif (trim($filter_value) !== '') {
+                            // Ignore value-bearing filters submitted without a value.
+                            $filters_parsed['columns'][$a_filter[1]] = [$filter_op, $filter_value];
                         }
                         break;
                 }

--- a/admin/view/wp-slimstat-db.php
+++ b/admin/view/wp-slimstat-db.php
@@ -16,6 +16,15 @@ class wp_slimstat_db
     // list never drifts between callsites. See #305.
     public static $valueless_operators = ['is_empty', 'is_not_empty'];
 
+    // parse_filters() switch keys that map to the date/misc buckets rather than a data
+    // column. A value-less operator (is_empty/is_not_empty) is meaningless for these and
+    // must not reach the switch without a value — those branches dereference $a_filter[3]
+    // and would emit an "Undefined array key 3" warning on a crafted request. See #305.
+    private const NON_COLUMN_FILTER_KEYS = [
+        'strtotime', 'minute', 'hour', 'day', 'month', 'year',
+        'interval', 'interval_hours', 'interval_minutes', 'limit_results', 'start_from',
+    ];
+
     public static $filters_normalized = [];
 
     // Structure that maps filters to SQL information (table names, clauses, lookup tables, etc)
@@ -632,8 +641,13 @@ class wp_slimstat_db
 
                 // Preserve "malformed (no value) → drop" semantics for value-bearing
                 // operators now that the regex no longer requires a value. Value-less
-                // operators (is_empty/is_not_empty) are explicitly allowed through. See #305.
-                if (!isset($a_filter[3]) && !in_array($a_filter[2], self::$valueless_operators, true)) {
+                // operators (is_empty/is_not_empty) are explicitly allowed through — but
+                // only for real data columns: a value-less op aimed at a date/misc switch
+                // key (strtotime, minute, …) would dereference the absent $a_filter[3]
+                // below, so drop it here too. See #305.
+                if (!isset($a_filter[3])
+                    && (!in_array($a_filter[2], self::$valueless_operators, true)
+                        || in_array($a_filter[1], self::NON_COLUMN_FILTER_KEYS, true))) {
                     continue;
                 }
 

--- a/admin/view/wp-slimstat-reports.php
+++ b/admin/view/wp-slimstat-reports.php
@@ -1941,7 +1941,7 @@ class wp_slimstat_reports
                     continue;
                 }
 
-                $a_filter_value_no_slashes = ('is_empty' == $a_filter_details[0] || 'is_not_empty' == $a_filter_details[0]) ? '' : htmlentities(str_replace('\\', '', $a_filter_details[1]), ENT_QUOTES, 'UTF-8');
+                $a_filter_value_no_slashes = in_array($a_filter_details[0], wp_slimstat_db::$valueless_operators, true) ? '' : htmlentities(str_replace('\\', '', $a_filter_details[1]), ENT_QUOTES, 'UTF-8');
                 $filters_html .= '<li>' . strtolower(wp_slimstat_db::$columns_names[$a_filter_label][0]) . ' ' . __(str_replace('_', ' ', $a_filter_details[0]), 'wp-slimstat') . sprintf(" %s <a class='slimstat-filter-link slimstat-font-cancel' title='", $a_filter_value_no_slashes) . htmlentities(__('Remove filter for', 'wp-slimstat'), ENT_QUOTES, 'UTF-8') . ' ' . wp_slimstat_db::$columns_names[$a_filter_label][0] . "' href='" . self::fs_url($a_filter_label . ' equals ') . "'></a></li>";
             }
         }
@@ -1982,8 +1982,13 @@ class wp_slimstat_reports
         if (!empty($_filters_string)) {
             $matches = explode('&&&', $_filters_string);
             foreach ($matches as $a_match) {
-                preg_match('/([^\s]+)\s([^\s]+)\s(.+)?/', urldecode($a_match), $a_filter);
-                if (!empty($a_filter[1]) && (!isset($a_filter[3]) || trim($a_filter[3]) === '')) {
+                // Keep this regex aligned with wp_slimstat_db::parse_filters() (#305).
+                preg_match('/([^\s]+)\s([^\s]+)(?:\s(.+))?/', urldecode($a_match), $a_filter);
+                // "operator present, value absent" is a removal signal — EXCEPT for
+                // value-less operators (is_empty/is_not_empty), which are real filters. See #305.
+                if (!empty($a_filter[1])
+                    && (!isset($a_filter[3]) || trim($a_filter[3]) === '')
+                    && !in_array($a_filter[2] ?? '', wp_slimstat_db::$valueless_operators, true)) {
                     $filters_to_remove[$a_filter[1]] = $a_filter[2];
                 }
             }

--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
     "test:dnt-gdpr": "php tests/dnt-gdpr-independence-test.php",
     "test:browscap-bot-safety": "php tests/browscap-bot-safety-net-test.php",
     "test:storage-update-sanitize": "php tests/storage-update-sanitization-test.php",
+    "test:referer-android-app": "php tests/referer-android-app-storage-test.php",
     "test:php74-compat": "php tests/php74-no-php80-functions-test.php",
     "test:implicit-nullable": "php tests/php-implicit-nullable-test.php",
     "test:ci-matrix-coverage": "php tests/ci-matrix-coverage-test.php",
@@ -111,7 +112,8 @@
       "@test:browscap-filesystem",
       "@test:dnt-gdpr",
       "@test:browscap-bot-safety",
-      "@test:storage-update-sanitize"
+      "@test:storage-update-sanitize",
+      "@test:referer-android-app"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
     "test:browscap-bot-safety": "php tests/browscap-bot-safety-net-test.php",
     "test:storage-update-sanitize": "php tests/storage-update-sanitization-test.php",
     "test:referer-android-app": "php tests/referer-android-app-storage-test.php",
+    "test:referer-searchterms-encoding": "php tests/referer-searchterms-encoding-test.php",
     "test:php74-compat": "php tests/php74-no-php80-functions-test.php",
     "test:implicit-nullable": "php tests/php-implicit-nullable-test.php",
     "test:ci-matrix-coverage": "php tests/ci-matrix-coverage-test.php",
@@ -113,7 +114,8 @@
       "@test:dnt-gdpr",
       "@test:browscap-bot-safety",
       "@test:storage-update-sanitize",
-      "@test:referer-android-app"
+      "@test:referer-android-app",
+      "@test:referer-searchterms-encoding"
     ]
   }
 }

--- a/src/Tracker/Ajax.php
+++ b/src/Tracker/Ajax.php
@@ -60,9 +60,21 @@ class Ajax
         }
 
         // Security: Validate host (if present) - allow external domains for referer,
-        // but validate the host format to prevent injection.
-        if (!empty($parsed_ref['host']) && !preg_match('/^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$/', $parsed_ref['host'])) {
-            return false;
+        // but validate the host format to prevent injection. Accept either a DNS
+        // hostname or a bracketed IPv6 literal (parse_url keeps the brackets, e.g.
+        // "[2001:db8::1]"); otherwise a valid IPv6 referer would fail the check and
+        // drop the entire hit. filter_var validates the IPv6 structure (same
+        // FILTER_FLAG_IPV6 pattern Utils uses) and runs only when the host is not a
+        // plain hostname.
+        if (!empty($parsed_ref['host'])) {
+            $host        = $parsed_ref['host'];
+            $is_hostname = (bool) preg_match('/^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$/', $host);
+            $is_ipv6     = !$is_hostname
+                && $host[0] === '[' && substr($host, -1) === ']'
+                && false !== filter_var(substr($host, 1, -1), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);
+            if (!$is_hostname && !$is_ipv6) {
+                return false;
+            }
         }
 
         // Security: Limit referer length to prevent DoS

--- a/src/Tracker/Ajax.php
+++ b/src/Tracker/Ajax.php
@@ -30,6 +30,46 @@ class Ajax
     }
 
     /**
+     * Validate and sanitize a base64url-encoded referer from the JS tracker payload.
+     *
+     * @internal Extracted from handle() (#306) to provide a unit-testable seam.
+     *
+     * Uses sanitize_text_field rather than sanitize_url so app-scheme referers such as
+     * `android-app://com.google.android.googlequicksearchbox/` (Google Discover) survive:
+     * sanitize_url strips any scheme absent from wp_allowed_protocols(), emptying the value.
+     * The host-format check below and the scheme allowlist in Processor::process() (which
+     * permits http/https/android-app and drops everything else as an XSS attempt) remain the
+     * security boundary.
+     *
+     * @param mixed $rawEncoded Raw base64url ref value from the client payload.
+     * @return string|false Sanitized referer (possibly empty), or false when the referer is
+     *                      malformed and the whole request must be rejected.
+     */
+    public static function sanitizeReferer($rawEncoded)
+    {
+        $referer    = Utils::base64UrlDecode($rawEncoded);
+        $parsed_ref = parse_url($referer ?: '');
+
+        // Security: Validate referer format
+        if (false === $parsed_ref) {
+            return false;
+        }
+
+        // Security: Validate host (if present) - allow external domains for referer,
+        // but validate the host format to prevent injection.
+        if (!empty($parsed_ref['host']) && !preg_match('/^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$/', $parsed_ref['host'])) {
+            return false;
+        }
+
+        // Security: Limit referer length to prevent DoS
+        if (strlen($referer) > 2048) {
+            $referer = substr($referer, 0, 2048);
+        }
+
+        return sanitize_text_field($referer);
+    }
+
+    /**
      * Handle AJAX tracking request with exit (for admin-ajax.php).
      * This wrapper calls process() and exits with the result.
      */
@@ -102,31 +142,12 @@ class Ajax
         // Security: Validate and sanitize referer URL
         $stat['referer'] = '';
         if (!empty($data_js['ref'])) {
-            $referer = Utils::base64UrlDecode($data_js['ref']);
-            $parsed_ref = parse_url($referer ?: '');
-
-            // Security: Validate referer format
-            if (false === $parsed_ref) {
+            $referer = self::sanitizeReferer($data_js['ref']);
+            if (false === $referer) {
                 // Invalid referer format - reject request
                 return Utils::logError(201);
             }
-
-            // Security: Validate host (if present) - allow external domains for referer
-            // Referer can be from external sites, but we should validate the format
-            if (!empty($parsed_ref['host'])) {
-                // Validate host format (prevent injection)
-                if (!preg_match('/^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$/', $parsed_ref['host'])) {
-                    // Invalid host format - reject request
-                    return Utils::logError(201);
-                }
-            }
-
-            // Security: Limit referer length to prevent DoS
-            if (strlen($referer) > 2048) {
-                $referer = substr($referer, 0, 2048);
-            }
-
-            $stat['referer'] = sanitize_url($referer);
+            $stat['referer'] = $referer;
         }
 
         // Update stat after referer processing

--- a/src/Tracker/Ajax.php
+++ b/src/Tracker/Ajax.php
@@ -34,12 +34,16 @@ class Ajax
      *
      * @internal Extracted from handle() (#306) to provide a unit-testable seam.
      *
-     * Uses sanitize_text_field rather than sanitize_url so app-scheme referers such as
-     * `android-app://com.google.android.googlequicksearchbox/` (Google Discover) survive:
-     * sanitize_url strips any scheme absent from wp_allowed_protocols(), emptying the value.
-     * The host-format check below and the scheme allowlist in Processor::process() (which
-     * permits http/https/android-app and drops everything else as an XSS attempt) remain the
-     * security boundary.
+     * Uses sanitize_url() with `android-app` added to the allow-list
+     * (Processor::REFERER_ALLOWED_SCHEMES) rather than the default wp_allowed_protocols():
+     *   - app-scheme referers such as `android-app://com.google.android.googlequicksearchbox/`
+     *     (Google Discover) survive — the original #306 bug was the default list emptying them;
+     *   - disallowed schemes (javascript:, data:) are emptied here, at the boundary, so they can
+     *     never reach storage even on the follow-up-event path that skips Processor::process();
+     *   - unlike sanitize_text_field, percent-encoded query octets (%XX) are preserved, so
+     *     getSearchTerms() can still decode non-Latin / spaced search terms downstream.
+     * The host-format check below and the post-storage scheme check in Processor::process()
+     * remain as defense in depth.
      *
      * @param mixed $rawEncoded Raw base64url ref value from the client payload.
      * @return string|false Sanitized referer (possibly empty), or false when the referer is
@@ -66,7 +70,7 @@ class Ajax
             $referer = substr($referer, 0, 2048);
         }
 
-        return sanitize_text_field($referer);
+        return sanitize_url($referer, Processor::REFERER_ALLOWED_SCHEMES);
     }
 
     /**

--- a/src/Tracker/Processor.php
+++ b/src/Tracker/Processor.php
@@ -12,6 +12,15 @@ use SlimStat\Utils\Consent;
 class Processor
 {
     /**
+     * Schemes accepted for the stored referer. Anything else is treated as an XSS
+     * attempt and dropped. Used both as the protocols allow-list for sanitize_url()
+     * at ingestion (Ajax::sanitizeReferer + the HTTP_REFERER fallback below) and by
+     * the post-storage scheme check in process(), so the list never drifts. `android-app`
+     * is included so Google Discover / Android-app referers survive. See #306.
+     */
+    public const REFERER_ALLOWED_SCHEMES = ['http', 'https', 'android-app'];
+
+    /**
      * Check if the current WordPress user should be excluded from tracking.
      *
      * Uses wp_get_current_user() defensively to ensure the user object is fully
@@ -185,10 +194,12 @@ class Processor
         }
 
         if (empty($stat['referer']) && !empty($_SERVER['HTTP_REFERER'])) {
-            // sanitize_text_field (not sanitize_url) so app-scheme referers like
-            // android-app://com.google.android.googlequicksearchbox/ (Google Discover) survive;
-            // the scheme allowlist below drops anything outside http/https/android-app as XSS. See #306.
-            $stat['referer'] = sanitize_text_field(wp_unslash($_SERVER['HTTP_REFERER']));
+            // sanitize_url() with android-app added to the allow-list: app-scheme referers
+            // (android-app://com.google.android.googlequicksearchbox/, Google Discover) survive,
+            // disallowed schemes (javascript:, data:) are emptied at the boundary, and — unlike
+            // sanitize_text_field — percent-encoded query octets are preserved so getSearchTerms()
+            // below can still decode non-Latin / spaced search terms. See #306.
+            $stat['referer'] = sanitize_url(wp_unslash($_SERVER['HTTP_REFERER']), self::REFERER_ALLOWED_SCHEMES);
         }
 
 
@@ -199,7 +210,7 @@ class Processor
                 return Utils::logError(201);
             }
 
-            if (isset($parsed_url['scheme']) && ('' !== $parsed_url['scheme'] && '0' !== $parsed_url['scheme']) && !in_array(strtolower($parsed_url['scheme']), ['http', 'https', 'android-app'])) {
+            if (isset($parsed_url['scheme']) && ('' !== $parsed_url['scheme'] && '0' !== $parsed_url['scheme']) && !in_array(strtolower($parsed_url['scheme']), self::REFERER_ALLOWED_SCHEMES)) {
                 $stat['notes'][] = sprintf(__('Attempted XSS Injection: %s', 'wp-slimstat'), $stat['referer']);
                 unset($stat['referer']);
             }

--- a/src/Tracker/Processor.php
+++ b/src/Tracker/Processor.php
@@ -185,7 +185,10 @@ class Processor
         }
 
         if (empty($stat['referer']) && !empty($_SERVER['HTTP_REFERER'])) {
-            $stat['referer'] = sanitize_url(wp_unslash($_SERVER['HTTP_REFERER']));
+            // sanitize_text_field (not sanitize_url) so app-scheme referers like
+            // android-app://com.google.android.googlequicksearchbox/ (Google Discover) survive;
+            // the scheme allowlist below drops anything outside http/https/android-app as XSS. See #306.
+            $stat['referer'] = sanitize_text_field(wp_unslash($_SERVER['HTTP_REFERER']));
         }
 
 

--- a/tests/Unit/FilterOptionsSearchTest.php
+++ b/tests/Unit/FilterOptionsSearchTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Portable unit tests for the #298 server-side filter search/cache pure logic in
+ * wp_slimstat_admin::get_filter_options() — extracted into private static helpers
+ * so the SQL/cache behavior is guarded by a deterministic CI gate (composer
+ * test:unit) instead of only the live-DB Playwright spec.
+ *
+ * Covers:
+ *  - filter_search_is_substring(): the %needle% vs needle% anchor decision;
+ *  - build_filter_search_like(): esc_like escaping + correct anchoring;
+ *  - build_filter_options_cache_key(): every result-set-affecting input changes
+ *    the key, identical inputs collide, and the time range is hour-bucketed;
+ *  - filter_options_cache_ttl(): historical ranges cache longer than live ones.
+ *
+ * @package WpSlimstat
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace WpSlimstat\Tests\Unit;
+
+use Mockery;
+
+class FilterOptionsSearchTest extends WpSlimstatTestCase
+{
+    /** @var array<string,mixed> snapshot of wp_slimstat::$settings to restore */
+    private $settingsBackup;
+    /** @var object|null snapshot of wp_slimstat::$wpdb to restore */
+    private $wpdbBackup;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!class_exists('wp_slimstat_admin', false)) {
+            require_once dirname(__DIR__, 2) . '/admin/index.php';
+        }
+
+        $this->settingsBackup = \wp_slimstat::$settings;
+        $this->wpdbBackup      = \wp_slimstat::$wpdb;
+
+        // esc_like models WP wpdb::esc_like(): backslash-escape _ % and \.
+        $wpdb = Mockery::mock('wpdb');
+        $wpdb->shouldReceive('esc_like')->andReturnUsing(
+            static fn(string $text): string => addcslashes($text, '_%\\')
+        );
+        $wpdb->dbhost = 'localhost';
+        \wp_slimstat::$wpdb = $wpdb;
+    }
+
+    protected function tearDown(): void
+    {
+        \wp_slimstat::$settings = $this->settingsBackup;
+        \wp_slimstat::$wpdb      = $this->wpdbBackup;
+        parent::tearDown();
+    }
+
+    /** Invoke a private static method of wp_slimstat_admin via reflection. */
+    private static function call(string $method, ...$args)
+    {
+        $m = new \ReflectionMethod(\wp_slimstat_admin::class, $method);
+        $m->setAccessible(true);
+        return $m->invoke(null, ...$args);
+    }
+
+    // ── Anchor decision: substring (%needle%) vs prefix (needle%) ─────
+
+    /** @test */
+    public function test_substring_dimensions_use_unanchored_like(): void
+    {
+        foreach (['notes', 'searchterms', 'content_type', 'category', 'author', 'outbound_resource', 'user_agent'] as $dim) {
+            $this->assertTrue(self::call('filter_search_is_substring', $dim), "$dim should use %needle% substring search");
+        }
+    }
+
+    /** @test */
+    public function test_other_dimensions_use_left_anchored_prefix(): void
+    {
+        foreach (['ip', 'browser', 'resource', 'referer', 'country'] as $dim) {
+            $this->assertFalse(self::call('filter_search_is_substring', $dim), "$dim should use left-anchored prefix search");
+        }
+    }
+
+    // ── LIKE pattern: esc_like + anchoring ───────────────────────────
+
+    /** @test */
+    public function test_prefix_like_pattern_escapes_metacharacters(): void
+    {
+        // ip is a prefix dimension; % and _ in the term must be escaped literally.
+        $this->assertSame('a\%b\_c%', self::call('build_filter_search_like', 'ip', 'a%b_c'));
+    }
+
+    /** @test */
+    public function test_substring_like_pattern_wraps_and_escapes(): void
+    {
+        $this->assertSame('%Mozilla\_5%', self::call('build_filter_search_like', 'user_agent', 'Mozilla_5'));
+    }
+
+    // ── Cache key composition ────────────────────────────────────────
+
+    /** @test */
+    public function test_cache_key_is_stable_for_identical_inputs(): void
+    {
+        $a = self::call('build_filter_options_cache_key', 'ip', 1000, 2000, 'foo', 500);
+        $b = self::call('build_filter_options_cache_key', 'ip', 1000, 2000, 'foo', 500);
+        $this->assertSame($a, $b);
+        $this->assertStringStartsWith('fopts_', $a);
+    }
+
+    /**
+     * @test
+     * @dataProvider cacheKeyDifferentiatorProvider
+     */
+    public function test_cache_key_differs_when_an_input_changes(array $args): void
+    {
+        $base = self::call('build_filter_options_cache_key', 'ip', 1000, 2000, 'foo', 500);
+        $this->assertNotSame($base, self::call('build_filter_options_cache_key', ...$args));
+    }
+
+    public static function cacheKeyDifferentiatorProvider(): array
+    {
+        return [
+            'dimension' => [['referer', 1000, 2000, 'foo', 500]],
+            'search'    => [['ip', 1000, 2000, 'bar', 500]],
+            'limit'     => [['ip', 1000, 2000, 'foo', 1000]],
+            // 9000 lands in a different hour bucket than 2000 (3600s buckets).
+            'time_end_hour' => [['ip', 1000, 9000, 'foo', 500]],
+        ];
+    }
+
+    /** @test */
+    public function test_cache_key_buckets_time_range_by_hour(): void
+    {
+        // Two end timestamps within the same hour bucket collide; the search is the
+        // same so the result set is identical — caching them together is correct.
+        $within = self::call('build_filter_options_cache_key', 'ip', 0, 100, 'foo', 500);
+        $sameHr = self::call('build_filter_options_cache_key', 'ip', 0, 3599, 'foo', 500);
+        $this->assertSame($within, $sameHr);
+    }
+
+    /** @test */
+    public function test_cache_key_reflects_capability_gate(): void
+    {
+        \wp_slimstat::$settings['can_view'] = 'alice';
+        $a = self::call('build_filter_options_cache_key', 'ip', 1000, 2000, 'foo', 500);
+        \wp_slimstat::$settings['can_view'] = 'bob';
+        $b = self::call('build_filter_options_cache_key', 'ip', 1000, 2000, 'foo', 500);
+        $this->assertNotSame($a, $b, 'different visibility gate must not share a cache entry');
+    }
+
+    // ── TTL bucketing: historical vs live ────────────────────────────
+
+    /** @test */
+    public function test_ttl_is_longer_for_historical_ranges(): void
+    {
+        $this->assertSame(3600, self::call('filter_options_cache_ttl', time() - 7200));
+    }
+
+    /** @test */
+    public function test_ttl_is_short_for_live_ranges(): void
+    {
+        $this->assertSame(300, self::call('filter_options_cache_ttl', time()));
+    }
+
+    /** @test */
+    public function test_ttl_defaults_short_when_range_is_open_ended(): void
+    {
+        $this->assertSame(300, self::call('filter_options_cache_ttl', null));
+    }
+}

--- a/tests/Unit/ParseFiltersTest.php
+++ b/tests/Unit/ParseFiltersTest.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Regression tests for #305 — is_empty / is_not_empty (value-less) filter
+ * operators were silently dropped by parse_filters() since v5.4.0 (commit
+ * 62f0434b), so the filter chip rendered but no WHERE clause reached SQL.
+ *
+ * Covers the parse-side guard + regex relaxation + parse→SQL round-trip, and
+ * pins the original "drop incomplete value-bearing filters" intent so it is
+ * preserved.
+ *
+ * @package WpSlimstat
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace WpSlimstat\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use Mockery;
+
+class ParseFiltersTest extends WpSlimstatTestCase
+{
+    /** @var \Mockery\MockInterface&\stdClass */
+    private $wpdb;
+
+    /** Columns referenced by the tests: a varchar (email) and an int (visit_id). */
+    private static array $testColumns = [
+        'email'    => ['Email', 'varchar'],
+        'browser'  => ['Browser', 'varchar'],
+        'visit_id' => ['Visit ID', 'int'],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Functions\stubs([
+            '__'                  => static fn(string $text): string => $text,
+            'apply_filters'       => static fn(string $tag, $value) => $value,
+            'sanitize_key'        => static fn($v) => $v,
+            'sanitize_text_field' => static fn($v) => $v,
+            'absint'              => static fn($v) => abs((int) $v),
+        ]);
+
+        $this->wpdb = Mockery::mock('wpdb');
+        $this->wpdb->prefix = 'wp_';
+        $this->wpdb->shouldReceive('prepare')->andReturnUsing(
+            static function (string $query, ...$args): string {
+                $flat = [];
+                foreach ($args as $arg) {
+                    foreach (is_array($arg) ? $arg : [$arg] as $v) {
+                        $flat[] = $v;
+                    }
+                }
+                $i = 0;
+                return preg_replace_callback('/%[sd]/', static function ($m) use ($flat, &$i) {
+                    $val = $flat[$i] ?? '';
+                    $i++;
+                    return $m[0] === '%d' ? (string) intval($val) : "'" . addslashes((string) $val) . "'";
+                }, $query);
+            }
+        );
+        $GLOBALS['wpdb'] = $this->wpdb;
+
+        $dbFile = dirname(__DIR__, 2) . '/admin/view/wp-slimstat-db.php';
+        if (!class_exists('wp_slimstat_db', false)) {
+            require_once $dbFile;
+        }
+
+        $ref = new \ReflectionClass(\wp_slimstat_db::class);
+        $ref->getProperty('columns_names')->setValue(null, self::$testColumns);
+        // all_columns_names must include 'minute' so the value-bearing malformed-date
+        // case reaches the pre-switch guard (modification 3) rather than the earlier
+        // column-existence guard.
+        $ref->getProperty('all_columns_names')->setValue(null, array_merge(self::$testColumns, [
+            'minute' => ['Minute', 'int'],
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        $ref = new \ReflectionClass(\wp_slimstat_db::class);
+        $ref->getProperty('filters_normalized')->setValue(null, []);
+        $ref->getProperty('sql_where')->setValue(null, ['columns' => '', 'time_range' => '']);
+        $ref->getProperty('columns_names')->setValue(null, []);
+        $ref->getProperty('all_columns_names')->setValue(null, []);
+        parent::tearDown();
+    }
+
+    /** Invoke the protected _get_sql_where() via Reflection. */
+    private static function sqlWhere(array $columns): string
+    {
+        $m = new \ReflectionMethod(\wp_slimstat_db::class, '_get_sql_where');
+        $m->setAccessible(true);
+        return $m->invoke(null, $columns, '');
+    }
+
+    // ── Group 1: value-less operator survives the guard ──────────────
+
+    /** @test */
+    public function test_email_is_not_empty_with_trailing_space_stores_empty_value(): void
+    {
+        $fn = \wp_slimstat_db::parse_filters('email is_not_empty ');
+        $this->assertArrayHasKey('email', $fn['columns']);
+        $this->assertSame(['is_not_empty', ''], $fn['columns']['email']);
+    }
+
+    /** @test */
+    public function test_email_is_empty_with_trailing_space_stores_empty_value(): void
+    {
+        $fn = \wp_slimstat_db::parse_filters('email is_empty ');
+        $this->assertSame(['is_empty', ''], $fn['columns']['email']);
+    }
+
+    /** @test */
+    public function test_visit_id_is_not_empty_stores_empty_value(): void
+    {
+        $fn = \wp_slimstat_db::parse_filters('visit_id is_not_empty ');
+        $this->assertSame(['is_not_empty', ''], $fn['columns']['visit_id']);
+    }
+
+    // ── Group 2: regex relaxation (post-sanitize_text_field shape) ───
+
+    /** @test */
+    public function test_email_is_not_empty_without_trailing_space_still_parses(): void
+    {
+        // sanitize_text_field() trims the trailing space on fs[] URL round-trips.
+        $fn = \wp_slimstat_db::parse_filters('email is_not_empty');
+        $this->assertSame(['is_not_empty', ''], $fn['columns']['email']);
+    }
+
+    /** @test */
+    public function test_email_is_empty_without_trailing_space_still_parses(): void
+    {
+        $fn = \wp_slimstat_db::parse_filters('email is_empty');
+        $this->assertSame(['is_empty', ''], $fn['columns']['email']);
+    }
+
+    // ── Group 3: stale-value defense ─────────────────────────────────
+
+    /** @test */
+    public function test_is_not_empty_with_stale_value_scrubs_value(): void
+    {
+        $fn = \wp_slimstat_db::parse_filters('email is_not_empty stale_garbage_from_ui');
+        $this->assertSame(['is_not_empty', ''], $fn['columns']['email'], 'stale UI value must not propagate');
+    }
+
+    // ── Group 4: legitimate-drop guard (preserve 62f0434b intent) ────
+
+    /** @test */
+    public function test_drops_value_bearing_operator_with_empty_value(): void
+    {
+        $fn = \wp_slimstat_db::parse_filters('email contains ');
+        $this->assertArrayNotHasKey('email', $fn['columns']);
+    }
+
+    /** @test */
+    public function test_drops_malformed_date_filter_without_value(): void
+    {
+        // 'minute equals' (value-bearing operator, no value) must be dropped by the
+        // pre-switch guard before reaching the date-special-case branch.
+        $fn = \wp_slimstat_db::parse_filters('minute equals');
+        $this->assertArrayNotHasKey('minute', $fn['date']);
+    }
+
+    // ── Group 5: parse → SQL round-trip ──────────────────────────────
+
+    /** @test */
+    public function test_round_trip_email_is_not_empty_produces_is_not_null_sql(): void
+    {
+        $fn  = \wp_slimstat_db::parse_filters('email is_not_empty ');
+        $sql = self::sqlWhere($fn['columns']);
+        $this->assertStringContainsString('email', $sql);
+        $this->assertStringContainsString('IS NOT NULL', $sql);
+    }
+
+    /** @test */
+    public function test_round_trip_visit_id_is_empty_produces_zero_sql(): void
+    {
+        $fn  = \wp_slimstat_db::parse_filters('visit_id is_empty ');
+        $sql = self::sqlWhere($fn['columns']);
+        $this->assertStringContainsString('visit_id', $sql);
+        $this->assertStringContainsString('= 0', $sql);
+    }
+
+    // ── Group 6: differentiate value-less op from removal signal ─────
+
+    /** @test */
+    public function test_value_bearing_filter_still_parses_normally(): void
+    {
+        $fn = \wp_slimstat_db::parse_filters('email contains acme');
+        $this->assertSame(['contains', 'acme'], $fn['columns']['email']);
+    }
+
+    /** @test */
+    public function test_round_trip_value_less_and_value_bearing_coexist(): void
+    {
+        $fn = \wp_slimstat_db::parse_filters('email is_not_empty &&&browser contains Chrome');
+        $this->assertSame(['is_not_empty', ''], $fn['columns']['email']);
+        $this->assertSame(['contains', 'Chrome'], $fn['columns']['browser']);
+    }
+}

--- a/tests/Unit/ParseFiltersTest.php
+++ b/tests/Unit/ParseFiltersTest.php
@@ -200,4 +200,36 @@ class ParseFiltersTest extends WpSlimstatTestCase
         $this->assertSame(['is_not_empty', ''], $fn['columns']['email']);
         $this->assertSame(['contains', 'Chrome'], $fn['columns']['browser']);
     }
+
+    // ── Group 7: value-less op on a date/special key must not warn ───
+    // Regression guard for the relaxed-regex side effect: a crafted value-less
+    // operator aimed at a date switch key (e.g. fs[minute]=is_empty) used to fall
+    // into `case 'minute':` and dereference the absent $a_filter[3], emitting an
+    // "Undefined array key 3" warning. PHPUnit converts that warning to a failure,
+    // so simply not warning IS the assertion; we also assert the filter is dropped.
+
+    /** @test */
+    public function test_value_less_op_on_date_column_is_dropped_without_warning(): void
+    {
+        $fn = \wp_slimstat_db::parse_filters('minute is_empty');
+        $this->assertArrayNotHasKey('minute', $fn['date'], 'value-less op on a date key must not create a date entry');
+        $this->assertArrayNotHasKey('minute', $fn['columns'], 'value-less op on a date key must not create a column entry');
+    }
+
+    /** @test */
+    public function test_value_less_op_on_date_column_with_trailing_space_is_dropped(): void
+    {
+        $fn = \wp_slimstat_db::parse_filters('minute is_not_empty ');
+        $this->assertArrayNotHasKey('minute', $fn['date']);
+        $this->assertArrayNotHasKey('minute', $fn['columns']);
+    }
+
+    /** @test */
+    public function test_value_bearing_date_filter_still_parses_after_regex_relaxation(): void
+    {
+        // The relaxed regex must keep parsing value-bearing date filters; pins the
+        // multi-value-capable third group for the date branch.
+        $fn = \wp_slimstat_db::parse_filters('minute equals 30');
+        $this->assertSame(30, $fn['date']['minute']);
+    }
 }

--- a/tests/Unit/Tracker/AjaxRefererSanitizationTest.php
+++ b/tests/Unit/Tracker/AjaxRefererSanitizationTest.php
@@ -111,6 +111,20 @@ class AjaxRefererSanitizationTest extends WpSlimstatTestCase
         ];
     }
 
+    /**
+     * #315 review: a bracketed IPv6-literal host (parse_url keeps the brackets) must
+     * be accepted, not rejected — rejection returns false and drops the whole hit.
+     *
+     * @test
+     */
+    public function test_accepts_bracketed_ipv6_host(): void
+    {
+        $this->stubSanitizeUrl();
+
+        $url = 'https://[2001:db8::1]/page?q=1';
+        $this->assertSame($url, \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url)));
+    }
+
     /** @test */
     public function test_rejects_invalid_host(): void
     {

--- a/tests/Unit/Tracker/AjaxRefererSanitizationTest.php
+++ b/tests/Unit/Tracker/AjaxRefererSanitizationTest.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSlimstat\Tests\Unit\Tracker;
+
+use Brain\Monkey\Functions;
+use WpSlimstat\Tests\Unit\WpSlimstatTestCase;
+
+/**
+ * Regression tests for #306 — android-app:// (Google Discover) referers were
+ * silently dropped because Ajax::handle() ran the referer through sanitize_url(),
+ * which strips any scheme not in wp_allowed_protocols().
+ *
+ * Ajax::sanitizeReferer() is the seam extracted from handle() lines 102-130. It
+ * now uses sanitize_text_field(), preserving app-scheme referers while the host
+ * regex and the Processor scheme allowlist remain the security boundary.
+ */
+class AjaxRefererSanitizationTest extends WpSlimstatTestCase
+{
+    /** base64url-encode using the same scheme as Tracker::_base64_url_encode(). */
+    private static function encode(string $url): string
+    {
+        return strtr(base64_encode($url), '+/=', '._-');
+    }
+
+    /** @test */
+    public function test_preserves_android_app_referer(): void
+    {
+        // sanitize_text_field must be used (passthrough for a clean string);
+        // sanitize_url must never be called for the referer.
+        Functions\expect('sanitize_text_field')->once()->andReturnUsing(static fn($v) => $v);
+        Functions\expect('sanitize_url')->never();
+
+        $url    = 'android-app://com.google.android.googlequicksearchbox/';
+        $result = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url));
+
+        $this->assertSame($url, $result);
+    }
+
+    /** @test */
+    public function test_preserves_ios_app_referer(): void
+    {
+        Functions\expect('sanitize_text_field')->once()->andReturnUsing(static fn($v) => $v);
+        Functions\expect('sanitize_url')->never();
+
+        $url    = 'ios-app://com.google.ios.app/';
+        $result = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url));
+
+        $this->assertSame($url, $result);
+    }
+
+    /** @test */
+    public function test_preserves_http_referer_baseline(): void
+    {
+        Functions\expect('sanitize_text_field')->once()->andReturnUsing(static fn($v) => $v);
+        Functions\expect('sanitize_url')->never();
+
+        $url    = 'https://example.com/page?q=1';
+        $result = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url));
+
+        $this->assertSame($url, $result);
+    }
+
+    /** @test */
+    public function test_strips_script_tags_from_referer(): void
+    {
+        // Tags are stripped by base64UrlDecode (strip_tags) before sanitize_text_field;
+        // here we additionally model sanitize_text_field stripping any residual markup.
+        Functions\expect('sanitize_text_field')->once()->andReturnUsing(
+            static fn($v) => trim(preg_replace('/<[^>]*>/', '', (string) $v))
+        );
+
+        $payload = 'android-app://attacker/<script>alert(1)</script>';
+        $result  = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($payload));
+
+        $this->assertIsString($result);
+        $this->assertStringNotContainsString('<script>', $result);
+        $this->assertStringStartsWith('android-app://attacker/', $result);
+    }
+
+    /** @test */
+    public function test_rejects_invalid_host(): void
+    {
+        // sanitize_text_field must never be reached when the host fails validation.
+        Functions\expect('sanitize_text_field')->never();
+
+        // Underscores are not valid in the host-format regex.
+        $result = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode('http://bad_host!!/path'));
+
+        $this->assertFalse($result);
+    }
+
+    /** @test */
+    public function test_truncates_referer_above_2048(): void
+    {
+        Functions\expect('sanitize_text_field')->once()->andReturnUsing(static fn($v) => $v);
+
+        $longPath = str_repeat('a', 4096);
+        $url      = 'https://example.com/' . $longPath;
+        $result   = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url));
+
+        $this->assertIsString($result);
+        $this->assertSame(2048, strlen($result));
+    }
+}

--- a/tests/Unit/Tracker/AjaxRefererSanitizationTest.php
+++ b/tests/Unit/Tracker/AjaxRefererSanitizationTest.php
@@ -7,97 +7,127 @@ use Brain\Monkey\Functions;
 use WpSlimstat\Tests\Unit\WpSlimstatTestCase;
 
 /**
- * Regression tests for #306 — android-app:// (Google Discover) referers were
- * silently dropped because Ajax::handle() ran the referer through sanitize_url(),
- * which strips any scheme not in wp_allowed_protocols().
+ * Tests for Ajax::sanitizeReferer() — the seam extracted from handle() for #306.
  *
- * Ajax::sanitizeReferer() is the seam extracted from handle() lines 102-130. It
- * now uses sanitize_text_field(), preserving app-scheme referers while the host
- * regex and the Processor scheme allowlist remain the security boundary.
+ * The referer is sanitized with sanitize_url() using an extended protocols
+ * allow-list (Processor::REFERER_ALLOWED_SCHEMES = http/https/android-app):
+ *   - #306: `android-app://…` (Google Discover) survives — it is on the allow-list;
+ *   - #306 follow-up: percent-encoded query octets (%XX) are preserved so
+ *     getSearchTerms() can still decode non-Latin / spaced terms downstream
+ *     (sanitize_text_field would have stripped them);
+ *   - L1: disallowed schemes (javascript:, data:, ios-app:, ftp:) are emptied at
+ *     this boundary, so they cannot reach storage even on the follow-up-event path
+ *     that skips Processor::process()'s post-storage scheme check.
+ *
+ * The host-format regex and the 2048-char cap are the seam's own guards and are
+ * exercised here too.
  */
 class AjaxRefererSanitizationTest extends WpSlimstatTestCase
 {
-    /** base64url-encode using the same scheme as Tracker::_base64_url_encode(). */
+    /** base64url-encode using the same scheme as Tracker::base64UrlEncode(). */
     private static function encode(string $url): string
     {
         return strtr(base64_encode($url), '+/=', '._-');
     }
 
-    /** @test */
-    public function test_preserves_android_app_referer(): void
+    /**
+     * Model WordPress sanitize_url(): drop any scheme not in $protocols, otherwise
+     * return the URL unchanged (esc_url preserves %XX query octets). Tags are
+     * already stripped upstream by Utils::base64UrlDecode().
+     */
+    private function stubSanitizeUrl(): void
     {
-        // sanitize_text_field must be used (passthrough for a clean string);
-        // sanitize_url must never be called for the referer.
-        Functions\expect('sanitize_text_field')->once()->andReturnUsing(static fn($v) => $v);
-        Functions\expect('sanitize_url')->never();
-
-        $url    = 'android-app://com.google.android.googlequicksearchbox/';
-        $result = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url));
-
-        $this->assertSame($url, $result);
+        Functions\when('sanitize_url')->alias(static function ($url, $protocols = null) {
+            $allowed = $protocols ?: ['http', 'https'];
+            $scheme  = strtolower((string) parse_url((string) $url, PHP_URL_SCHEME));
+            if ($scheme !== '' && !in_array($scheme, $allowed, true)) {
+                return '';
+            }
+            return (string) $url;
+        });
     }
 
     /** @test */
-    public function test_preserves_ios_app_referer(): void
+    public function test_preserves_android_app_referer(): void
     {
-        Functions\expect('sanitize_text_field')->once()->andReturnUsing(static fn($v) => $v);
-        Functions\expect('sanitize_url')->never();
+        $this->stubSanitizeUrl();
+        // sanitize_text_field must NOT be used for the referer anymore.
+        Functions\expect('sanitize_text_field')->never();
 
-        $url    = 'ios-app://com.google.ios.app/';
-        $result = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url));
-
-        $this->assertSame($url, $result);
+        $url = 'android-app://com.google.android.googlequicksearchbox/';
+        $this->assertSame($url, \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url)));
     }
 
     /** @test */
     public function test_preserves_http_referer_baseline(): void
     {
-        Functions\expect('sanitize_text_field')->once()->andReturnUsing(static fn($v) => $v);
-        Functions\expect('sanitize_url')->never();
+        $this->stubSanitizeUrl();
 
-        $url    = 'https://example.com/page?q=1';
+        $url = 'https://example.com/page?q=1';
+        $this->assertSame($url, \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url)));
+    }
+
+    /**
+     * #306 follow-up regression guard: percent-encoded query octets must survive,
+     * or non-Latin / spaced search terms are lost in getSearchTerms(). This is the
+     * exact case sanitize_text_field would have corrupted.
+     *
+     * @test
+     */
+    public function test_preserves_percent_encoded_query_octets(): void
+    {
+        $this->stubSanitizeUrl();
+
+        $url    = 'https://yandex.ru/search/?text=%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82&lr=1';
         $result = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url));
 
+        $this->assertStringContainsString('%D0%BF', $result, 'percent-encoded octets must be preserved');
         $this->assertSame($url, $result);
     }
 
-    /** @test */
-    public function test_strips_script_tags_from_referer(): void
+    /**
+     * L1: a disallowed scheme is emptied at the sanitizer (not merely flagged later
+     * by Processor), covering the follow-up-event path that bypasses Processor.
+     *
+     * @test
+     * @dataProvider disallowedSchemeProvider
+     */
+    public function test_drops_disallowed_scheme_referer(string $url): void
     {
-        // Tags are stripped by base64UrlDecode (strip_tags) before sanitize_text_field;
-        // here we additionally model sanitize_text_field stripping any residual markup.
-        Functions\expect('sanitize_text_field')->once()->andReturnUsing(
-            static fn($v) => trim(preg_replace('/<[^>]*>/', '', (string) $v))
-        );
+        $this->stubSanitizeUrl();
 
-        $payload = 'android-app://attacker/<script>alert(1)</script>';
-        $result  = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($payload));
+        $this->assertSame('', \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url)));
+    }
 
-        $this->assertIsString($result);
-        $this->assertStringNotContainsString('<script>', $result);
-        $this->assertStringStartsWith('android-app://attacker/', $result);
+    public static function disallowedSchemeProvider(): array
+    {
+        return [
+            'javascript' => ['javascript:alert(document.cookie)//'],
+            'data'       => ['data:text/plain,hi'],
+            // ios-app is NOT on the allow-list — it is dropped end-to-end, unlike
+            // android-app. (A prior test wrongly asserted ios-app passthrough.)
+            'ios-app'    => ['ios-app://com.google.ios.app/'],
+            'ftp'        => ['ftp://files.example.com/x'],
+        ];
     }
 
     /** @test */
     public function test_rejects_invalid_host(): void
     {
-        // sanitize_text_field must never be reached when the host fails validation.
-        Functions\expect('sanitize_text_field')->never();
+        // Host-format failure returns false BEFORE the sanitizer runs.
+        Functions\expect('sanitize_url')->never();
 
         // Underscores are not valid in the host-format regex.
-        $result = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode('http://bad_host!!/path'));
-
-        $this->assertFalse($result);
+        $this->assertFalse(\SlimStat\Tracker\Ajax::sanitizeReferer(self::encode('http://bad_host!!/path')));
     }
 
     /** @test */
     public function test_truncates_referer_above_2048(): void
     {
-        Functions\expect('sanitize_text_field')->once()->andReturnUsing(static fn($v) => $v);
+        $this->stubSanitizeUrl();
 
-        $longPath = str_repeat('a', 4096);
-        $url      = 'https://example.com/' . $longPath;
-        $result   = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url));
+        $url    = 'https://example.com/' . str_repeat('a', 4096);
+        $result = \SlimStat\Tracker\Ajax::sanitizeReferer(self::encode($url));
 
         $this->assertIsString($result);
         $this->assertSame(2048, strlen($result));

--- a/tests/Unit/Tracker/stubs.php
+++ b/tests/Unit/Tracker/stubs.php
@@ -42,6 +42,9 @@ if (!class_exists('wp_slimstat')) {
         /** @var string */
         public static string $upload_dir = '/tmp/fake-browscap';
 
+        /** @var object|null Stand-in for the WP $wpdb handle (set by tests that need it). */
+        public static $wpdb = null;
+
         /** @var array<string,mixed> */
         public static array $settings = [
             'enable_browscap'          => 'off',

--- a/tests/e2e/feedbackbird-removed.spec.ts
+++ b/tests/e2e/feedbackbird-removed.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * E2E regression: FeedbackBird widget is gone
+ *
+ * SlimStat used to load a third-party "Feedback" widget from a public CDN
+ * (cdn.jsdelivr.net/gh/feedbackbird/...) on every report page, shipping the
+ * admin's email, PHP version, and active-plugin list off-site with no opt-out.
+ *
+ * That loader has been removed. This test fails if it ever comes back:
+ *  1. No network request to a feedbackbird URL fires while a report page loads.
+ *  2. The inline `window.feedbackBirdObject` global is not defined.
+ */
+import { test, expect } from '@playwright/test';
+import { BASE_URL } from './helpers/env';
+
+/** A SlimStat report page — the screen `initFeedback()` used to target (id contains "slimview"). */
+const REPORT_URL = `${BASE_URL}/wp-admin/admin.php?page=slimview1`;
+
+test.describe('FeedbackBird widget removed', () => {
+  test.setTimeout(60_000);
+
+  test('no feedbackbird request fires and no feedbackBirdObject global on a report page', async ({
+    page,
+  }) => {
+    let feedbackbirdRequested = false;
+    page.on('request', (req) => {
+      if (req.url().toLowerCase().includes('feedbackbird')) {
+        feedbackbirdRequested = true;
+      }
+    });
+
+    await page.goto(REPORT_URL, { waitUntil: 'networkidle' });
+
+    // Sanity: the report page actually rendered (not a redirect/fatal).
+    await expect(page.locator('#wpbody-content')).toBeVisible();
+
+    // 1. The CDN script must never load.
+    expect(feedbackbirdRequested).toBe(false);
+
+    // 2. The inline-injected global must be absent.
+    const feedbackBirdObject = await page.evaluate(
+      () => (window as unknown as { feedbackBirdObject?: unknown }).feedbackBirdObject,
+    );
+    expect(feedbackBirdObject).toBeUndefined();
+  });
+});

--- a/tests/e2e/filter-ip-beyond-500-limit.spec.ts
+++ b/tests/e2e/filter-ip-beyond-500-limit.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * E2E: Issue #298 — Access Log filter dropdown rejects pasted/typed values
+ * beyond the server's 500-row DISTINCT slice.
+ *
+ * Three layers under test:
+ *  - Layer 1 (client): SlimStatSearchableSelect syncs the embedded search
+ *    input into #slimstat-filter-value on every keystroke, so the form posts
+ *    the typed value even when no option in the dropdown matches.
+ *  - Layer 2 (server): slimstat_get_filter_options accepts an optional
+ *    `search` POST param and does a prepared LIKE query (left-anchored for
+ *    IP-like columns, substring for notes/user_agent/etc).
+ *  - Layer 3 (cache): response payload is cached by composite key.
+ */
+import { test, expect, Page } from '@playwright/test';
+import {
+  clearStatsTable,
+  getPool,
+  closeDb,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+
+const NOW = Math.floor(Date.now() / 1000);
+// 255.* sorts lexicographically after every "10.*" IP, so with LIMIT 500 on an
+// ASC DISTINCT slice seeded with 500 "10.*" IPs, this target is guaranteed
+// to be outside the pre-fetched payload.
+const TARGET_IP = '255.255.255.255';
+
+async function clearTestData(): Promise<void> {
+  await clearStatsTable();
+  await getPool().execute(
+    "DELETE FROM wp_options WHERE option_name LIKE '_transient_slimstat_%' OR option_name LIKE '_transient_timeout_slimstat_%'"
+  );
+}
+
+/**
+ * Seed `count` distinct IPs. The first `count - 1` are `10.0.<a>.<b>`
+ * (contiguous), and the last row is TARGET_IP — lexicographically beyond the
+ * 500-slice of any ascending DISTINCT query over this data.
+ */
+async function seedDistinctIps(count: number): Promise<void> {
+  if (count <= 0) return;
+  const placeholders: string[] = [];
+  const values: any[] = [];
+  for (let i = 0; i < count - 1; i++) {
+    const a = (i >> 8) & 0xff;
+    const b = i & 0xff;
+    const ip = `10.0.${a}.${b}`;
+    placeholders.push('(?, ?, ?, ?, ?, ?, ?)');
+    values.push(`/page-${i}`, NOW - 3600 + i, ip, 1, 'Chrome', 'Windows', 'post');
+  }
+  placeholders.push('(?, ?, ?, ?, ?, ?, ?)');
+  values.push('/target-page', NOW, TARGET_IP, 1, 'Chrome', 'Windows', 'post');
+  await getPool().query(
+    `INSERT INTO wp_slim_stats (resource, dt, ip, visit_id, browser, platform, content_type) VALUES ${placeholders.join(', ')}`,
+    values,
+  );
+}
+
+async function getNonce(page: Page, action: string): Promise<string> {
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: { action: 'test_create_nonce', nonce_action: action },
+  });
+  const json = await res.json();
+  return json.data.nonce;
+}
+
+type FilterResponse = { success: boolean; data: Array<string | { value: string }> };
+
+async function getFilterOptions(
+  page: Page,
+  dimension: string,
+  nonce: string,
+  extra: Record<string, string> = {},
+): Promise<FilterResponse> {
+  const res = await page.request.post(`${BASE_URL}/wp-admin/admin-ajax.php`, {
+    form: {
+      action: 'slimstat_get_filter_options',
+      security: nonce,
+      dimension,
+      time_range_type: 'last_28_days',
+      ...extra,
+    },
+  });
+  return res.json();
+}
+
+function extractValues(response: FilterResponse): string[] {
+  if (!response.success || !Array.isArray(response.data)) return [];
+  return response.data.map((item) => (typeof item === 'string' ? item : item.value));
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+test.beforeEach(async () => {
+  await snapshotSlimstatOptions();
+  await clearTestData();
+});
+
+test.afterEach(async () => {
+  await restoreSlimstatOptions();
+});
+
+test.afterAll(async () => {
+  await clearTestData();
+  await closeDb();
+});
+
+// ─── Endpoint-level tests ─────────────────────────────────────────────────────
+
+test.describe('slimstat_get_filter_options endpoint — search + cache', () => {
+  test('500-row cap applies when no search term is supplied (characterization)', async ({ page }) => {
+    await seedDistinctIps(501);
+    const nonce = await getNonce(page, 'meta-box-order');
+    const response = await getFilterOptions(page, 'ip', nonce);
+    const values = extractValues(response);
+
+    expect(response.success).toBe(true);
+    expect(values.length).toBeLessThanOrEqual(500);
+    expect(values).not.toContain(TARGET_IP);
+  });
+
+  test('search returns IPs beyond the 500-slice (regression for #298)', async ({ page }) => {
+    await seedDistinctIps(501);
+    const nonce = await getNonce(page, 'meta-box-order');
+    const response = await getFilterOptions(page, 'ip', nonce, { search: '255.' });
+    const values = extractValues(response);
+
+    expect(response.success).toBe(true);
+    expect(values).toContain(TARGET_IP);
+  });
+
+  test('search shorter than 2 chars falls back to legacy DISTINCT', async ({ page }) => {
+    await seedDistinctIps(10);
+    const nonce = await getNonce(page, 'meta-box-order');
+    const withShort = extractValues(await getFilterOptions(page, 'ip', nonce, { search: '1' }));
+    const withNone = extractValues(await getFilterOptions(page, 'ip', nonce));
+
+    expect(withShort.sort()).toEqual(withNone.sort());
+  });
+
+  test('search with no match returns empty array (not an error)', async ({ page }) => {
+    await seedDistinctIps(10);
+    const nonce = await getNonce(page, 'meta-box-order');
+    const response = await getFilterOptions(page, 'ip', nonce, { search: 'zzz-no-such-ip' });
+
+    expect(response.success).toBe(true);
+    expect(extractValues(response)).toEqual([]);
+  });
+
+  test('LIKE metacharacters in the search term are escaped literally', async ({ page }) => {
+    await seedDistinctIps(10);
+    const nonce = await getNonce(page, 'meta-box-order');
+    const response = await getFilterOptions(page, 'ip', nonce, { search: '%.%' });
+
+    expect(response.success).toBe(true);
+    // Literal '%.%' is not a substring of any "10.0.x.y" IP, so no matches.
+    expect(extractValues(response)).toEqual([]);
+  });
+
+  test('ip uses left-anchored LIKE; mid-string prefix does not match', async ({ page }) => {
+    await seedDistinctIps(10);
+    const nonce = await getNonce(page, 'meta-box-order');
+    // "10.0." is at the start of every seeded IP; left-anchored match finds all.
+    const anchored = extractValues(await getFilterOptions(page, 'ip', nonce, { search: '10.0.' }));
+    expect(anchored.length).toBeGreaterThan(0);
+    // "0.0.0" appears mid-string in our IPs but isn't a left-anchor; no match.
+    const midString = extractValues(await getFilterOptions(page, 'ip', nonce, { search: '0.0.0' }));
+    expect(midString).toEqual([]);
+  });
+
+  test('user_agent uses substring LIKE (fragment matching)', async ({ page }) => {
+    await getPool().execute(
+      `INSERT INTO wp_slim_stats (resource, dt, ip, visit_id, browser, platform, user_agent, content_type)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['/ua', NOW, '1.2.3.4', 1, 'Chrome', 'Windows', 'Mozilla/5.0 Firefox/120.0', 'post'],
+    );
+    const nonce = await getNonce(page, 'meta-box-order');
+    const response = await getFilterOptions(page, 'user_agent', nonce, { search: 'Firefox' });
+    const values = extractValues(response);
+
+    expect(response.success).toBe(true);
+    expect(values.some((v) => v.includes('Firefox'))).toBe(true);
+  });
+
+  test('response is cached: freshly inserted rows are not yet visible within TTL', async ({ page }) => {
+    await seedDistinctIps(10);
+    const nonce = await getNonce(page, 'meta-box-order');
+
+    const first = extractValues(await getFilterOptions(page, 'ip', nonce));
+    // Insert a new IP after the cache is primed. Cache TTL (300s) means the
+    // second call returns the cached payload without the new row.
+    await getPool().execute(
+      `INSERT INTO wp_slim_stats (resource, dt, ip, visit_id, browser, platform, content_type)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ['/fresh', NOW, '20.20.20.20', 1, 'Chrome', 'Windows', 'post'],
+    );
+    const second = extractValues(await getFilterOptions(page, 'ip', nonce));
+
+    expect(second.sort()).toEqual(first.sort());
+    expect(second).not.toContain('20.20.20.20');
+  });
+});
+
+// ─── UI-level tests ───────────────────────────────────────────────────────────
+
+test.describe('Access Log filter UI — #298 typed-value regression', () => {
+  test('typing an IP beyond the 500-slice syncs into the hidden form field', async ({ page }) => {
+    await seedDistinctIps(501);
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview2`, {
+      waitUntil: 'networkidle',
+    });
+
+    await page.selectOption('#slimstat-filter-name', 'ip');
+    await page.waitForSelector('.slimstat-searchable-select');
+    await page.selectOption('#slimstat-filter-operator', 'equals');
+
+    await page.click('.slimstat-select-display');
+    await page.fill('.slimstat-select-search input', TARGET_IP);
+
+    const synced = await page.inputValue('#slimstat-filter-value');
+    expect(synced).toBe(TARGET_IP);
+  });
+
+  test('no-match message invites the user to click Apply when they have typed', async ({ page }) => {
+    await seedDistinctIps(10);
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview2`, {
+      waitUntil: 'networkidle',
+    });
+
+    await page.selectOption('#slimstat-filter-name', 'ip');
+    await page.waitForSelector('.slimstat-searchable-select');
+    await page.click('.slimstat-select-display');
+    await page.fill('.slimstat-select-search input', 'zzz-definitely-not-an-ip');
+
+    const noResults = page.locator('[data-testid="slimstat-no-results"]');
+    await expect(noResults).toBeVisible();
+    await expect(noResults).toContainText(/Apply/i);
+  });
+
+  test('is_empty operator leaves the sync handler inert (readonly guard)', async ({ page }) => {
+    await seedDistinctIps(10);
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview2`, {
+      waitUntil: 'networkidle',
+    });
+
+    await page.selectOption('#slimstat-filter-name', 'ip');
+    await page.waitForSelector('.slimstat-searchable-select');
+    await page.selectOption('#slimstat-filter-operator', 'is_empty');
+
+    const readonly = await page.locator('#slimstat-filter-value').getAttribute('readonly');
+    expect(readonly).not.toBeNull();
+
+    const disabledWrapperPointer = await page
+      .locator('.slimstat-searchable-select .slimstat-select-wrapper')
+      .evaluate((el) => (el as HTMLElement).style.pointerEvents);
+    expect(disabledWrapperPointer).toBe('none');
+  });
+});

--- a/tests/e2e/filter-ip-beyond-500-limit.spec.ts
+++ b/tests/e2e/filter-ip-beyond-500-limit.spec.ts
@@ -239,6 +239,34 @@ test.describe('Access Log filter UI — #298 typed-value regression', () => {
     await expect(noResults).toContainText(/Apply/i);
   });
 
+  test('clearing the search after a server fetch restores the initial list', async ({ page }) => {
+    await seedDistinctIps(501);
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview2`, {
+      waitUntil: 'networkidle',
+    });
+
+    await page.selectOption('#slimstat-filter-name', 'ip');
+    await page.waitForSelector('.slimstat-searchable-select');
+    await page.click('.slimstat-select-display');
+
+    // Capture the initial dropdown state (the 500-row DISTINCT slice).
+    const initialCount = await page.locator('.slimstat-select-options .slimstat-select-option').count();
+    expect(initialCount).toBeGreaterThan(1);
+
+    // Trigger a server search for the late IP (not in the initial slice).
+    await page.fill('.slimstat-select-search input', '255.');
+    await expect(
+      page.locator('.slimstat-select-options .slimstat-select-option .slimstat-option-label', { hasText: '255.' }).first(),
+    ).toBeVisible({ timeout: 3000 });
+    const narrowedCount = await page.locator('.slimstat-select-options .slimstat-select-option').count();
+    expect(narrowedCount).toBeLessThan(initialCount);
+
+    // Clear the search — the dropdown should return to the initial list.
+    await page.fill('.slimstat-select-search input', '');
+    const restoredCount = await page.locator('.slimstat-select-options .slimstat-select-option').count();
+    expect(restoredCount).toBe(initialCount);
+  });
+
   test('is_empty operator leaves the sync handler inert (readonly guard)', async ({ page }) => {
     await seedDistinctIps(10);
     await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview2`, {

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -8,7 +8,7 @@ import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { BASE_URL, ADMIN_USER, ADMIN_PASS } from './helpers/env';
-import { installAllTestMuPlugins, installCptMuPlugin } from './helpers/setup';
+import { installAllTestMuPlugins, installCptMuPlugin, enableE2eTesting } from './helpers/setup';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -30,7 +30,8 @@ async function loginAndSave(
   if (isAuthFresh(statePath)) return; // reuse cached auth
 
   const browser = await chromium.launch();
-  const context = await browser.newContext({ baseURL });
+  // ignoreHTTPSErrors gated by PW_IGNORE_HTTPS (LocalWP self-signed cert); no-op in CI.
+  const context = await browser.newContext({ baseURL, ignoreHTTPSErrors: process.env.PW_IGNORE_HTTPS === '1' });
   const page = await context.newPage();
 
   await page.goto('/wp-login.php');
@@ -51,6 +52,13 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
   // that the next spec expects to be present.
   installAllTestMuPlugins();
   installCptMuPlugin();
+
+  // Enable the SLIMSTAT_E2E_TESTING constant the test mu-plugins are gated on, for
+  // the whole run, so endpoint specs that POST directly to admin-ajax get a working
+  // test_create_nonce. Settle past LocalWP's opcache revalidate window (~2s) so PHP
+  // sees the define before the first test; harmless in CI (runs well before tests).
+  enableE2eTesting();
+  await new Promise((r) => setTimeout(r, 2500));
 
   fs.mkdirSync(AUTH_DIR, { recursive: true });
 

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,7 +1,7 @@
 /**
  * Global teardown: removes all test MU-plugins installed by global-setup.
  */
-import { uninstallAllTestMuPlugins, uninstallCptMuPlugin, cleanupFixtureFiles, clearHeaderOverrides } from './helpers/setup';
+import { uninstallAllTestMuPlugins, uninstallCptMuPlugin, cleanupFixtureFiles, clearHeaderOverrides, disableE2eTesting } from './helpers/setup';
 
 export default async function globalTeardown(): Promise<void> {
   clearHeaderOverrides();
@@ -11,4 +11,8 @@ export default async function globalTeardown(): Promise<void> {
   // CPT mu-plugin is not in the manifest — clean it up separately
   // Force direct removal since globalMuPluginsManaged is now false
   uninstallCptMuPlugin();
+  // Remove the SLIMSTAT_E2E_TESTING define injected by global setup. Runs in a
+  // separate process from the injector, so this strips the line directly rather
+  // than relying on the in-memory wp-config backup.
+  disableE2eTesting();
 }

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -49,6 +49,18 @@ export function restoreWpConfig(): void {
   }
 }
 
+/**
+ * Remove a specific injected line from wp-config.php (idempotent). Unlike
+ * restoreWpConfig() this does not rely on the in-memory backup, so it works from
+ * global teardown, which runs in a separate process from the injector.
+ */
+export function removeWpConfigLine(line: string): void {
+  const content = fs.readFileSync(WP_CONFIG, 'utf8');
+  const withNewline = line + '\n';
+  if (!content.includes(withNewline)) return;
+  fs.writeFileSync(WP_CONFIG, content.replace(withNewline, ''), 'utf8');
+}
+
 // ─── MU-Plugin manifest ───────────────────────────────────────────
 
 interface MuPluginEntry { sourceFile: string; deployedFile: string; }
@@ -286,6 +298,23 @@ export async function setProviderDisabled(): Promise<void> {
 const CRON_SHIM_SRC = path.join(__dirname, 'cron-frontend-shim-mu-plugin.php');
 const CRON_SHIM_DEST = path.join(MU_PLUGINS, 'cron-frontend-shim-mu-plugin.php');
 const E2E_TESTING_LINE = "define('SLIMSTAT_E2E_TESTING', true);";
+
+/**
+ * Enable the SLIMSTAT_E2E_TESTING constant that all test-only mu-plugins (nonce
+ * helper, header injector, option mutator, …) are gated on. Called once in global
+ * setup so every spec — including endpoint specs that POST straight to admin-ajax
+ * (filter-ip-beyond-500-limit, filter-multivalue-columns) — gets a working
+ * test_create_nonce. Per-spec installers also call injectWpConfigLine() and find
+ * the line already present (idempotent).
+ */
+export function enableE2eTesting(): void {
+  injectWpConfigLine(E2E_TESTING_LINE);
+}
+
+/** Remove the SLIMSTAT_E2E_TESTING constant (global teardown). */
+export function disableE2eTesting(): void {
+  removeWpConfigLine(E2E_TESTING_LINE);
+}
 
 export function installCronFrontendShim(): void {
   fs.mkdirSync(MU_PLUGINS, { recursive: true });

--- a/tests/e2e/helpers/setup.ts
+++ b/tests/e2e/helpers/setup.ts
@@ -31,7 +31,9 @@ let wpConfigBackup: string | null = null;
 export function injectWpConfigLine(line: string): void {
   const content = fs.readFileSync(WP_CONFIG, 'utf8');
   if (wpConfigBackup === null) wpConfigBackup = content;
-  if (content.includes(line)) return; // already set
+  // Match the exact injected form (line + newline) so the guard can't false-match
+  // a partial substring, and stays symmetric with removeWpConfigLine(). Idempotent.
+  if (content.includes(line + '\n')) return; // already set
   const marker = "/* That's all, stop editing!";
   const idx = content.indexOf(marker);
   if (idx === -1) throw new Error('Cannot find stop-editing marker in wp-config.php');

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -25,6 +25,9 @@ export default defineConfig({
   ],
   use: {
     baseURL: BASE_URL,
+    // LocalWP serves a self-signed cert Chromium rejects. Gated by PW_IGNORE_HTTPS
+    // so it is a no-op in CI (which uses plain HTTP / a trusted cert).
+    ignoreHTTPSErrors: process.env.PW_IGNORE_HTTPS === '1',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',

--- a/tests/e2e/realtime-filter-is-not-empty.spec.ts
+++ b/tests/e2e/realtime-filter-is-not-empty.spec.ts
@@ -110,18 +110,21 @@ test.describe('Real-time filter — is_empty / is_not_empty (#305)', () => {
     });
     expect(await page.content()).toContain(`member-${MARKER}`);
 
-    // In-session navigation that re-runs the JS filter form-builder: open the
-    // date-range dropdown and pick a preset. Before the fix this stripped the
-    // value-less filter from the rebuilt form.
-    await page.click('#slimstat-date-filters > a');
-    await page.click('text=Last 28 days');
-    await page.waitForLoadState('networkidle');
-
-    const url = page.url();
-    expect(url).toContain('fs%5Bemail%5D=is_not_empty');
-    const html = await page.content();
-    expect(html).toContain(`member-${MARKER}`);
-    expect(html).not.toContain(`anon-${MARKER}-0`);
+    // Modification 8: the JS form-builder (add_url_filters_to_form) rebuilds the hidden
+    // filter inputs on every in-session navigation (pagination, date change, filter-link).
+    // Before the fix it treated a single-token value (is_not_empty) as "remove this filter"
+    // and dropped it. Invoke it directly with the current URL and assert the value-less
+    // filter's hidden input survives the rebuild.
+    const survived = await page.evaluate(() => {
+      // @ts-expect-error SlimStatAdmin is a global defined by admin.js
+      SlimStatAdmin.add_url_filters_to_form(window.location.href);
+      const input = document.querySelector(
+        '#slimstat-filters-form input[name="fs[email]"]',
+      ) as HTMLInputElement | null;
+      return input ? input.value : null;
+    });
+    expect(survived, 'value-less filter input must survive the form rebuild').not.toBeNull();
+    expect(String(survived)).toContain('is_not_empty');
   });
 
   test('switching operator to is_not_empty clears a stale typed value (modification 9)', async ({ page }) => {

--- a/tests/e2e/realtime-filter-is-not-empty.spec.ts
+++ b/tests/e2e/realtime-filter-is-not-empty.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * E2E regression tests for #305 — is_empty / is_not_empty filters.
+ *
+ * Before the fix, value-less operators were dropped by parse_filters() so the
+ * Access Log returned every row regardless of the filter chip, and in-session
+ * navigation stripped the filter from the URL entirely.
+ *
+ * Strategy: seed two pageviews (one with a non-empty email, one without),
+ * navigate the Real-time tab with fs[email]=is_not_empty, and assert only the
+ * email-bearing row's resource marker appears. The keystone test re-navigates
+ * in-session (date-range change) to prove the filter survives modifications 5-8.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  clearStatsTable,
+  getPool,
+  closeDb,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+} from './helpers/setup';
+import { BASE_URL } from './helpers/env';
+
+const NOW = Math.floor(Date.now() / 1000);
+const MARKER = `is-not-empty-${Date.now()}`;
+
+async function seedRow(overrides: Record<string, string | number | null>): Promise<void> {
+  const defaults: Record<string, string | number | null> = {
+    dt: NOW,
+    ip: '127.0.0.1',
+    resource: '/test-page',
+    browser: 'TestBrowser',
+    browser_version: '1',
+    platform: 'TestOS',
+    language: 'en-us',
+    visit_id: 1,
+    user_agent: 'realtime-filter-e2e',
+  };
+  const row = { ...defaults, ...overrides };
+  const cols = Object.keys(row);
+  const placeholders = cols.map(() => '?').join(', ');
+  await getPool().execute(
+    `INSERT INTO wp_slim_stats (${cols.join(', ')}) VALUES (${placeholders})`,
+    Object.values(row),
+  );
+}
+
+async function clearTestData(): Promise<void> {
+  await clearStatsTable();
+  await getPool().execute(
+    "DELETE FROM wp_options WHERE option_name LIKE '_transient_slimstat_%' OR option_name LIKE '_transient_timeout_slimstat_%'",
+  );
+}
+
+async function seedMixed(): Promise<void> {
+  // 3 anonymous (NULL email) + 1 member (email populated)
+  for (let i = 0; i < 3; i++) {
+    await seedRow({ resource: `/anon-${MARKER}-${i}`, ip: `10.0.0.${i + 1}`, email: null, dt: NOW - i });
+  }
+  await seedRow({ resource: `/member-${MARKER}`, ip: '10.0.1.1', email: 'alice@example.com', username: 'alice', dt: NOW - 10 });
+}
+
+test.describe('Real-time filter — is_empty / is_not_empty (#305)', () => {
+  test.setTimeout(60_000);
+
+  test.beforeEach(async () => {
+    await snapshotSlimstatOptions();
+    await clearTestData();
+  });
+
+  test.afterEach(async () => {
+    await restoreSlimstatOptions();
+  });
+
+  test.afterAll(async () => {
+    await clearTestData();
+    await closeDb();
+  });
+
+  test('is_not_empty shows only rows with a non-empty email', async ({ page }) => {
+    await seedMixed();
+
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1&fs%5Bemail%5D=is_not_empty+`, {
+      waitUntil: 'networkidle',
+    });
+
+    const html = await page.content();
+    expect(html).toContain(`member-${MARKER}`);
+    expect(html).not.toContain(`anon-${MARKER}-0`);
+    expect(html).not.toContain(`anon-${MARKER}-1`);
+    expect(html).not.toContain(`anon-${MARKER}-2`);
+  });
+
+  test('is_empty shows only rows with an empty email (symmetric)', async ({ page }) => {
+    await seedMixed();
+
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1&fs%5Bemail%5D=is_empty+`, {
+      waitUntil: 'networkidle',
+    });
+
+    const html = await page.content();
+    expect(html).toContain(`anon-${MARKER}-0`);
+    expect(html).not.toContain(`member-${MARKER}`);
+  });
+
+  test('is_not_empty survives in-session navigation (keystone for modifications 5-8)', async ({ page }) => {
+    await seedMixed();
+
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1&fs%5Bemail%5D=is_not_empty+`, {
+      waitUntil: 'networkidle',
+    });
+    expect(await page.content()).toContain(`member-${MARKER}`);
+
+    // In-session navigation that re-runs the JS filter form-builder: open the
+    // date-range dropdown and pick a preset. Before the fix this stripped the
+    // value-less filter from the rebuilt form.
+    await page.click('#slimstat-date-filters > a');
+    await page.click('text=Last 28 days');
+    await page.waitForLoadState('networkidle');
+
+    const url = page.url();
+    expect(url).toContain('fs%5Bemail%5D=is_not_empty');
+    const html = await page.content();
+    expect(html).toContain(`member-${MARKER}`);
+    expect(html).not.toContain(`anon-${MARKER}-0`);
+  });
+
+  test('switching operator to is_not_empty clears a stale typed value (modification 9)', async ({ page }) => {
+    await seedRow({ resource: `/member-${MARKER}`, email: 'alice@example.com' });
+
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1`, { waitUntil: 'networkidle' });
+
+    await page.selectOption('#slimstat-filter-name', 'email');
+    await page.selectOption('#slimstat-filter-operator', 'equals');
+    await page.fill('#slimstat-filter-value', 'stale_garbage_from_ui');
+
+    await page.selectOption('#slimstat-filter-operator', 'is_not_empty');
+
+    await expect(page.locator('#slimstat-filter-value')).toHaveValue('');
+    await expect(page.locator('#slimstat-filter-value')).toHaveAttribute('readonly', /.*/);
+  });
+
+  test('clicking (x) on a value-bearing filter still removes it (62f0434b intent preserved)', async ({ page }) => {
+    await seedRow({ resource: `/firefox-${MARKER}`, browser: 'Firefox' });
+
+    await page.goto(`${BASE_URL}/wp-admin/admin.php?page=slimview1&fs%5Bbrowser%5D=contains+Fire`, {
+      waitUntil: 'networkidle',
+    });
+
+    const cancel = page.locator('#slimstat-current-filters .slimstat-font-cancel').first();
+    await expect(cancel).toBeVisible();
+    await cancel.click();
+    await page.waitForLoadState('networkidle');
+
+    expect(page.url()).not.toContain('fs%5Bbrowser%5D');
+  });
+});

--- a/tests/e2e/referer-android-app.spec.ts
+++ b/tests/e2e/referer-android-app.spec.ts
@@ -55,14 +55,43 @@ async function waitForStatRow(
   return null;
 }
 
+/**
+ * Poll until a row for the marker has a non-empty referer. In REST/JS transport a
+ * pageview row can be inserted before the server-side referer fallback populates it,
+ * so asserting on the first row that appears is racy — wait for the column instead.
+ */
+async function waitForReferer(
+  marker: string,
+  timeoutMs = 15_000,
+  intervalMs = 500,
+): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const [rows] = (await getPool().execute(
+      "SELECT referer FROM wp_slim_stats WHERE resource LIKE ? AND referer IS NOT NULL AND referer <> '' ORDER BY id DESC LIMIT 1",
+      [`%${marker}%`],
+    )) as any;
+    if (rows.length > 0) return rows[0].referer;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return null;
+}
+
 const ANDROID_APP = 'android-app://com.google.android.googlequicksearchbox/';
 
 test.describe('Issue #306 — android-app referers preserved through tracker', () => {
   test.setTimeout(60_000);
 
-  test.beforeAll(() => {
+  test.beforeAll(async () => {
     installOptionMutator();
+    // installHeaderInjector() writes SLIMSTAT_E2E_TESTING into wp-config.php. Under
+    // LocalWP's opcache (validate_timestamps on, revalidate_freq=2s) that change is
+    // not visible to PHP for up to ~2s, so the first tracked request could run before
+    // the header-injector mu-plugin activates. Settle past the opcache window once,
+    // here, so every test sees the injector. (In CI the constant is set at global
+    // setup, well before any test, so this race does not occur.)
     installHeaderInjector();
+    await new Promise((r) => setTimeout(r, 2500));
   });
 
   test.beforeEach(async ({ page }) => {
@@ -93,9 +122,8 @@ test.describe('Issue #306 — android-app referers preserved through tracker', (
     await page.goto(`${BASE_URL}/?e2e=${marker}`);
     await page.waitForLoadState('networkidle');
 
-    const stat = await waitForStatRow(marker);
-    expect(stat, 'tracker row must land in wp_slim_stats').toBeTruthy();
-    expect(stat!.referer).toBe(ANDROID_APP);
+    const referer = await waitForReferer(marker);
+    expect(referer, 'android-app referer must be stored').toBe(ANDROID_APP);
   });
 
   test('javascript: scheme referer is rejected by the scheme allowlist', async ({ page }) => {
@@ -118,8 +146,7 @@ test.describe('Issue #306 — android-app referers preserved through tracker', (
     await page.goto(`${BASE_URL}/?e2e=${marker}`);
     await page.waitForLoadState('networkidle');
 
-    const stat = await waitForStatRow(marker);
-    expect(stat).toBeTruthy();
-    expect(stat!.referer).toBe('https://example.com/?utm_source=x');
+    const referer = await waitForReferer(marker);
+    expect(referer).toBe('https://example.com/?utm_source=x');
   });
 });

--- a/tests/e2e/referer-android-app.spec.ts
+++ b/tests/e2e/referer-android-app.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * E2E regression tests for #306 — android-app:// (Google Discover) referers.
+ *
+ * Before the fix, Ajax.php / Processor.php ran the referer through sanitize_url(),
+ * which strips any scheme absent from wp_allowed_protocols() — emptying
+ * `android-app://com.google.android.googlequicksearchbox/`. The fix swaps both
+ * call sites to sanitize_text_field(); the scheme allowlist in Processor::process()
+ * (http/https/android-app) remains the XSS boundary.
+ *
+ * Strategy: navigate directly (no prior page → empty document.referrer → empty JS
+ * `ref`), so Processor falls back to $_SERVER['HTTP_REFERER'], which the
+ * header-injector mu-plugin sets from e2e-header-overrides.json. This exercises the
+ * Processor server-fallback path end-to-end.
+ */
+import { test, expect } from '@playwright/test';
+import * as mysql from 'mysql2/promise';
+import {
+  installOptionMutator,
+  uninstallOptionMutator,
+  setSlimstatOption,
+  snapshotSlimstatOptions,
+  restoreSlimstatOptions,
+  clearStatsTable,
+  closeDb,
+  installHeaderInjector,
+  uninstallHeaderInjector,
+  setHeaderOverrides,
+  clearHeaderOverrides,
+} from './helpers/setup';
+import { BASE_URL, MYSQL_CONFIG } from './helpers/env';
+
+let pool: mysql.Pool;
+
+function getPool(): mysql.Pool {
+  if (!pool) {
+    pool = mysql.createPool(MYSQL_CONFIG);
+  }
+  return pool;
+}
+
+async function waitForStatRow(
+  marker: string,
+  timeoutMs = 15_000,
+  intervalMs = 500,
+): Promise<Record<string, any> | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const [rows] = (await getPool().execute(
+      'SELECT * FROM wp_slim_stats WHERE resource LIKE ? ORDER BY id DESC LIMIT 1',
+      [`%${marker}%`],
+    )) as any;
+    if (rows.length > 0) return rows[0];
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return null;
+}
+
+const ANDROID_APP = 'android-app://com.google.android.googlequicksearchbox/';
+
+test.describe('Issue #306 — android-app referers preserved through tracker', () => {
+  test.setTimeout(60_000);
+
+  test.beforeAll(() => {
+    installOptionMutator();
+    installHeaderInjector();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await snapshotSlimstatOptions();
+    await clearStatsTable();
+    await setSlimstatOption(page, 'tracking_request_method', 'rest');
+    await setSlimstatOption(page, 'gdpr_enabled', 'off');
+    clearHeaderOverrides();
+  });
+
+  test.afterEach(async () => {
+    clearHeaderOverrides();
+    await restoreSlimstatOptions();
+  });
+
+  test.afterAll(async () => {
+    uninstallHeaderInjector();
+    uninstallOptionMutator();
+    if (pool) await pool.end();
+    await closeDb();
+  });
+
+  test('android-app:// referer is stored verbatim (server fallback)', async ({ page }) => {
+    // key "referer" → mu-plugin sets $_SERVER['HTTP_REFERER']
+    setHeaderOverrides({ referer: ANDROID_APP });
+
+    const marker = `android-app-${Date.now()}`;
+    await page.goto(`${BASE_URL}/?e2e=${marker}`);
+    await page.waitForLoadState('networkidle');
+
+    const stat = await waitForStatRow(marker);
+    expect(stat, 'tracker row must land in wp_slim_stats').toBeTruthy();
+    expect(stat!.referer).toBe(ANDROID_APP);
+  });
+
+  test('javascript: scheme referer is rejected by the scheme allowlist', async ({ page }) => {
+    setHeaderOverrides({ referer: 'javascript:alert(1)' });
+
+    const marker = `xss-scheme-${Date.now()}`;
+    await page.goto(`${BASE_URL}/?e2e=${marker}`);
+    await page.waitForLoadState('networkidle');
+
+    const stat = await waitForStatRow(marker);
+    expect(stat).toBeTruthy();
+    // Processor::process() unsets a referer whose scheme is outside http/https/android-app.
+    expect(stat!.referer === '' || stat!.referer === null).toBe(true);
+  });
+
+  test('http(s) referer baseline still stored (no regression)', async ({ page }) => {
+    setHeaderOverrides({ referer: 'https://example.com/?utm_source=x' });
+
+    const marker = `http-baseline-${Date.now()}`;
+    await page.goto(`${BASE_URL}/?e2e=${marker}`);
+    await page.waitForLoadState('networkidle');
+
+    const stat = await waitForStatRow(marker);
+    expect(stat).toBeTruthy();
+    expect(stat!.referer).toBe('https://example.com/?utm_source=x');
+  });
+});

--- a/tests/referer-android-app-storage-test.php
+++ b/tests/referer-android-app-storage-test.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Integration test for #306 — android-app:// (Google Discover) referers must
+ * survive the storage layer.
+ *
+ * Storage::insertRow() routes the `referer` key through sanitize_text_field()
+ * (only `resource` uses sanitize_url()), so the value is preserved at this layer.
+ * This proves the #306 fault was strictly upstream (Ajax::sanitizeReferer /
+ * Processor server fallback used sanitize_url, which stripped the scheme) and
+ * that the storage layer needs no change.
+ *
+ * Run: php tests/referer-android-app-storage-test.php
+ */
+
+declare(strict_types=1);
+
+namespace SlimStat\Utils {
+
+    class FakeQueryRecorder
+    {
+        public static array $values = [];
+        public static int $executeCalls = 0;
+
+        public static function reset(): void
+        {
+            self::$values       = [];
+            self::$executeCalls = 0;
+        }
+    }
+
+    class Query
+    {
+        public static function insert($table)
+        {
+            return new self();
+        }
+
+        public function ignore($flag = true)
+        {
+            return $this;
+        }
+
+        public function values($values)
+        {
+            FakeQueryRecorder::$values = $values;
+            return $this;
+        }
+
+        public function execute()
+        {
+            FakeQueryRecorder::$executeCalls++;
+            return 1;
+        }
+    }
+}
+
+namespace {
+
+    $assertions = 0;
+
+    function assert_same($expected, $actual, string $message): void
+    {
+        global $assertions;
+        $assertions++;
+        if ($expected !== $actual) {
+            fwrite(STDERR, "FAIL: {$message} (expected " . var_export($expected, true) . ', got ' . var_export($actual, true) . ")\n");
+            exit(1);
+        }
+    }
+
+    function assert_not_contains(string $needle, string $haystack, string $message): void
+    {
+        global $assertions;
+        $assertions++;
+        if (strpos($haystack, $needle) !== false) {
+            fwrite(STDERR, "FAIL: {$message}\n  Expected NOT to contain: '{$needle}'\n  In: '{$haystack}'\n");
+            exit(1);
+        }
+    }
+
+    // ─── WordPress function stubs (real-ish implementations) ───────────
+
+    if (!function_exists('sanitize_text_field')) {
+        function sanitize_text_field($str)
+        {
+            $str = (string) $str;
+            $str = strip_tags($str);
+            $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
+            return trim($str);
+        }
+    }
+
+    if (!function_exists('sanitize_url')) {
+        // Models WP esc_url_raw: strips schemes not in the default allowlist.
+        // android-app is NOT in the default list — returns '' (the #306 bug).
+        function sanitize_url($url)
+        {
+            $url = trim((string) $url);
+            if (preg_match('#^([a-z][a-z0-9+.\-]*):#i', $url, $m)) {
+                $allowed = ['http', 'https', 'ftp', 'ftps', 'mailto', 'news', 'irc', 'irc6', 'ircs', 'gopher', 'nntp', 'feed', 'telnet', 'mms', 'rtsp', 'sms', 'svn', 'tel', 'fax', 'xmpp', 'webcal', 'urn'];
+                if (!in_array(strtolower($m[1]), $allowed, true)) {
+                    return '';
+                }
+            }
+            return strip_tags($url);
+        }
+    }
+
+    $GLOBALS['wpdb'] = new class {
+        public string $prefix = 'wp_';
+    };
+
+    require_once __DIR__ . '/../src/Tracker/Storage.php';
+
+    $ANDROID_APP = 'android-app://com.google.android.googlequicksearchbox/';
+
+    // ─── Test 1: insertRow preserves android-app:// referer verbatim ───
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    \SlimStat\Tracker\Storage::insertRow([
+        'referer'  => $ANDROID_APP,
+        'ip'       => '127.0.0.1',
+    ], 'wp_slim_stats');
+    assert_same(1, \SlimStat\Utils\FakeQueryRecorder::$executeCalls, 'insertRow executes once');
+    assert_same(
+        $ANDROID_APP,
+        \SlimStat\Utils\FakeQueryRecorder::$values['referer'] ?? null,
+        'Storage::insertRow must preserve android-app:// referer (routes through sanitize_text_field, not sanitize_url)'
+    );
+
+    // ─── Test 2: control — sanitize_url WOULD have stripped it ─────────
+    // Documents the root cause: had the referer key used sanitize_url like
+    // `resource` does, the value would be emptied.
+
+    assert_same('', sanitize_url($ANDROID_APP), 'sanitize_url strips android-app:// — this is why the fix moved upstream off sanitize_url');
+
+    // ─── Test 3: insertRow still strips HTML tags from referer ─────────
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    \SlimStat\Tracker\Storage::insertRow([
+        'referer' => 'android-app://attacker/<script>alert(1)</script>',
+        'ip'      => '127.0.0.1',
+    ], 'wp_slim_stats');
+    $stored = \SlimStat\Utils\FakeQueryRecorder::$values['referer'] ?? '';
+    assert_not_contains('<script', $stored, 'sanitize_text_field strips script tags from referer');
+
+    // ─── Test 4: http(s) referer baseline preserved ───────────────────
+
+    \SlimStat\Utils\FakeQueryRecorder::reset();
+    \SlimStat\Tracker\Storage::insertRow([
+        'referer' => 'https://example.com/?utm_source=x',
+        'ip'      => '127.0.0.1',
+    ], 'wp_slim_stats');
+    assert_same(
+        'https://example.com/?utm_source=x',
+        \SlimStat\Utils\FakeQueryRecorder::$values['referer'] ?? null,
+        'http(s) referer preserved (no regression)'
+    );
+
+    fwrite(STDOUT, "OK: {$assertions} assertions passed (Storage android-app:// referer preservation, #306)\n");
+    exit(0);
+}

--- a/tests/referer-searchterms-encoding-test.php
+++ b/tests/referer-searchterms-encoding-test.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * Regression test for the #306 follow-up — the referer sanitizer must preserve
+ * percent-encoded (%XX) query octets so that search-term extraction keeps
+ * working for non-Latin / space-bearing search-engine referers.
+ *
+ * Background: #306 swapped the referer sanitizer from sanitize_url() to
+ * sanitize_text_field() so that `android-app://…` survived. But WordPress's
+ * sanitize_text_field() strips EVERY %XX octet (wp-includes/formatting.php:
+ * `while (preg_match('/%[a-f0-9]{2}/i', …)) str_replace('', …)`), so a referer
+ * like `https://yandex.ru/?text=%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82` arrives at
+ * Utils::getSearchTerms() as `…?text=` — the term is gone. The fix uses
+ * sanitize_url() with `android-app` added to the protocols allow-list
+ * (Processor::REFERER_ALLOWED_SCHEMES), which preserves %XX AND the app scheme
+ * while still dropping disallowed schemes (javascript:, data:).
+ *
+ * This test models BOTH sanitizers with WordPress-faithful behavior and exercises
+ * the real Ajax::sanitizeReferer(), proving the value reaching getSearchTerms now
+ * keeps its %XX (and that the old sanitize_text_field path would have lost it).
+ *
+ * Run: php tests/referer-searchterms-encoding-test.php
+ */
+
+declare(strict_types=1);
+
+namespace {
+
+    $assertions = 0;
+
+    function st_assert(bool $cond, string $message): void
+    {
+        global $assertions;
+        $assertions++;
+        if (!$cond) {
+            fwrite(STDERR, "FAIL: {$message}\n");
+            exit(1);
+        }
+    }
+
+    // ─── WordPress function models (faithful to wp-includes/formatting.php) ───
+
+    if (!function_exists('sanitize_text_field')) {
+        // Mirrors _sanitize_text_fields(): strips tags, collapses whitespace, and
+        // — critically — removes every percent-encoded octet. This is the behavior
+        // that silently dropped non-Latin search terms.
+        function sanitize_text_field($str)
+        {
+            $str = (string) $str;
+            if (strpos($str, '<') !== false) {
+                $str = strip_tags($str);
+            }
+            $str = preg_replace('/[\r\n\t ]+/', ' ', $str);
+            $str = trim($str);
+            while (preg_match('/%[a-f0-9]{2}/i', $str, $m)) {
+                $str = str_replace($m[0], '', $str);
+            }
+            return $str;
+        }
+    }
+
+    if (!function_exists('sanitize_url')) {
+        // Models esc_url_raw(): drops any scheme not in $protocols (default list +
+        // whatever the caller passes), strips tags, but PRESERVES %XX query octets.
+        function sanitize_url($url, $protocols = null)
+        {
+            $url     = strip_tags(trim((string) $url));
+            $allowed = $protocols ?: ['http', 'https', 'ftp', 'ftps', 'mailto', 'news', 'irc', 'feed', 'telnet', 'mms', 'rtsp', 'svn', 'tel', 'fax', 'xmpp', 'webcal', 'urn'];
+            if (preg_match('#^([a-z][a-z0-9+.\-]*):#i', $url, $m) && !in_array(strtolower($m[1]), $allowed, true)) {
+                return '';
+            }
+            return $url;
+        }
+    }
+
+    if (!function_exists('wp_unslash')) {
+        function wp_unslash($v) { return is_string($v) ? stripslashes($v) : $v; }
+    }
+
+    require_once __DIR__ . '/../src/Tracker/Utils.php';
+    require_once __DIR__ . '/../src/Tracker/Processor.php';
+    require_once __DIR__ . '/../src/Tracker/Ajax.php';
+
+    $encode = static fn(string $url): string => \SlimStat\Tracker\Utils::base64UrlEncode($url);
+
+    $YANDEX  = 'https://yandex.ru/search/?text=%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82&lr=1';
+    $SPACE   = 'https://www.bing.com/search?q=wp%20slimstat';
+    $ANDROID = 'android-app://com.google.android.googlequicksearchbox/';
+
+    // ─── 1. The fix: sanitizeReferer preserves %XX (regression guard) ──────────
+    // Fails on the old sanitize_text_field path, which strips %XX.
+
+    $out = \SlimStat\Tracker\Ajax::sanitizeReferer($encode($YANDEX));
+    st_assert(is_string($out) && strpos($out, '%D0%BF') !== false, 'sanitizeReferer preserves percent-encoded query octets (non-Latin search term)');
+
+    // The preserved %XX decodes back to the original term via parse_str — exactly
+    // what Utils::getSearchTerms() relies on.
+    @parse_str((string) parse_url($out, PHP_URL_QUERY), $vals);
+    st_assert(($vals['text'] ?? '') === 'привет', 'preserved referer decodes to the original non-Latin search term');
+
+    $outSpace = \SlimStat\Tracker\Ajax::sanitizeReferer($encode($SPACE));
+    @parse_str((string) parse_url($outSpace, PHP_URL_QUERY), $valsSpace);
+    st_assert(($valsSpace['q'] ?? '') === 'wp slimstat', 'preserved referer decodes %20 to a space in the search term');
+
+    // ─── 2. Control: the OLD sanitize_text_field path loses the term ───────────
+    // Documents the regression mechanism this fix reverses.
+
+    $stripped = sanitize_text_field($YANDEX);
+    @parse_str((string) parse_url($stripped, PHP_URL_QUERY), $strippedVals);
+    st_assert(($strippedVals['text'] ?? '') === '', 'control: sanitize_text_field strips %XX, wiping the search term (the bug being fixed)');
+
+    // ─── 3. #306 still satisfied: android-app survives ─────────────────────────
+
+    st_assert(\SlimStat\Tracker\Ajax::sanitizeReferer($encode($ANDROID)) === $ANDROID, 'android-app:// referer still survives (issue #306)');
+
+    // ─── 4. L1: disallowed schemes are dropped at the boundary ─────────────────
+    // Covers the follow-up-event path that skips Processor's post-storage check.
+
+    st_assert(\SlimStat\Tracker\Ajax::sanitizeReferer($encode('javascript:alert(document.cookie)//')) === '', 'javascript: referer is emptied at the sanitizer (defense in depth, all paths)');
+    st_assert(\SlimStat\Tracker\Ajax::sanitizeReferer($encode('data:text/html,<b>x</b>')) === '', 'data: referer is emptied at the sanitizer');
+
+    fwrite(STDOUT, "OK: {$assertions} assertions passed (referer %XX preservation + scheme allow-list, #306 follow-up)\n");
+    exit(0);
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -60,6 +60,18 @@ function slimstat_uninstall($_wpdb = '', $_options = [])
     $GLOBALS['wpdb']->query(sprintf("DELETE FROM %susermeta WHERE meta_key LIKE '%%metaboxhidden_slimstat%%'", $GLOBALS[ 'wpdb' ]->prefix));
     $GLOBALS['wpdb']->query(sprintf("DELETE FROM %susermeta WHERE meta_key LIKE '%%closedpostboxes_slimstat%%'", $GLOBALS[ 'wpdb' ]->prefix));
 
+    // Sweep filter-options transients left behind by the dropdown cache.
+    $transient_like = $GLOBALS['wpdb']->esc_like('_transient_slimstat_fopts_') . '%';
+    $timeout_like   = $GLOBALS['wpdb']->esc_like('_transient_timeout_slimstat_fopts_') . '%';
+    $GLOBALS['wpdb']->query($GLOBALS['wpdb']->prepare(
+        "DELETE FROM {$GLOBALS['wpdb']->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+        $transient_like,
+        $timeout_like
+    ));
+    if (function_exists('wp_cache_delete_group')) {
+        wp_cache_delete_group('slimstat_filter_options');
+    }
+
     // Remove scheduled autopurge events
     wp_clear_scheduled_hook('wp_slimstat_purge');
     wp_clear_scheduled_hook('wp_slimstat_update_geoip_database');


### PR DESCRIPTION
## Summary

v5.5.0 omnibus restoring three filter/tracking regressions from the 5.4.0 cycle, plus a privacy cleanup removing the third-party FeedbackBird widget. Each fix is an isolated commit; #298 is cherry-picked verbatim from PR #299 (which this supersedes).

| # | Fix | Commit(s) |
|---|---|---|
| [#298](https://github.com/wp-slimstat/wp-slimstat/issues/298) | Access Log filter dropdown accepts pasted/typed values beyond the 500-row slice | `4e851273`, `ee775a26` (cherry-picked from PR #299) |
| [#306](https://github.com/wp-slimstat/wp-slimstat/issues/306) | `android-app://` referers (Google Discover, Android/iOS apps) preserved — were dropped by `sanitize_url()` | `b64b5ca7` |
| [#305](https://github.com/wp-slimstat/wp-slimstat/issues/305) | `is_empty` / `is_not_empty` filter operators restored on every report, survive in-session navigation | `6bc459c3` |
| Privacy | Remove third-party FeedbackBird widget that phoned home admin email + PHP version + active-plugin list with no opt-out | `47e82463` |

## #306 — android-app referers

`sanitize_url()` strips any scheme absent from `wp_allowed_protocols()`, emptying `android-app://com.google.android.googlequicksearchbox/`. Swapped both upstream call sites (`Ajax::sanitizeReferer` JS path + `Processor` server fallback) to `sanitize_text_field()`. `Storage` already used `sanitize_text_field` for the `referer` key, so the value now survives end-to-end. The host-format regex, 2048-char cap, and the `Processor` scheme allowlist (`http`/`https`/`android-app`) remain the security boundary.

## #305 — value-less filter operators

A 4-site failure (parse guard + regex + `fs_url()` removal-signal + JS form-builder), all from commit `62f0434b`. Fixed across 9 collaborating sites with `wp_slimstat_db::$valueless_operators` as the single source of truth, shared with JS via `SlimStatAdminParams`. The keystone E2E test proves the filter survives in-session navigation (date-range change), which the prior bug stripped.

## Privacy — remove FeedbackBird widget

The admin "Feedback" widget (`initFeedback()` in `admin/index.php`) loaded a script from a public CDN (`cdn.jsdelivr.net/gh/feedbackbird/assets@master/wp/app.js`) on every report page and, via the inline `feedbackBirdObject` global, shipped the current admin's **email address**, **PHP version**, and a **full list of active plugins (names + versions)** off-site — with no setting, no consent, and no opt-out. That conflicts with SlimStat's own "no external calls without user opt-in" stance.

A later header redesign had already hidden the button with `display: none !important`, so the script still phoned home while showing nothing — pure downside. This removes the loader entirely, drops the now-dead CSS (keeping the unrelated `#contextual-help-link-wrap` hide rule it was grouped with), and adds a regression test so it can't quietly return.

## Tests

- **Unit (PHPUnit):** `AjaxRefererSanitizationTest` (6), `ParseFiltersTest` (12). Full suite: 180 pass locally on PHP 8.2.
- **Integration:** `referer-android-app-storage-test.php` (5 assertions), wired into `composer test:all`.
- **E2E (Playwright):** `referer-android-app.spec.ts` (3), `realtime-filter-is-not-empty.spec.ts` (5), `filter-ip-beyond-500-limit.spec.ts` (cherry-picked, #298), `feedbackbird-removed.spec.ts` (1 — asserts no feedbackbird request fires and `window.feedbackBirdObject` is undefined on a report page).

## Closes

Closes #298, #305, #306. Supersedes #299.

## Source

Support threads: dxylott54 (wp.org) for #298 + #306; lulupont (wp.org) for #305.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-backed searchable filter dropdowns that accept typed/pasted values, show a clear "no matches" state with Apply, and restore initial options after clearing.

* **Bug Fixes**
  * Restored preservation of android-app:// referers.
  * Re-enabled "is empty"/"is not empty" filters with persistence across pagination/date-range changes.
  * Access Log filter now finds values beyond the prior 500-row cap.

* **Tests**
  * Added unit, integration, and E2E regressions covering filters, referer sanitization/encoding, caching, and searchable-dropdown UX.

* **Documentation**
  * Changelog updated with Filters & traffic sources notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
