### PR TITLE
fix(goals-funnels): funnels now respect active report filters & date range

### DIFF
--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -1134,6 +1134,40 @@ jQuery(function () {
     // Expose for use by other scripts (e.g., goals-funnels.js)
     window.SlimStatGetTimeRangeForAjax = getTimeRangeForAjax;
 
+    /**
+     * Collect the active global report filters (the hidden fs[...] inputs) for an
+     * AJAX request, mirroring how refresh_report() harvests them, so a sub-report
+     * loaded out-of-band (e.g. a lazily-loaded funnel tab) honors the same filters
+     * as the rest of the page. The DATE/window filters are stripped — callers that
+     * need the date pass it separately (the time_range and gf_utime params); funnels
+     * pin the window verbatim, so re-sending the date here would only risk a mismatch.
+     * Returns a plain object { "fs[browser]": "equals firefox", ... }.
+     */
+    function getFiltersForAjax() {
+        // Date + pagination/meta keys are sent via dedicated params, not as column
+        // filters. Source the skip-list from the server's canonical
+        // NON_COLUMN_FILTER_KEYS (localized) so it never drifts from parse_filters().
+        var nonColumn = SlimStatAdminParams.non_column_filter_keys || [
+            "strtotime", "minute", "hour", "day", "month", "year",
+            "interval", "interval_hours", "interval_minutes", "limit_results", "start_from"
+        ];
+        var skip = {};
+        for (var k = 0; k < nonColumn.length; k++) {
+            skip["fs[" + nonColumn[k] + "]"] = 1;
+        }
+        var out = {};
+        var inputs = jQuery("#slimstat-filters-form .slimstat-post-filter").toArray();
+        for (var i in inputs) {
+            var name = inputs[i]["name"];
+            if (!name || skip[name]) continue;
+            out[name] = inputs[i]["value"];
+        }
+        return out;
+    }
+
+    // Expose for use by other scripts (e.g., goals-funnels.js)
+    window.SlimStatGetFiltersForAjax = getFiltersForAjax;
+
     // Handle dimension change to load filter options dynamically
     jQuery("#slimstat-filter-name").on("change", function () {
         var dimension = jQuery(this).val();

--- a/admin/assets/js/goals-funnels.js
+++ b/admin/assets/js/goals-funnels.js
@@ -762,6 +762,12 @@
         var loadRange = (typeof window.SlimStatGetTimeRangeForAjax === 'function')
             ? window.SlimStatGetTimeRangeForAjax() : {};
 
+        // Send the active global report filters too, so a lazily-loaded funnel tab
+        // honors the same filters as the server-rendered first funnel and as Goals.
+        // init() ingests these from $_REQUEST['fs'] on the AJAX side. (#22)
+        var loadFilters = (typeof window.SlimStatGetFiltersForAjax === 'function')
+            ? window.SlimStatGetFiltersForAjax() : {};
+
         funnelInflight[funnelId] = post($.extend({
             action:          'slimstat_load_funnel_data',
             security:        nonce,
@@ -769,7 +775,7 @@
             time_range_type: loadRange.type || '',
             time_range_from: loadRange.from || '',
             time_range_to:   loadRange.to   || ''
-        }, pinnedRange()), function (data) {
+        }, pinnedRange(), loadFilters), function (data) {
             if (!$panel.hasClass('is-active')) return;
             $panel.attr('data-loaded', 'true');
             $panel.find('.slimstat-gf-funnel-panel__meta').html(renderFunnelSummary(data.summary));

--- a/admin/index.php
+++ b/admin/index.php
@@ -1176,6 +1176,11 @@ class wp_slimstat_admin
             // Guarded: this method also runs on the Dashboard-widget path, where
             // wp_slimstat_db may not be included — fall back to the literal list.
             'valueless_operators' => class_exists('wp_slimstat_db') ? wp_slimstat_db::$valueless_operators : ['is_empty', 'is_not_empty'],
+            // Canonical date/misc filter keys, shared with SlimStatGetFiltersForAjax() so it
+            // strips the same non-column keys when harvesting filters for a sub-report (#22).
+            'non_column_filter_keys' => class_exists('wp_slimstat_db')
+                ? wp_slimstat_db::NON_COLUMN_FILTER_KEYS
+                : ['strtotime', 'minute', 'hour', 'day', 'month', 'year', 'interval', 'interval_hours', 'interval_minutes', 'limit_results', 'start_from'],
             // WP-locale number separators so JS-rendered (lazily-loaded) funnel tabs
             // match the server's number_format_i18n() output instead of the browser
             // locale's toLocaleString().

--- a/admin/view/wp-slimstat-db.php
+++ b/admin/view/wp-slimstat-db.php
@@ -20,7 +20,9 @@ class wp_slimstat_db
     // column. A value-less operator (is_empty/is_not_empty) is meaningless for these and
     // must not reach the switch without a value — those branches dereference $a_filter[3]
     // and would emit an "Undefined array key 3" warning on a crafted request. See #305.
-    private const NON_COLUMN_FILTER_KEYS = [
+    // Public + shared with the JS layer (via SlimStatAdminParams) so SlimStatGetFiltersForAjax()
+    // strips the same date/misc keys when harvesting column filters for a sub-report. (#22)
+    public const NON_COLUMN_FILTER_KEYS = [
         'strtotime', 'minute', 'hour', 'day', 'month', 'year',
         'interval', 'interval_hours', 'interval_minutes', 'limit_results', 'start_from',
     ];
@@ -1878,28 +1880,56 @@ class wp_slimstat_db
     }
 
     /**
+     * Signature of the active global column filters, for the funnel cache key.
+     *
+     * Derived from the NORMALIZED filter array ([col => [operator, value]]), NOT
+     * from get_combined_where()'s SQL: that SQL is run through $wpdb->prepare(),
+     * whose per-request placeholder salt would make the signature unstable and
+     * re-split a server-rendered funnel from its AJAX-loaded twin (the very #1
+     * symptom). Serializing the normalized array is request-stable by construction
+     * and mirrors normalize_funnel_steps(). An empty/absent filter set hashes to a
+     * fixed baseline so an unfiltered render is a stable key. (#22)
+     *
+     * @return string
+     */
+    private static function funnel_filters_signature()
+    {
+        return md5(serialize(self::$filters_normalized['columns'] ?? []));
+    }
+
+    /**
      * Build the funnel-result cache key: normalized step signature + the date
-     * window bucketed to the hour + cache version. Bucketing the end (which is
-     * "now" for a live range, set with second precision) to the hour absorbs the
-     * sub-hour drift between a server-rendered funnel and its AJAX-loaded twin, so
-     * two identical funnels share one transient and return identical numbers. (#1)
+     * window bucketed to the hour + the active column-filter signature + cache
+     * version. Bucketing the end (which is "now" for a live range, set with second
+     * precision) to the hour absorbs the sub-hour drift between a server-rendered
+     * funnel and its AJAX-loaded twin, so two identical funnels share one transient
+     * and return identical numbers. (#1)
      * (A render pair straddling an hour boundary can still miss — a rare, ~few-second
      * window that self-heals on the next render; acceptable given the 5-min TTL.)
+     *
+     * $filters_sig folds the active global filters into the key so toggling a report
+     * filter (e.g. "browser equals X") yields a new key instead of serving the stale
+     * unfiltered transient — the funnel equivalent of how Goals key on the filter
+     * WHERE. The date is intentionally NOT in $filters_sig (it lives in $range,
+     * hour-bucketed); only the COLUMN filters are, so the SSR/AJAX drift fix stands.
+     * The sig folds into the trailing md5 so the "slimstat_funnel_" prefix that
+     * clear_goals_cache() sweeps with a LIKE is preserved. (#22)
      *
      * @param array      $steps
      * @param int        $range_start utime range start (seconds)
      * @param int        $range_end   utime range end (seconds)
+     * @param string     $filters_sig column-filter signature (funnel_filters_signature())
      * @param int|string $cache_ver
      * @return string
      */
-    private static function funnel_cache_key($steps, $range_start, $range_end, $cache_ver)
+    private static function funnel_cache_key($steps, $range_start, $range_end, $filters_sig, $cache_ver)
     {
         // 3600 = bucket the window end to the hour (mirrors the hour-bucketing in
         // wp_slimstat_admin::build_filter_options_cache_key()).
         $range = (int) $range_start . ':' . (int) floor((int) $range_end / 3600);
 
         return 'slimstat_funnel_' . md5(serialize(self::normalize_funnel_steps($steps)))
-            . '_' . md5($range . '|' . $cache_ver);
+            . '_' . md5($range . '|' . $filters_sig . '|' . $cache_ver);
     }
 
     /**
@@ -1919,14 +1949,17 @@ class wp_slimstat_db
         }
 
         $cache_ver = get_option('slimstat_goals_cache_ver', '0');
-        // Deterministic key: normalized step signature + hour-bucketed date window
-        // (NOT the funnel id, NOT the raw $date_where SQL) — so two identical funnels,
-        // and a server-rendered funnel + its AJAX twin, share one transient. See
-        // funnel_cache_key(). (#1, builds on #19)
+        // Deterministic key: normalized step signature + hour-bucketed date window +
+        // active column-filter signature (NOT the funnel id, NOT the raw $date_where
+        // SQL) — so two identical funnels, and a server-rendered funnel + its AJAX
+        // twin, share one transient, while a change to the global report filters
+        // rotates the key instead of serving a stale unfiltered result. See
+        // funnel_cache_key() / funnel_filters_signature(). (#1, #22, builds on #19)
         $cache_key = self::funnel_cache_key(
             $funnel['steps'],
             (int) (self::$filters_normalized['utime']['start'] ?? 0),
             (int) (self::$filters_normalized['utime']['end'] ?? 0),
+            self::funnel_filters_signature(),
             $cache_ver
         );
 

--- a/tests/Integration/GoalsFunnelsFilterPassthroughTest.php
+++ b/tests/Integration/GoalsFunnelsFilterPassthroughTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WpSlimstat\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression guard: funnels must honor the active global report filters, not just
+ * the date range (#22).
+ *
+ * Two defects made funnels ignore filters that Goals respected:
+ *   A) the funnel cache key omitted the column-filter signature, so toggling a
+ *      filter served the stale unfiltered transient;
+ *   B) the lazily-loaded (non-first) funnel tab never POSTed the active fs[...]
+ *      filters, so its AJAX request computed unfiltered.
+ *
+ * The fix folds funnel_filters_signature() into funnel_cache_key(), exposes a
+ * reusable SlimStatGetFiltersForAjax() in admin.js, and posts those filters on
+ * funnel-load. The per-step "Test" affordance is deliberately left unfiltered
+ * (it validates a raw rule while building).
+ *
+ * Source-shape test (mirrors GoalsFunnelsAjaxInitTest) — no live MySQL.
+ */
+class GoalsFunnelsFilterPassthroughTest extends TestCase
+{
+    private function read(string $relpath): string
+    {
+        $contents = (string) file_get_contents(dirname(__DIR__, 2) . '/' . $relpath);
+        if ($contents === '') {
+            $this->fail("Could not read {$relpath}");
+        }
+        return $contents;
+    }
+
+    public function test_cache_key_includes_a_filter_signature_argument(): void
+    {
+        $db = $this->read('admin/view/wp-slimstat-db.php');
+
+        // The key builder must accept and fold in a column-filter signature.
+        $this->assertMatchesRegularExpression(
+            '/function funnel_cache_key\([^)]*\$filters_sig[^)]*\)/',
+            $db,
+            'funnel_cache_key() must take a $filters_sig argument'
+        );
+        $this->assertStringContainsString(
+            'function funnel_filters_signature(',
+            $db,
+            'A funnel_filters_signature() helper must exist'
+        );
+
+        // The signature must derive from the NORMALIZED filter array, never from the
+        // prepared get_combined_where() SQL (whose $wpdb->prepare salt is unstable).
+        $this->assertMatchesRegularExpression(
+            "/funnel_filters_signature\(\)\s*\{[\s\S]*?serialize\(self::\\\$filters_normalized\['columns'\]/",
+            $db,
+            'funnel_filters_signature() must serialize $filters_normalized[columns], not the prepared SQL'
+        );
+
+        // get_funnel_results() must feed the signature into the key.
+        $this->assertStringContainsString(
+            'self::funnel_filters_signature()',
+            $db,
+            'get_funnel_results() must pass the filter signature into the cache key'
+        );
+    }
+
+    public function test_admin_js_exposes_a_filter_getter_that_skips_date_keys(): void
+    {
+        $js = $this->read('admin/assets/js/admin.js');
+
+        $this->assertStringContainsString(
+            'window.SlimStatGetFiltersForAjax',
+            $js,
+            'admin.js must expose SlimStatGetFiltersForAjax for other scripts'
+        );
+        $this->assertStringContainsString(
+            '.slimstat-post-filter',
+            $js,
+            'The getter must harvest the hidden .slimstat-post-filter inputs'
+        );
+        // Date/window keys must be excluded — sourced from the server's canonical
+        // NON_COLUMN_FILTER_KEYS (localized) so the skip-list never drifts.
+        $this->assertStringContainsString(
+            'non_column_filter_keys',
+            $js,
+            'The getter must source its skip-list from the localized NON_COLUMN_FILTER_KEYS'
+        );
+
+        // And the server must localize that canonical list for the JS layer.
+        $admin = $this->read('admin/index.php');
+        $this->assertStringContainsString(
+            "'non_column_filter_keys'",
+            $admin,
+            'admin/index.php must localize non_column_filter_keys into SlimStatAdminParams'
+        );
+        $this->assertStringContainsString(
+            'wp_slimstat_db::NON_COLUMN_FILTER_KEYS',
+            $admin,
+            'The localized list must come from the canonical NON_COLUMN_FILTER_KEYS constant'
+        );
+    }
+
+    public function test_funnel_load_posts_the_active_filters(): void
+    {
+        $js = $this->read('admin/assets/js/goals-funnels.js');
+
+        // The merged var must derive from the reusable getter...
+        $this->assertMatchesRegularExpression(
+            '/loadFilters\s*=\s*\(typeof window\.SlimStatGetFiltersForAjax/',
+            $js,
+            'goals-funnels.js must source the active filters from SlimStatGetFiltersForAjax'
+        );
+        // ...and be merged into the funnel lazy-load POST body.
+        $this->assertMatchesRegularExpression(
+            '/slimstat_load_funnel_data[\s\S]{0,400}loadFilters/',
+            $js,
+            'The funnel lazy-load request must merge the active global filters (loadFilters)'
+        );
+    }
+
+    public function test_test_step_is_deliberately_left_unfiltered(): void
+    {
+        $js = $this->read('admin/assets/js/goals-funnels.js');
+
+        // Scope decision: the per-step "Test" validates a raw rule while building,
+        // so it must NOT inherit the page's active report filters.
+        if (!preg_match('/slimstat_test_funnel_step[\s\S]{0,400}/', $js, $m)) {
+            $this->fail('Could not locate the slimstat_test_funnel_step request');
+        }
+        $this->assertStringNotContainsString(
+            'SlimStatGetFiltersForAjax',
+            $m[0],
+            'The funnel-step Test must stay unfiltered (raw-rule validation)'
+        );
+    }
+}

--- a/tests/Unit/FunnelCacheKeyTest.php
+++ b/tests/Unit/FunnelCacheKeyTest.php
@@ -12,6 +12,12 @@
  *   - a new hour bucket / different start / cache-version bump → a new key;
  *   - the key is the normalized step signature (order-sensitive), never the funnel id.
  *
+ * It ALSO folds in a column-filter signature, so toggling a global report filter
+ * (e.g. "browser equals X") produces a new key instead of serving the stale,
+ * unfiltered transient — the funnel equivalent of how Goals key on the filter
+ * WHERE. The signature participates WITHOUT disturbing the "slimstat_funnel_"
+ * prefix that clear_goals_cache() sweeps with a LIKE.
+ *
  * @package WpSlimstat
  * @license GPL-2.0-or-later
  */
@@ -28,6 +34,9 @@ class FunnelCacheKeyTest extends WpSlimstatTestCase
         ['dimension' => 'resource', 'operator' => 'contains', 'value' => '/pricing'],
     ];
 
+    /** Empty-filter signature — the "no global filter applied" baseline. */
+    private const NO_FILTERS = 'd751713988987e9331980363e24189ce'; // md5(serialize([]))
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -37,11 +46,11 @@ class FunnelCacheKeyTest extends WpSlimstatTestCase
     }
 
     /** Invoke the private static helper via reflection. */
-    private static function key(array $steps, int $start, int $end, $cacheVer): string
+    private static function key(array $steps, int $start, int $end, string $filtersSig, $cacheVer): string
     {
         $m = new \ReflectionMethod(\wp_slimstat_db::class, 'funnel_cache_key');
         $m->setAccessible(true);
-        return $m->invoke(null, $steps, $start, $end, $cacheVer);
+        return $m->invoke(null, $steps, $start, $end, $filtersSig, $cacheVer);
     }
 
     /** @test */
@@ -49,8 +58,8 @@ class FunnelCacheKeyTest extends WpSlimstatTestCase
     {
         // The exact bug: SSR computes end = T, the AJAX twin computes end = T + a few
         // seconds. Same hour bucket → same key → the twin reuses the SSR result.
-        $a = self::key(self::$steps, 1000, 1718900000, '0');
-        $b = self::key(self::$steps, 1000, 1718900005, '0');
+        $a = self::key(self::$steps, 1000, 1718900000, self::NO_FILTERS, '0');
+        $b = self::key(self::$steps, 1000, 1718900005, self::NO_FILTERS, '0');
         $this->assertSame($a, $b, 'Two ends within the same hour must share one cache key');
         $this->assertStringStartsWith('slimstat_funnel_', $a);
     }
@@ -58,37 +67,71 @@ class FunnelCacheKeyTest extends WpSlimstatTestCase
     /** @test */
     public function test_a_new_hour_bucket_changes_the_key(): void
     {
-        $base = self::key(self::$steps, 1000, 1718900000, '0');
-        $nextHour = self::key(self::$steps, 1000, 1718900000 + 3600, '0');
+        $base = self::key(self::$steps, 1000, 1718900000, self::NO_FILTERS, '0');
+        $nextHour = self::key(self::$steps, 1000, 1718900000 + 3600, self::NO_FILTERS, '0');
         $this->assertNotSame($base, $nextHour, 'Crossing the hour bucket must produce a new key');
     }
 
     /** @test */
     public function test_start_and_cache_version_participate_in_the_key(): void
     {
-        $base = self::key(self::$steps, 1000, 1718900000, '0');
-        $this->assertNotSame($base, self::key(self::$steps, 2000, 1718900000, '0'), 'A different start must change the key');
-        $this->assertNotSame($base, self::key(self::$steps, 1000, 1718900000, '1'), 'A cache-version bump must change the key');
+        $base = self::key(self::$steps, 1000, 1718900000, self::NO_FILTERS, '0');
+        $this->assertNotSame($base, self::key(self::$steps, 2000, 1718900000, self::NO_FILTERS, '0'), 'A different start must change the key');
+        $this->assertNotSame($base, self::key(self::$steps, 1000, 1718900000, self::NO_FILTERS, '1'), 'A cache-version bump must change the key');
     }
 
     /** @test */
     public function test_key_is_step_signature_order_sensitive_and_id_independent(): void
     {
-        $base = self::key(self::$steps, 1000, 1718900000, '0');
+        $base = self::key(self::$steps, 1000, 1718900000, self::NO_FILTERS, '0');
 
         // Different rules → different key.
-        $this->assertNotSame($base, self::key([self::$steps[0]], 1000, 1718900000, '0'), 'Different steps must change the key');
+        $this->assertNotSame($base, self::key([self::$steps[0]], 1000, 1718900000, self::NO_FILTERS, '0'), 'Different steps must change the key');
 
         // A->B is not B->A: step order is significant.
         $reversed = array_reverse(self::$steps);
-        $this->assertNotSame($base, self::key($reversed, 1000, 1718900000, '0'), 'Reversed step order must change the key');
+        $this->assertNotSame($base, self::key($reversed, 1000, 1718900000, self::NO_FILTERS, '0'), 'Reversed step order must change the key');
 
-        // Only step rules + window feed the key — the funnel id is never an input, so two
-        // funnels with identical steps collide on purpose (the #19 contract preserved).
+        // Only step rules + window + filters feed the key — the funnel id is never an
+        // input, so two funnels with identical steps collide on purpose (#19 contract).
         $sameRulesDifferentLabels = [
             ['dimension' => 'resource', 'operator' => 'contains', 'value' => '/', 'name' => 'Home A'],
             ['dimension' => 'resource', 'operator' => 'contains', 'value' => '/pricing', 'name' => 'Pricing A'],
         ];
-        $this->assertSame($base, self::key($sameRulesDifferentLabels, 1000, 1718900000, '0'), 'Per-step labels must not affect the key');
+        $this->assertSame($base, self::key($sameRulesDifferentLabels, 1000, 1718900000, self::NO_FILTERS, '0'), 'Per-step labels must not affect the key');
+    }
+
+    /** @test */
+    public function test_column_filter_signature_participates_in_the_key(): void
+    {
+        // The funnel-filter bug: same steps + same window, but a different active
+        // report filter MUST produce a different key (otherwise a stale unfiltered
+        // transient is served). And the same filter must reuse the key.
+        $unfiltered = self::key(self::$steps, 1000, 1718900000, self::NO_FILTERS, '0');
+        $filteredA  = self::key(self::$steps, 1000, 1718900000, md5('browser=firefox'), '0');
+        $filteredB  = self::key(self::$steps, 1000, 1718900000, md5('browser=chrome'), '0');
+
+        $this->assertNotSame($unfiltered, $filteredA, 'Applying a column filter must change the key');
+        $this->assertNotSame($filteredA, $filteredB, 'Different column filters must produce different keys');
+        $this->assertSame($filteredA, self::key(self::$steps, 1000, 1718900000, md5('browser=firefox'), '0'), 'The same filter must reuse the key');
+    }
+
+    /** @test */
+    public function test_filter_signature_differs_within_the_same_hour_bucket(): void
+    {
+        // Guards that the filter sig is not swallowed by the hour-bucketing: same
+        // steps, same start, ends in the SAME hour bucket, different filters → keys differ.
+        $a = self::key(self::$steps, 1000, 1718900000, md5('browser=firefox'), '0');
+        $b = self::key(self::$steps, 1000, 1718900005, md5('browser=chrome'), '0');
+        $this->assertNotSame($a, $b, 'Different filters in the same hour bucket must still differ');
+    }
+
+    /** @test */
+    public function test_filtered_key_keeps_the_gc_prefix(): void
+    {
+        // clear_goals_cache() sweeps transients with LIKE 'slimstat_funnel_%'.
+        // The filter sig folds into the trailing md5 term, so the prefix is preserved.
+        $filtered = self::key(self::$steps, 1000, 1718900000, md5('browser=firefox'), '0');
+        $this->assertStringStartsWith('slimstat_funnel_', $filtered);
     }
 }

--- a/tests/Unit/FunnelFiltersSignatureTest.php
+++ b/tests/Unit/FunnelFiltersSignatureTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Guards wp_slimstat_db::funnel_filters_signature() — the column-filter component
+ * of the funnel cache key.
+ *
+ * The signature MUST be derived from the NORMALIZED filter array
+ * (self::$filters_normalized['columns']), never from get_combined_where()'s SQL:
+ * that SQL is run through $wpdb->prepare(), whose per-request placeholder salt
+ * would make the signature non-deterministic and re-split a server-rendered funnel
+ * from its AJAX-loaded twin (the very #1 symptom the cache key exists to prevent).
+ * Serializing the [col => [operator, value]] array is request-stable by construction.
+ *
+ * @package WpSlimstat
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace WpSlimstat\Tests\Unit;
+
+class FunnelFiltersSignatureTest extends WpSlimstatTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!class_exists('wp_slimstat_db', false)) {
+            require_once dirname(__DIR__, 2) . '/admin/view/wp-slimstat-db.php';
+        }
+        \wp_slimstat_db::$filters_normalized = [];
+    }
+
+    protected function tearDown(): void
+    {
+        \wp_slimstat_db::$filters_normalized = [];
+        parent::tearDown();
+    }
+
+    private static function sig(): string
+    {
+        $m = new \ReflectionMethod(\wp_slimstat_db::class, 'funnel_filters_signature');
+        $m->setAccessible(true);
+        return $m->invoke(null);
+    }
+
+    /** @test */
+    public function test_empty_filters_produce_a_stable_baseline_hash(): void
+    {
+        \wp_slimstat_db::$filters_normalized = ['columns' => []];
+        $this->assertSame(md5(serialize([])), self::sig(), 'No column filters must hash to the empty-array baseline');
+
+        // Missing 'columns' key entirely must not warn and must match the baseline.
+        \wp_slimstat_db::$filters_normalized = [];
+        $this->assertSame(md5(serialize([])), self::sig(), 'A missing columns key must be treated as no filters');
+    }
+
+    /** @test */
+    public function test_signature_is_stable_across_calls(): void
+    {
+        \wp_slimstat_db::$filters_normalized = ['columns' => ['browser' => ['equals', 'firefox']]];
+        $first  = self::sig();
+        $second = self::sig();
+        $this->assertSame($first, $second, 'The same normalized filters must hash identically across calls');
+    }
+
+    /** @test */
+    public function test_different_filter_values_produce_different_signatures(): void
+    {
+        \wp_slimstat_db::$filters_normalized = ['columns' => ['browser' => ['equals', 'firefox']]];
+        $firefox = self::sig();
+
+        \wp_slimstat_db::$filters_normalized = ['columns' => ['browser' => ['equals', 'chrome']]];
+        $chrome = self::sig();
+
+        $this->assertNotSame($firefox, $chrome, 'A different filter value must change the signature');
+    }
+
+    /** @test */
+    public function test_different_columns_and_operators_change_the_signature(): void
+    {
+        \wp_slimstat_db::$filters_normalized = ['columns' => ['browser' => ['equals', 'firefox']]];
+        $base = self::sig();
+
+        \wp_slimstat_db::$filters_normalized = ['columns' => ['country' => ['equals', 'firefox']]];
+        $this->assertNotSame($base, self::sig(), 'A different column must change the signature');
+
+        \wp_slimstat_db::$filters_normalized = ['columns' => ['browser' => ['contains', 'firefox']]];
+        $this->assertNotSame($base, self::sig(), 'A different operator must change the signature');
+
+        // Adding a second filter must change the signature too.
+        \wp_slimstat_db::$filters_normalized = ['columns' => ['browser' => ['equals', 'firefox'], 'country' => ['equals', 'us']]];
+        $this->assertNotSame($base, self::sig(), 'Adding a second filter must change the signature');
+    }
+}

--- a/tests/e2e/goals-funnels-filters.spec.ts
+++ b/tests/e2e/goals-funnels-filters.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Goals & Funnels — funnels must respect the active global report filters (#22).
+ *
+ * The bug: a funnel kept showing data even when a global filter (e.g.
+ * "browser equals X") matched nothing, because (A) the funnel cache key omitted
+ * the column-filter signature — so toggling a filter served the stale unfiltered
+ * transient — and (B) the lazily-loaded funnel tab never POSTed the active
+ * fs[...] filters. Goals already respected filters; funnels now do too.
+ *
+ * Strategy: seed Firefox + Chrome visitors through a 2-step funnel, then drive
+ * slimview6 with fs[browser]=... in the URL ($_REQUEST['fs'], honored by init()
+ * on both the SSR render and the AJAX tab load).
+ *
+ *   1. Keystone three-phase: unfiltered → filtered (counts CHANGE, not stale) →
+ *      unfiltered (full counts restored). This is the exact stale-cache failure.
+ *   2. No-match filter: the first/SSR funnel AND a 2nd/AJAX-loaded funnel both
+ *      show the "no visitors matched" state.
+ *   3. Positive control: a real filter narrows the funnel to exactly the matching
+ *      segment (Firefox), strictly fewer than the unfiltered total.
+ */
+import { test, expect, Page, Locator } from '@playwright/test';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { BASE_URL, WP_ROOT } from './helpers/env';
+import { closeDb, clearStatsTable, getPool } from './helpers/setup';
+import {
+    seedFunnels,
+    seedStats,
+    clearAll,
+    forceLimits,
+    restoreDefaultLimits,
+} from './helpers/goals-funnels';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const WP_CONTENT = path.join(WP_ROOT, 'wp-content');
+
+const SLIMVIEW6 = `${BASE_URL}/wp-admin/admin.php?page=slimview6`;
+const ago = (s: number) => Math.floor(Date.now() / 1000) - s;
+
+const STEPS = [
+    { name: 'Home',    dimension: 'resource', operator: 'contains', value: '/' },
+    { name: 'Pricing', dimension: 'resource', operator: 'contains', value: '/pricing' },
+];
+
+/**
+ * Firefox: ff1 + ff2 complete (/ → /pricing), ff3 stops at '/'.  → FF step1=3, step2=2
+ * Chrome:  ch1 completes.                                        → Chrome step1=1, step2=1
+ * Unfiltered totals: step1 = 4, step2 = 3.
+ */
+async function seedBrowserFunnelData(): Promise<void> {
+    await clearStatsTable();
+    await seedStats([
+        { resource: '/',        fingerprint: 'ff-1', browser: 'Firefox', dt: ago(300) },
+        { resource: '/pricing', fingerprint: 'ff-1', browser: 'Firefox', dt: ago(240) },
+        { resource: '/',        fingerprint: 'ff-2', browser: 'Firefox', dt: ago(220) },
+        { resource: '/pricing', fingerprint: 'ff-2', browser: 'Firefox', dt: ago(180) },
+        { resource: '/',        fingerprint: 'ff-3', browser: 'Firefox', dt: ago(160) },
+        { resource: '/',        fingerprint: 'ch-1', browser: 'Chrome',  dt: ago(140) },
+        { resource: '/pricing', fingerprint: 'ch-1', browser: 'Chrome',  dt: ago(100) },
+    ]);
+}
+
+async function gotoSlimview6(page: Page, query = ''): Promise<void> {
+    await page.goto(SLIMVIEW6 + query, { waitUntil: 'domcontentloaded' });
+}
+
+/** First step's unique-visitor count from a funnel panel (text is "N (P%)"). */
+async function firstStepCount(panel: Locator): Promise<number> {
+    const txt = await panel.locator('.slimstat-gf-step__count').first().innerText();
+    const m = txt.replace(/\s+/g, ' ').match(/\d[\d,]*/);
+    expect(m, `could not parse a step count from "${txt}"`).not.toBeNull();
+    return parseInt((m as RegExpMatchArray)[0].replace(/,/g, ''), 10);
+}
+
+test.describe('Funnels respect global report filters (#22)', () => {
+    test.setTimeout(60_000);
+
+    test.beforeEach(async () => {
+        await clearAll();
+        await forceLimits(5, 3, WP_CONTENT);
+    });
+
+    test.afterAll(async () => {
+        await restoreDefaultLimits(WP_CONTENT);
+        await clearStatsTable();
+        await clearAll();
+        await closeDb();
+    });
+
+    test('keystone: apply filter changes counts (not stale), removing it restores them', async ({ page }) => {
+        await seedBrowserFunnelData();
+        await seedFunnels([{ name: 'Home → Pricing', steps: STEPS }]);
+
+        const panel = () => page.locator('.slimstat-gf-funnel-panel[data-funnel-index="0"]');
+
+        // Phase 1 — unfiltered: all 4 visitors reach step 1.
+        await gotoSlimview6(page);
+        await expect(panel().locator('.slimstat-gf-step__count').first()).toBeVisible();
+        const unfiltered = await firstStepCount(panel());
+        expect(unfiltered).toBe(4);
+
+        // Phase 2 — browser=Firefox: only the 3 Firefox visitors remain. Same window,
+        // same steps — before the fix this returned the stale unfiltered 4.
+        await gotoSlimview6(page, '&fs%5Bbrowser%5D=equals+Firefox');
+        await expect(panel().locator('.slimstat-gf-step__count').first()).toBeVisible();
+        const filtered = await firstStepCount(panel());
+        expect(filtered).toBe(3);
+        expect(filtered).toBeLessThan(unfiltered);
+
+        // Phase 3 — filter removed: full counts restored (not stuck on the filtered value).
+        await gotoSlimview6(page);
+        await expect(panel().locator('.slimstat-gf-step__count').first()).toBeVisible();
+        expect(await firstStepCount(panel())).toBe(unfiltered);
+    });
+
+    test('no-match filter empties both the SSR funnel and an AJAX-loaded funnel', async ({ page }) => {
+        await seedBrowserFunnelData();
+        // Two funnels → a 2nd tab that lazy-loads via AJAX.
+        await seedFunnels([
+            { name: 'Funnel A', steps: STEPS },
+            { name: 'Funnel B', steps: STEPS.map(s => ({ ...s, name: `${s.name} (B)` })) },
+        ]);
+
+        await gotoSlimview6(page, '&fs%5Bbrowser%5D=equals+ZzNoSuchBrowser');
+
+        // Funnel A (server-rendered) honors the filter via the filter-aware cache key.
+        const panelA = page.locator('.slimstat-gf-funnel-panel[data-funnel-index="0"]');
+        await expect(panelA.locator('.slimstat-gf-summary--empty')).toBeVisible();
+
+        // Funnel B loads via AJAX on tab switch and must honor the same filter.
+        await page.locator('.slimstat-gf-tab[data-funnel-index="1"]').click();
+        const panelB = page.locator('.slimstat-gf-funnel-panel[data-funnel-index="1"]');
+        await expect(panelB).toBeVisible();
+        await expect(panelB.locator('.slimstat-gf-summary--empty')).toBeVisible({ timeout: 10_000 });
+    });
+
+    test('positive control: a matching filter narrows the funnel to that segment', async ({ page }) => {
+        await seedBrowserFunnelData();
+        await seedFunnels([{ name: 'Home → Pricing', steps: STEPS }]);
+
+        await gotoSlimview6(page, '&fs%5Bbrowser%5D=equals+Firefox');
+        const panel = page.locator('.slimstat-gf-funnel-panel[data-funnel-index="0"]');
+        await expect(panel.locator('.slimstat-gf-step__count').first()).toBeVisible();
+
+        // Exactly the 3 Firefox visitors at step 1 (Chrome's visitor is filtered out).
+        const counts = (await panel.locator('.slimstat-gf-step__count').allInnerTexts())
+            .map(t => parseInt(t.replace(/\s+/g, ' ').replace(/[, ].*$/, ''), 10));
+        expect(counts[0]).toBe(3);
+        expect(counts[1]).toBe(2);
+    });
+});

--- a/tests/e2e/helpers/goals-funnels.ts
+++ b/tests/e2e/helpers/goals-funnels.ts
@@ -83,6 +83,8 @@ export interface StatRow {
     fingerprint?: string;
     ip?: string;
     country?: string;
+    /** Browser column — lets a test exercise the global "browser equals X" filter. */
+    browser?: string;
     /** Unix seconds; defaults to now. Earlier steps need an earlier/equal dt. */
     dt?: number;
 }
@@ -90,6 +92,8 @@ export interface StatRow {
 /**
  * Insert raw pageview rows into wp_slim_stats so funnel/goal counts are non-zero
  * (otherwise an "identical funnels match" assertion trivially passes on 0 == 0).
+ * Columns are built per-row so optional dimensions (e.g. browser) only appear when
+ * provided — preserving the previous default-only shape for existing callers.
  * Guarded by assertSafeTestDatabase() — this writes to the stats table and must
  * never run against a real site DB.
  */
@@ -101,9 +105,22 @@ export async function seedStats(rows: StatRow[]): Promise<void> {
     const pool = getPool();
     const now = Math.floor(Date.now() / 1000);
     for (const r of rows) {
+        const row: Record<string, string | number | null> = {
+            resource:    r.resource,
+            fingerprint: r.fingerprint ?? null,
+            ip:          r.ip ?? '127.0.0.1',
+            country:     r.country ?? null,
+            dt:          r.dt ?? now,
+            visit_id:    0,
+        };
+        if (r.browser !== undefined) {
+            row.browser = r.browser;
+        }
+        const cols = Object.keys(row);
+        const placeholders = cols.map(() => '?').join(', ');
         await pool.execute(
-            'INSERT INTO wp_slim_stats (resource, fingerprint, ip, country, dt, visit_id) VALUES (?, ?, ?, ?, ?, 0)',
-            [r.resource, r.fingerprint ?? null, r.ip ?? '127.0.0.1', r.country ?? null, r.dt ?? now],
+            `INSERT INTO wp_slim_stats (${cols.join(', ')}) VALUES (${placeholders})`,
+            Object.values(row),
         );
     }
 }


### PR DESCRIPTION
## Problem

Funnels ignored the active **global report filters** (e.g. `browser equals X`) that Goals already respected. Reproduction: applying `browser equals ducducgo` (matches nothing) with the range set to **Today** still rendered a funnel with 169 → 31 visitors instead of "no matching visitors".

## Root cause (two linked defects)

- **A — cache key omitted the column-filter signature.** `wp_slimstat_db::funnel_cache_key()` keyed only on the step signature + hour-bucketed date window + cache version. Toggling a column filter kept the **same** key, so `get_transient()` returned the stale, unfiltered result *before* `get_combined_where()` (which does include columns) ever ran. Goals key on the filter WHERE (`md5($filters_where . $cache_ver)`) — that's precisely why Goals worked and funnels didn't.
- **B — AJAX funnel tabs never sent the filters.** The lazy-loaded (non-first) funnel tab POSTed only the date range to `slimstat_load_funnel_data`, never the active `fs[...]` filters, so it computed unfiltered.

The SQL builder was already correct (`get_combined_where('', '*', true, 't1')` folds columns into both SSR and AJAX step queries) — this was purely a cache-key + missing-POST bug.

## Fix (all in the free plugin)

- **`admin/view/wp-slimstat-db.php`** — new `funnel_filters_signature()` (`md5(serialize($filters_normalized['columns']))`, derived from the **normalized** array, *not* `get_combined_where()`'s prepared SQL whose `$wpdb->prepare` placeholder salt is request-unstable and would re-split SSR/AJAX twins). `funnel_cache_key()` folds it into the trailing `md5` term — the date stays hour-bucketed in `$range`, so the #1 SSR/AJAX twin-sharing **and** the `slimstat_funnel_` GC prefix (`clear_goals_cache()` `LIKE`) are preserved.
- **`admin/assets/js/admin.js`** — new `window.SlimStatGetFiltersForAjax()` (sibling to `SlimStatGetTimeRangeForAjax`): harvests the `.slimstat-post-filter` hidden inputs, stripping date/misc keys sourced from the **canonical** `NON_COLUMN_FILTER_KEYS` (now `public`, localized via `SlimStatAdminParams`) so the skip-list never drifts from `parse_filters()`.
- **`admin/assets/js/goals-funnels.js`** — the funnel-load POST merges those filters; `ensure_goals_db_initialized()` → `init()` ingests them from `$_REQUEST['fs']` (no PHP handler change). The per-step **Test** affordance is deliberately left unfiltered (it validates a raw rule while building).

## Effect on end users

Funnels now match Goals: apply a segment + window and every funnel — the first/SSR one **and** the lazily-loaded tabs — recomputes for exactly that segment. A no-match filter correctly shows "No visitors matched in this date range" instead of stale counts. No config change, no migration; cached results refresh within the existing 5-minute TTL (or instantly on any goal/funnel CRUD).

## Tests

- **Unit** — `FunnelCacheKeyTest` extended (filter sig changes the key, identical sig reuses it, sig not swallowed by hour-bucketing, GC prefix preserved) + new `FunnelFiltersSignatureTest` (request-stable, distinct per filter, empty-stable).
- **Integration** — `GoalsFunnelsFilterPassthroughTest` (source-shape guards: cache key takes a filter sig from the normalized array; the JS getter sources its skip-list from the localized `NON_COLUMN_FILTER_KEYS`; the funnel-load POST merges the filters; the Test step stays unfiltered).
- **E2E** — `goals-funnels-filters.spec.ts`: keystone three-phase stale-cache regression (unfiltered → filtered counts change, not stale → unfiltered restored), no-match filter empties both the SSR funnel and an AJAX-loaded tab, and a positive control narrowing to the matching segment.

Full unit (215) + integration (156) suites pass; the 3 new E2E specs pass locally. (Pre-existing goals-funnels E2E failures on the local site are unrelated environment noise — they fail identically on clean `development`.)
