### PR TITLE
fix: uninstall deletes data only on explicit opt-in (data-safety)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+= 5.5.1 - Unreleased =
+
+**Compatibility & stability**
+
+- Fixed: Deleting the SlimStat plugin no longer erases your analytics by default. Your stats, settings, and stored data are removed only if you explicitly turned on "Delete Data on Uninstall" (Settings → Maintenance). Previously, on a normal install that had never touched that option, deleting the plugin dropped all SlimStat tables and settings.
+
 = 5.5.0 - 2026-06-24 =
 
 **New: Goals & Funnels**

--- a/composer.json
+++ b/composer.json
@@ -109,6 +109,7 @@
     "test:access-log-author-link": "php tests/access-log-author-edit-link-test.php",
     "test:funnels-widget-compact": "php tests/funnels-widget-compact-test.php",
     "test:css-selector-scope": "php tests/css-selector-scope-test.php",
+    "test:uninstall-data-safety": "php tests/uninstall-data-safety-test.php",
     "phpstan": "phpstan analyse --memory-limit=2G",
     "test:phpstan": "@phpstan",
     "test:source-level": [
@@ -132,7 +133,8 @@
       "@test:goals-indexes-migration",
       "@test:access-log-author-link",
       "@test:funnels-widget-compact",
-      "@test:css-selector-scope"
+      "@test:css-selector-scope",
+      "@test:uninstall-data-safety"
     ],
     "test:unit": "phpunit --configuration phpunit.xml.dist --testsuite=Unit",
     "test:integration": "phpunit --configuration phpunit.xml.dist --testsuite=Integration --bootstrap tests/bootstrap-integration.php",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -953,3 +953,21 @@ parameters:
 			identifier: function.void
 			count: 1
 			path: wp-slimstat.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: src/Utils/Query.php
+
+		-
+			message: '#^Variable \$conditions in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/Utils/Query.php
+
+		-
+			message: '#^Offset 3 on array\{non\-falsy\-string, numeric\-string, non\-falsy\-string, string\} in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: src/Utils/UADetector.php

--- a/tests/uninstall-data-safety-test.php
+++ b/tests/uninstall-data-safety-test.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Regression: uninstall.php must only delete data when the user explicitly opted
+ * in via "Delete Data on Uninstall".
+ *
+ * The option has no default, so on a normal install the key is absent. The old
+ * gate `isset(key) && 'on' != key` was false for an absent key, so it fell
+ * through and DROPped every table + deleted every option + removed the uploads
+ * dir. This test proves an absent key now RETAINS data, and that 'on' still deletes.
+ *
+ * uninstall.php declares a top-level function, so it can't be required twice in
+ * one process. The driver spawns one child PHP process per case.
+ *
+ * 7.4-safe: plain PHP, no PHPUnit, no vendor autoload.
+ */
+
+declare(strict_types=1);
+
+$case = getenv('SLIMSTAT_UNINSTALL_CASE');
+
+if ($case !== false && $case !== '') {
+    // ─────────────────────────── HARNESS MODE (child process) ───────────────
+    define('WP_UNINSTALL_PLUGIN', true);
+
+    $GLOBALS['__deleted_options'] = [];
+    $GLOBALS['__fs_deletes']      = 0;
+    $GLOBALS['__options']         = $case === 'on'
+        ? ['delete_data_on_uninstall' => 'on']
+        : []; // key deliberately absent
+
+    // A $wpdb double that records every query(); also serves as the custom-db
+    // fallback target ($GLOBALS['wpdb']).
+    $GLOBALS['wpdb'] = new class {
+        public $prefix      = 'wp_';
+        public $base_prefix = 'wp_';
+        public $options     = 'wp_options';
+        public $queries     = [];
+        public function query($sql) { $this->queries[] = $sql; return 0; }
+        public function esc_like($text) { return $text; }
+        public function prepare($sql, ...$args) { return $sql; }
+    };
+
+    function get_option($name, $default = false)
+    {
+        return $name === 'slimstat_options' ? $GLOBALS['__options'] : $default;
+    }
+    function delete_option($name)
+    {
+        $GLOBALS['__deleted_options'][] = $name;
+        return true;
+    }
+    function is_multisite() { return false; }
+    function wp_clear_scheduled_hook($hook) {}
+    function wp_upload_dir()
+    {
+        return ['basedir' => sys_get_temp_dir() . '/wp-slimstat-test-uploads'];
+    }
+    function WP_Filesystem()
+    {
+        $GLOBALS['wp_filesystem'] = new class {
+            public function delete($file, $recursive = false, $type = false)
+            {
+                $GLOBALS['__fs_deletes']++;
+                return true;
+            }
+        };
+        return true;
+    }
+
+    require __DIR__ . '/../uninstall.php';
+
+    $drops = 0;
+    foreach ($GLOBALS['wpdb']->queries as $q) {
+        if (stripos($q, 'DROP TABLE') !== false) {
+            $drops++;
+        }
+    }
+    echo json_encode([
+        'queries'   => count($GLOBALS['wpdb']->queries),
+        'drops'     => $drops,
+        'deleted'   => $GLOBALS['__deleted_options'],
+        'fsDeletes' => $GLOBALS['__fs_deletes'],
+    ]);
+    exit(0);
+}
+
+// ─────────────────────────────── DRIVER MODE ────────────────────────────────
+$assertions = 0;
+
+function fail($message)
+{
+    fwrite(STDERR, "FAIL: {$message}\n");
+    exit(1);
+}
+function assert_same($expected, $actual, $message)
+{
+    global $assertions;
+    $assertions++;
+    if ($expected !== $actual) {
+        fail($message . ' (expected ' . var_export($expected, true) . ', got ' . var_export($actual, true) . ')');
+    }
+}
+function assert_true($cond, $message)
+{
+    global $assertions;
+    $assertions++;
+    if ($cond !== true) {
+        fail($message);
+    }
+}
+
+function run_case($case)
+{
+    // Set the selector in the parent; the child inherits it via proc_open's
+    // default (null) environment.
+    putenv("SLIMSTAT_UNINSTALL_CASE={$case}");
+    $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+    $proc        = proc_open(
+        escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg(__FILE__),
+        $descriptors,
+        $pipes
+    );
+    if (!is_resource($proc)) {
+        fail("could not spawn child for case '{$case}'");
+    }
+    $out = stream_get_contents($pipes[1]);
+    $err = stream_get_contents($pipes[2]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    proc_close($proc);
+
+    $result = json_decode($out, true);
+    if (!is_array($result)) {
+        fail("child for case '{$case}' returned no JSON.\nSTDOUT: {$out}\nSTDERR: {$err}");
+    }
+    return $result;
+}
+
+// Case 1 — opt-out key ABSENT (fresh install): nothing may be deleted.
+$absent = run_case('absent');
+assert_same(0, $absent['queries'], 'no DB queries at all when the key is absent');
+assert_same([], $absent['deleted'], 'no options deleted when the key is absent');
+assert_same(0, $absent['fsDeletes'], 'uploads dir not deleted when the key is absent');
+
+// Case 2 — explicit opt-in: deletion proceeds as before.
+$on = run_case('on');
+assert_true($on['drops'] >= 7, 'DROP TABLE runs when delete_data_on_uninstall is on');
+assert_true(in_array('slimstat_options', $on['deleted'], true), 'slimstat_options deleted when opted in');
+assert_same(1, $on['fsDeletes'], 'uploads dir deleted when opted in');
+
+fwrite(STDOUT, "OK: {$assertions} assertions passed (uninstall deletes only on explicit opt-in)\n");
+exit(0);

--- a/uninstall.php
+++ b/uninstall.php
@@ -7,8 +7,9 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
 
 $slimstat_options = get_option('slimstat_options', []);
 
-if (isset($slimstat_options['delete_data_on_uninstall']) && 'on' != $slimstat_options['delete_data_on_uninstall']) {
-    // Do not delete db data and settings
+// Delete data only when the user explicitly opted in (Settings → Maintenance →
+// "Delete Data on Uninstall"); an absent/any-non-'on' value keeps all data.
+if ('on' !== ($slimstat_options['delete_data_on_uninstall'] ?? 'no')) {
     return;
 }
 


### PR DESCRIPTION
Uninstall now deletes data **only on explicit opt-in**.

The "Delete Data on Uninstall" option has no default, so on a normal install the key is absent — the old gate (`isset(key) && 'on' != key`) fell through and dropped every SlimStat table + options + the uploads dir on a routine plugin deletion. The gate now returns unless the value is exactly `'on'`.

Adds `tests/uninstall-data-safety-test.php` (source-level). Surfaced during the #325 review; shipped separately as it's an independent data-safety bug.

> Note: shares the `= 5.5.1 =` CHANGELOG section and a `test:source-level` entry with the #325 autoloader PR, so `CHANGELOG.md` / `composer.json` will conflict trivially at merge — resolve by keeping both entries.
